### PR TITLE
Present a message when no project is open and macroexpand is called, fix...

### DIFF
--- a/sources/environment/commands/browsing.dylan
+++ b/sources/environment/commands/browsing.dylan
@@ -228,8 +228,6 @@ end command-line macroexpand;
 define method command-complete?
     (context :: <environment-context>, command :: <macroexpand-code-command>)
  => (complete? :: <boolean>)
-  let project = context.context-project;
-  let module  = context.context-project-context.context-module;
   //---*** We have no way to determine this yet!
   let complete? = #t;
   complete?


### PR DESCRIPTION
...es #77

yeah, a bit intrinsic, but that works. the default <project-command> handler takes care of ensuring to have an open project :)
