### PR TITLE
Fix formatting error when a condition is displayed.

### DIFF
--- a/sources/environment/commands/command-line.dylan
+++ b/sources/environment/commands/command-line.dylan
@@ -320,7 +320,7 @@ define function display-condition
 	end
       end;
   message(context, "");
-  message(context, "%s: %s", prefix, error-message)
+  message(context, "%s%s", prefix, error-message)
 end function display-condition;
 
 define method tokenize-string


### PR DESCRIPTION
Previously, this would look like:

```
Internal error: : Foo
```

Now, it will be:

```
Internal error: Foo
```
