### PR TITLE
Remove info-available?: not used, not exported.

### DIFF
--- a/sources/environment/tools/initialization.dylan
+++ b/sources/environment/tools/initialization.dylan
@@ -444,31 +444,9 @@ define method note-example-selected
     (dialog :: <examples-dialog>, info :: false-or(<release-info>)) => ()
   gadget-text(dialog.%description-pane)
     := if (info)
-	 //---*** Should we add back info-available?
-	 let available? = #t; // info.info-available?;
-	 format-to-string
-	   ("%s\n%s",
-	    info.info-description,
-	    if (available?)
-	      ""
-	    else
-	      let (message, library-pack)
-		= select (info by instance?)
-		    <library-pack-info>, <library-category-info> =>
-		      values("these examples",  info);
-		    <example-info> =>
-		      values("this example",    info.info-library-pack);
-		    <test-suite-info> =>
-		      values("this test suite", info.info-library-pack);
-		  end;
-	      as-uppercase
-		(format-to-string
-		   ("\nWarning: %s can only be built %s\n",
-		    message,
-		    format-to-string("using the %s library pack", library-pack.info-title)))
-	    end)
+	 format-to-string("%s\n", info.info-description)
        else
-	 "" 
+	 ""
        end;
   dialog-exit-enabled?(dialog) := instance?(info, <library-info>)
 end method note-example-selected;

--- a/sources/lib/release-info/libraries.dylan
+++ b/sources/lib/release-info/libraries.dylan
@@ -538,11 +538,6 @@ define method info-library-pack
   example.info-group.info-library-pack
 end method info-library-pack;
 
-define method info-available?
-    (example :: <example-info>) => (available? :: <boolean>)
-  info-available?(example.info-group)
-end method info-available?;
-
 define function example-location
     (info :: <example-info>) => (location :: false-or(<string>))
   let project = info-project(info);
@@ -606,14 +601,6 @@ define method initialize
     example.info-group := group
   end
 end method initialize;
-
-define method info-available?
-    (group :: <example-group-info>) => (available? :: <boolean>)
-  let edition      = group.info-edition;
-  let library-pack = group.info-library-pack;
-  release-contains-edition?(edition)
-    & (~library-pack | release-contains-library-pack?(library-pack))
-end method info-available?;
 
 define constant $root-example-group =
     make(<example-group-info>,

--- a/sources/lib/release-info/module.dylan
+++ b/sources/lib/release-info/module.dylan
@@ -45,8 +45,7 @@ define module release-info
          release-bug-report-template-location;
 
   // Information accessors
-  export // info-available?,
-         info-author,
+  export info-author,
          info-binary,
          info-categories,
          info-company,


### PR DESCRIPTION
Simplifies initialization as well
