### PR TITLE
treat system registry as system registry, don't compile everything when ...

### DIFF
--- a/sources/project-manager/registry-projects/defaults.dylan
+++ b/sources/project-manager/registry-projects/defaults.dylan
@@ -68,8 +68,7 @@ define function find-registries-internal
 	debug-message("Making system registries for %s",
 		      as(<string>, path));
 	let (platform-registry, generic-registry) 
-	  = make-registry-from-path(path, platform, personal?: #t);
-        //XXX: set to #f here to prevent rebuilds all over the place
+	  = make-registry-from-path(path, platform, personal?: #f);
 	platform-system-registries
 	  := add!(platform-system-registries, platform-registry);
 	generic-system-registries


### PR DESCRIPTION
...building a library, but reuse libraries shipped with compiler

I believe that'd be the more correct behaviour when we want to do a release. opinions on that?
