### PR TITLE
Fix deletion of <unwind-protect> with neither body nor cleanup

### DIFF
--- a/sources/dfmc/flow-graph/utilities.dylan
+++ b/sources/dfmc/flow-graph/utilities.dylan
@@ -419,10 +419,12 @@ define method delete-computation! (c :: <unwind-protect>) => ();
         values(c.cleanups,
                previous-computation(c.cleanups-end), 
                #t);
-      else                   // cleanup #f or empty
+      elseif (has-body?(c))   // cleanup #f or empty
         values(c.body, 
                previous-computation(c.protected-end), 
                #f);
+      else                    // neither body nor cleanup
+        values(next-c, prev-c, #f)
       end if;
   
   redirect-previous-computations!(c, first-c);  // fixup next-computation values

--- a/sources/dylan/tests/control.dylan
+++ b/sources/dylan/tests/control.dylan
@@ -650,10 +650,8 @@ define test bind-exits ()
 end test bind-exits;
 
 define test unwind-protects ()
-//---*** This results in a Bus error when the C back-end is used
-//       - hannes (Jan 2012)
-//  check-equal("unwind-protect returns protected",
-//	      block () 1 cleanup 2 end, 1);
+  check-equal("unwind-protect returns protected",
+	      block () 1 cleanup 2 end, 1);
   check-equal("unwind-protect returns protected even with throw",
 	      block (return) return(1) cleanup 2 end, 1);
   check-equal("unwind-protect cleanup takes precedence",


### PR DESCRIPTION
Also, uncomment the corresponding test case. Fixes #182
