### PR TITLE
Output on stderr rather than stdout; fixes #207

### DIFF
--- a/documentation/library-reference/source/common-dylan/common-extensions.rst
+++ b/documentation/library-reference/source/common-dylan/common-extensions.rst
@@ -245,8 +245,8 @@ The extensions are:
 
 .. function:: default-last-handler
 
-   Formats and outputs a Dylan condition using *format-out* and passes
-   control on to the next handler.
+   Formats and outputs a Dylan condition using :gf:`condition-to-string`
+   and passes control on to the next handler.
 
    :signature: default-last-handler *serious-condition* *next-handler* => ()
 
@@ -261,11 +261,11 @@ The extensions are:
      via :macro:`define last-handler`.
 
      This function formats and outputs the Dylan condition
-     *serious-condition* using *format-out* from the Format-Out library,
+     *serious-condition* using :gf:`condition-to-string` from this library,
      and passes control on to the next handler.
 
      This function is automatically installed as the last handler if
-     your library uses the Common Dylan library.
+     your library uses the *common-dylan* library.
 
    :example:
 

--- a/sources/common-dylan/common-extensions.dylan
+++ b/sources/common-dylan/common-extensions.dylan
@@ -429,10 +429,13 @@ end function fill-table!;
 
 define method default-last-handler (condition :: <serious-condition>, next-handler :: <function>)
   block()
-    format-out("%s\n", condition);
-  exception ( print-error :: <error> )
-    format-out("%=\nsignalled while trying to print an instance of %=\n",
-	       print-error, object-class(condition));
+    write-console(concatenate(condition-to-string(condition), "\n"),
+                  stream: #"standard-error");
+  exception (print-error :: <error>)
+    let string =
+      format-to-string("%=\nsignalled while trying to print an instance of %=\n",
+                       print-error, object-class(condition));
+    write-console(string, stream: #"standard-error");
   end block;
   next-handler();
 end method;

--- a/sources/common-dylan/unix-common-extensions.dylan
+++ b/sources/common-dylan/unix-common-extensions.dylan
@@ -11,16 +11,25 @@ define function format-out (format-string :: <string>, #rest format-arguments) =
   write-console(string);
 end function format-out;
 
-define inline function write-console (string :: <string>, #key end: _end) => ()
+define inline function write-console
+    (string :: <string>,
+     #key end: _end,
+          stream :: one-of(#"standard-output", #"standard-error") = #"standard-output")
+ => ()
+  let stream = if (stream == #"standard-output")
+                 1
+               elseif (stream == #"standard-error")
+                 2
+               end;
   let string-size :: <integer> = _end | size(string);
   %call-c-function ("write")
       (fd :: <raw-c-signed-int>, buffer :: <raw-byte-string>, size :: <raw-c-unsigned-long>)
    => (count :: <raw-c-signed-int>)
-    (integer-as-raw(1), primitive-string-as-raw(string), integer-as-raw(string-size))
+    (integer-as-raw(stream), primitive-string-as-raw(string), integer-as-raw(string-size))
   end;
   //---*** NOTE: Should we do something here if we can't do the I/O???
   %call-c-function ("fsync") (fd :: <raw-c-signed-int>) => (result :: <raw-c-signed-int>)
-    (integer-as-raw(1))
+    (integer-as-raw(stream))
   end;
 end function write-console;
 

--- a/sources/common-dylan/win32-common-extensions.dylan
+++ b/sources/common-dylan/win32-common-extensions.dylan
@@ -54,7 +54,11 @@ define function format-out (format-string :: <string>, #rest format-arguments) =
   write-console(string);
 end function format-out;
 
-define inline function write-console (string :: <string>, #key end: _end) => ()
+define inline function write-console
+    (string :: <string>,
+     #key end: _end,
+          stream :: one-of(#"standard-output", #"standard-error") = #"standard-output")
+ => ()
   let string-end :: <integer> = _end | size(string);
   ensure-console();
   when (*console*)

--- a/sources/dfmc/c-run-time/debug-print.c
+++ b/sources/dfmc/c-run-time/debug-print.c
@@ -525,8 +525,9 @@ void do_debug_message (BOOL forBreak, D string, D arguments) {
     OutputDebugStringA(error_output);
   }
 #else
-  puts(error_output);		/* Adds a terminating newline */
-  fflush(stdout);
+  fputs(error_output, stderr);
+  fputs("\n", stderr); /* Adds a terminating newline */
+  fflush(stderr);
 #endif
   return;
 }


### PR DESCRIPTION
Both debug-message and the last-handler now output to
standard error. The debug-message does this in the C
runtime (on UNIX only so far).
