### PR TITLE
Remove references to SunOS, Solaris, IRIX, OSF3.

### DIFF
--- a/sources/app/djam/djam.dylan
+++ b/sources/app/djam/djam.dylan
@@ -15,7 +15,7 @@ define function main(name, arguments)
   select($os-name)
     #"win32" =>
       jam-variable(state, "NT") := #["true"];
-    #"linux", #"freebsd", #"solaris", #"osf3" =>
+    #"linux", #"freebsd", #"darwin" =>
       jam-variable(state, "UNIX") := #["true"];
   end select;
 

--- a/sources/dfmc/c-run-time/run-time.c
+++ b/sources/dfmc/c-run-time/run-time.c
@@ -568,21 +568,6 @@ DMINT primitive_unwrap_abstract_integer(D x) {
 }
 #endif
 
-/* SunOS4 doesn't include ldiv and friends in <stdlib.h> (Sigh) */
-#if defined(sun) && !defined(__svr4__)
-typedef struct ldiv_t {
-  long quot;
-  long rem;
-} ldiv_t;
-
-ldiv_t ldiv(long x, long y) {
-  ldiv_t z;
-  z.quot = x / y;
-  z.rem = x % y;
-  return(z);
-}
-#endif
-
 DMINT primitive_machine_word_divide(DMINT x, DMINT y) {
   ldiv_t z = ldiv(x, y);
   MV2((DMINT)z.quot, (DMINT)z.rem);

--- a/sources/dfmc/c-run-time/run-time.h
+++ b/sources/dfmc/c-run-time/run-time.h
@@ -1290,9 +1290,8 @@ extern DMINT primitive_machine_word_unsigned_double_shift_right(DMINT, DMINT, DM
 
 #include <math.h>
 
-/* SunOS and Solaris also don't include single precision functions in <math.h> (Sigh)
-   Win32 only defines the single precision functions for C++ (Huh?) */
-#if defined(sun) || defined(WIN32)
+/* Win32 only defines the single precision functions for C++ (Huh?) */
+#if defined(WIN32)
 #define sqrtf(x)  (DSFLT)sqrt((DDFLT)x)
 #define logf(x)   (DSFLT)log((DDFLT)x)
 #define expf(x)   (DSFLT)exp((DDFLT)x)

--- a/sources/lib/build-system/jam-build.dylan
+++ b/sources/lib/build-system/jam-build.dylan
@@ -112,7 +112,7 @@ define function make-jam-state
     select($os-name)
       #"win32" =>
         jam-variable(state, "NT") := #["true"];
-      #"linux", #"freebsd", #"solaris", #"osf3", #"darwin" =>
+      #"linux", #"freebsd", #"darwin" =>
         jam-variable(state, "UNIX") := #["true"];
     end select;
     

--- a/sources/system/file-system/unix-file-system.dylan
+++ b/sources/system/file-system/unix-file-system.dylan
@@ -186,7 +186,7 @@ define function %copy-file
   end;
   run-application
     (concatenate
-       (if ($os-name = #"osf3") "cp -pf" else "cp -p" end,
+       ("cp -p",
         " ",
         as(<string>, source),
         " ",

--- a/sources/system/file-system/unix-interface.dylan
+++ b/sources/system/file-system/unix-interface.dylan
@@ -119,24 +119,18 @@ define constant $o_rdwr   = 2;
 define constant $o_creat
   = select ($os-name)
       #"linux"              =>   64;
-      #"Solaris2", #"IRIX5" =>  256;
-      #"SunOS4", #"OSF3"    =>  512;
       #"freebsd", #"darwin" => #x200;
     end;
 
 define constant $o_trunc
   = select ($os-name)
-      #"Solaris2", #"IRIX5",  #"linux" =>  512;
-      #"SunOS4", #"OSF3"               => 1024;
-      #"freebsd", #"darwin"            => #x400;
+      #"linux"              =>   512;
+      #"freebsd", #"darwin" => #x400;
     end;
 
 define constant $o_sync
   = select ($os-name)
-      #"Solaris2", #"IRIX5" =>    16;
       #"linux"              =>  4096;
-      #"SunOS4"             =>  8192;
-      #"OSF3"               => 16384;
       #"freebsd", #"darwin" => #x80;
     end;
 


### PR DESCRIPTION
Also, fix a missing reference to Darwin found at the same time.

There was no other code present to support these ancient OSes, so this isn't removing anything that worked. (And Solaris was represented by both #"solaris" and #"solaris2"...)

There's one other reference that is handled by my stdio_cleanup branch ... and I left some CPU stuff for Alpha and MIPS64 which I can tackle another time.
