### PR TITLE
Fix clean/distclean targets to clean up all files.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -280,13 +280,16 @@ clean:
 	rm -rf $(abs_builddir)/Bootstrap.2
 	rm -rf $(abs_builddir)/Bootstrap.3
 	rm -rf $(BOOTSTRAP_1_REGISTRY)
+	$(MAKE) -C $(rt_build) clean
 
 distclean: clean
+	-rm -f aclocal.m4
 	-rm -f configure
 	-rm -f config.log
 	-rm -f config.status
 	-rm -f config.status.lineno
-	-rm -f Makefile
+	-rm -f libtool
+	-rm -f Makefile sources/lib/run-time/pentium-linux/Makefile sources/lib/run-time/pentium-freebsd/Makefile sources/dfmc/c-run-time/Makefile
 	-rm -rf build-aux
 	-rm -rf autom4te.cache
 


### PR DESCRIPTION
With these changes, the tree is now restored to a pristine state after running `make distclean`. Also, the clean target now removes the generated `.o` files from building the runtime.
