### PR TITLE
Fix application-name() on MacOSX, used to return full path. Fixes #202

### DIFF
--- a/sources/common-dylan/darwin-common-extensions.dylan
+++ b/sources/common-dylan/darwin-common-extensions.dylan
@@ -103,7 +103,16 @@ define inline-only function get-application-commandline
         add!(tokens, token);
       end;
     end while;
-    values(tokens[0], apply(vector, copy-sequence(tokens, start: 2, end: argc + 1)))
+    *application-filename* := tokens[0];
+    let name = make(<byte-string>);
+    for (x in tokens[1])
+      if (x == '/')
+        name := make(<byte-string>);
+      else
+        name := add(name, x);
+      end;
+    end;
+    values(name, apply(vector, copy-sequence(tokens, start: 2, end: argc + 1)))
   else
     values("", vector())
   end

--- a/sources/common-dylan/unix-common-extensions.dylan
+++ b/sources/common-dylan/unix-common-extensions.dylan
@@ -68,7 +68,9 @@ define inline-only function ensure-application-name-filename-and-arguments () =>
       end;
     *application-name* := name;
     *application-arguments* := arguments;
-    *application-filename* := get-application-filename();
+    unless (*application-filename*)
+      *application-filename* := get-application-filename();
+    end;
   end;
 end function ensure-application-name-filename-and-arguments;
 


### PR DESCRIPTION
This also fills _application-filename_ if available. On MacOSX
I can hardly see a reason to call _NSGetExecutablePath. Anyone
can enlighten me in which cases the KERN_PROCARGS2 sysctl fails?
