### PR TITLE
Rename split's remove-if-empty param to remove-if-empty?.

### DIFF
--- a/sources/common-dylan/common-extensions.dylan
+++ b/sources/common-dylan/common-extensions.dylan
@@ -200,7 +200,7 @@ define open generic split
      #key start :: <integer>,
           end: epos :: <integer>,
           count :: <integer>,
-          remove-if-empty :: <boolean>)
+          remove-if-empty? :: <boolean>)
  => (parts :: <sequence>);
 
 // This is in some sense the most basic method, since others can be
@@ -221,7 +221,7 @@ define method split
      #key start :: <integer> = 0,
           end: epos :: <integer> = seq.size,
           count :: <integer> = epos + 1,
-          remove-if-empty :: <boolean> = #f)
+          remove-if-empty? :: <boolean> = #f)
  => (parts :: <sequence>)
   reverse!(iterate loop (bpos :: <integer> = start,
                          parts :: <list> = #(),
@@ -229,7 +229,7 @@ define method split
              let (sep-start, sep-end) = find-separator(seq, bpos, epos);
              if (sep-start & sep-end & (sep-end <= epos))
                let part = copy-sequence(seq, start: bpos, end: sep-start);
-               if (remove-if-empty & empty?(part))
+               if (remove-if-empty? & empty?(part))
                  loop(sep-end, parts, nparts)
                elseif (nparts < count)
                  loop(sep-end, pair(part, parts), nparts + 1)
@@ -238,7 +238,7 @@ define method split
                end
              else
                let part = copy-sequence(seq, start: bpos, end: epos);
-               if (remove-if-empty & empty?(part))
+               if (remove-if-empty? & empty?(part))
                  parts
                else
                  pair(part, parts)
@@ -256,7 +256,7 @@ define method split
           end: epos :: <integer> = seq.size,
           count :: <integer> = epos + 1,
           test :: <function> = \==,
-          remove-if-empty :: <boolean> = #f)
+          remove-if-empty? :: <boolean> = #f)
  => (parts :: <sequence>)
   // Is there a function that does this already?
   local method looking-at? (pattern :: <sequence>, big :: <sequence>,
@@ -271,6 +271,7 @@ define method split
             #t
           end
         end method looking-at?;
+  // TODO(cgay): use boyer-moore/kmp for strings.
   local method find-subseq (seq :: <sequence>,
                             bpos :: <integer>,
                             epos :: false-or(<integer>))
@@ -288,7 +289,7 @@ define method split
           end
         end;
   split(seq, find-subseq, start: start, end: epos, count: count,
-        remove-if-empty: remove-if-empty)
+        remove-if-empty?: remove-if-empty?)
 end method split;
 
 // Split on a given object.
@@ -299,7 +300,7 @@ define method split
           end: epos :: <integer> = seq.size,
           count :: <integer> = epos + 1,
           test :: <function> = \==,
-          remove-if-empty :: <boolean> = #f)
+          remove-if-empty? :: <boolean> = #f)
  => (parts :: <sequence>)
   local method find-pos (seq :: <sequence>,
                          bpos :: <integer>,
@@ -316,7 +317,7 @@ define method split
           end block
         end method;
   split(seq, find-pos, start: start, end: epos, count: count,
-        remove-if-empty: remove-if-empty)
+        remove-if-empty?: remove-if-empty?)
 end method split;
 
 // Join several sequences together, including a separator between each

--- a/sources/common-dylan/tests/functions.dylan
+++ b/sources/common-dylan/tests/functions.dylan
@@ -353,32 +353,32 @@ define common-extensions function-test split ()
     check-equal(fmt("split with count = 1"),
                 split("a/b/c/d", separator, count: 1),
                 #["a/b/c/d"]);
-    check-equal(fmt("split with remove-if-empty"),
-                split("/a/b/", separator, remove-if-empty: #t),
+    check-equal(fmt("split with remove-if-empty?: #t"),
+                split("/a/b/", separator, remove-if-empty?: #t),
                 #["a", "b"]);
-    check-equal(fmt("split with remove-if-empty and separator only"),
-                split("/", separator, remove-if-empty: #t),
+    check-equal(fmt("split with remove-if-empty?: #t and separator only"),
+                split("/", separator, remove-if-empty?: #t),
                 #[]);
-    check-equal(fmt("split with remove-if-empty and separators only"),
-                split("///", separator, remove-if-empty: #t),
+    check-equal(fmt("split with remove-if-empty?: #t and separators only"),
+                split("///", separator, remove-if-empty?: #t),
                 #[]);
-    check-equal(fmt("split with remove-if-empty and start, only separator"),
-                split("a/", separator, start: 1, remove-if-empty: #t),
+    check-equal(fmt("split with remove-if-empty?: #t and start, only separator"),
+                split("a/", separator, start: 1, remove-if-empty?: #t),
                 #[]);
-    check-equal(fmt("split with remove-if-empty and start"),
-                split("/a", separator, start: 1, remove-if-empty: #t),
+    check-equal(fmt("split with remove-if-empty?: #t and start"),
+                split("/a", separator, start: 1, remove-if-empty?: #t),
                 #["a"]);
-    check-equal(fmt("split with remove-if-empty and end, only separator"),
-                split("/a", separator, end: 1, remove-if-empty: #t),
+    check-equal(fmt("split with remove-if-empty?: #t and end, only separator"),
+                split("/a", separator, end: 1, remove-if-empty?: #t),
                 #[]);
-    check-equal(fmt("split with remove-if-empty and end"),
-                split("a/", separator, end: 1, remove-if-empty: #t),
+    check-equal(fmt("split with remove-if-empty?: #t and end"),
+                split("a/", separator, end: 1, remove-if-empty?: #t),
                 #["a"]);
-    check-equal(fmt("split with remove-if-empty and count"),
-                split("/a/b", separator, count: 1, remove-if-empty: #t),
+    check-equal(fmt("split with remove-if-empty?: #t and count"),
+                split("/a/b", separator, count: 1, remove-if-empty?: #t),
                 #["a/b"]);
-    check-equal(fmt("split with remove-if-empty and count, only separator character"),
-                split("/", separator, count: 1, remove-if-empty: #t),
+    check-equal(fmt("split with remove-if-empty?: #t and count, only separator character"),
+                split("/", separator, count: 1, remove-if-empty?: #t),
                 #[]);
     check-equal(fmt("split with test"),
                 split("a/", separator, test: \~==),

--- a/sources/common-dylan/tests/specification.dylan
+++ b/sources/common-dylan/tests/specification.dylan
@@ -67,7 +67,7 @@ define module-spec common-extensions ()
    => (false-or(<integer>));
   open generic-function split
       (<sequence>, <object>,
-       #"key", #"start", #"end", #"count", #"remove-if-empty")
+       #"key", #"start", #"end", #"count", #"remove-if-empty?")
    => (<sequence>);
   function join
     (<sequence>, <sequence>, #"key" #"key", #"conjunction") => (<sequence>);

--- a/sources/environment/reports/library-report.dylan
+++ b/sources/environment/reports/library-report.dylan
@@ -697,7 +697,7 @@ define method write-definition-name
   next-method();
   do(method (mod) format(stream, "   :%s:\n", as-lowercase(mod)) end,
      split(class-modifiers(report.report-project, class), " ",
-           remove-if-empty: #t))
+           remove-if-empty?: #t))
 end method write-definition-name;
 
 define method write-definition-name
@@ -707,7 +707,7 @@ define method write-definition-name
   next-method();
   do(method (mod) format(stream, "   :%s:\n", as-lowercase(mod)) end,
      split(generic-function-modifiers(report.report-project, function), " ",
-           remove-if-empty: #t))
+           remove-if-empty?: #t))
 end method write-definition-name;
 
 define method write-definition-name


### PR DESCRIPTION
Something I've been meaning to fix for a long time.

I was unable to run the common-dylan-test-suite on OS X so this is untested, but it's pretty simple.  If no one merges it I'll try it on Windows when I get a chance and update the pull request with any changes.

I'll update regular-expressions' split method, and callers outside the opendylan repo, after this is merged.
