### PR TITLE
Remove 'unwind' instruction.

### DIFF
--- a/sources/lib/llvm/llvm-asm-parser.dylgram
+++ b/sources/lib/llvm/llvm-asm-parser.dylgram
@@ -1304,8 +1304,6 @@ b-b-terminator-inst:
                                     map(param-value, param-list)),
               metadata: arg$16)
        end;;
-  %UNWIND opt-inst-metadata
-    => make(<llvm-unwind-instruction>, metadata: arg$2);;
   %UNREACHABLE opt-inst-metadata
     => make(<llvm-unreachable-instruction>, metadata: arg$2);;
   %RESUME resolved-val opt-inst-metadata

--- a/sources/lib/llvm/llvm-asm-reader.dylan
+++ b/sources/lib/llvm/llvm-asm-reader.dylan
@@ -204,7 +204,6 @@ define table $llvm-keywords :: <string-table>
      "switch" => $%SWITCH-token,
      "invoke" => $%INVOKE-token,
      "indirectbr" => $%INDIRECTBR-token,
-     "unwind" => $%UNWIND-token,
      "unreachable" => $%UNREACHABLE-token,
 
      "alloca" => $%ALLOCA-token,

--- a/sources/lib/llvm/llvm-bitcode.dylan
+++ b/sources/lib/llvm/llvm-bitcode.dylan
@@ -81,7 +81,6 @@ define bitcode-block $FUNCTION_BLOCK = 12
   record INST_BR          = 11; // BR:         [bb#, bb#, cond] or [bb#]
   record INST_SWITCH      = 12; // SWITCH:     [opty, opval, n, n x ops]
   record INST_INVOKE      = 13; // INVOKE:     [attr, fnty, op0,op1, ...]
-  record INST_UNWIND      = 14; // UNWIND
   record INST_UNREACHABLE = 15; // UNREACHABLE
 
   record INST_PHI         = 16; // PHI:        [ty, val0,bb0, ...]
@@ -1651,17 +1650,6 @@ define method write-instruction-record
                attributes-index-table[attribute-list-encoding],
                value.llvm-invoke-instruction-calling-convention,
                operands);
-end method;
-
-define method write-instruction-record
-    (stream :: <bitcode-stream>,
-     instruction-index :: <integer>,
-     type-partition-table :: <object-table>,
-     value-partition-table :: <explicit-key-collection>,
-     attributes-index-table :: <encoding-sequence-table>,
-     value :: <llvm-unwind-instruction>)
- => ();
-  write-record(stream, #"INST_UNWIND");
 end method;
 
 define method write-instruction-record

--- a/sources/lib/llvm/llvm-builder.dylan
+++ b/sources/lib/llvm/llvm-builder.dylan
@@ -598,10 +598,6 @@ define instruction-set
              metadata: builder-metadata(builder, metadata),
              options);
 
-  op unwind (#key metadata :: <list> = #())
-    => make(<llvm-unwind-instruction>,
-            metadata: builder-metadata(builder, metadata));
-
   op resume (value, #key metadata :: <list> = #())
     => make(<llvm-resume-instruction>,
             operands: vector(llvm-builder-value(builder, value)),

--- a/sources/lib/llvm/llvm-instruction.dylan
+++ b/sources/lib/llvm/llvm-instruction.dylan
@@ -176,9 +176,6 @@ define class <llvm-invoke-instruction> (<llvm-terminator-instruction>)
     init-value: $llvm-calling-convention-c, init-keyword: calling-convention:;
 end class;
 
-define class <llvm-unwind-instruction> (<llvm-terminator-instruction>)
-end class;
-
 define class <llvm-unreachable-instruction> (<llvm-terminator-instruction>)
 end class;
 

--- a/sources/lib/llvm/llvm-library.dylan
+++ b/sources/lib/llvm/llvm-library.dylan
@@ -180,7 +180,6 @@ define module llvm
     <llvm-branch-instruction>,
     <llvm-switch-instruction>,
     <llvm-invoke-instruction>,
-    <llvm-unwind-instruction>,
     <llvm-unreachable-instruction>,
     <llvm-indirect-branch-instruction>,
     <llvm-phi-node>,
@@ -345,7 +344,6 @@ define module llvm-builder
     ins--br,
     ins--switch,
     ins--invoke,
-    ins--unwind,
     ins--resume,
     ins--unreachable;
 end module;

--- a/sources/lib/llvm/tests/llvm-builder-test.dylan
+++ b/sources/lib/llvm/tests/llvm-builder-test.dylan
@@ -1449,14 +1449,6 @@ define llvm-builder function-test ins--invoke ()
   //---*** Fill this in...
 end function-test ins--invoke;
 
-define llvm-builder function-test ins--unwind ()
-  let builder = make-builder-with-test-function();
-  ins--unwind(builder);
-  check-equal("ins--unwind disassembly",
-              #("entry:", "unwind"),
-              builder-test-function-disassembly(builder));
-end function-test ins--unwind;
-
 define llvm-builder function-test ins--resume ()
   let builder = make-builder-with-test-function();
   let struct-type

--- a/sources/lib/llvm/tests/specification.dylan
+++ b/sources/lib/llvm/tests/specification.dylan
@@ -318,7 +318,6 @@ define module-spec llvm-builder ()
        #"rest")
    => (<llvm-instruction>);
 
-  function ins--unwind (<llvm-builder>, #"key", #"metadata") => (<llvm-instruction>);
   function ins--unreachable
      (<llvm-builder>, #"key", #"metadata")
   => (<llvm-instruction>);


### PR DESCRIPTION
The unwind instruction is gone in LLVM 3.1.  This is for @housel, hoping it helps out some.

A couple of questions about this ...

I'm assuming this should stay:

``` dylan
  $llvm-intrinsic-makers["llvm.eh.unwind.init"]
    := begin
         let function-type
           = make(<llvm-function-type>,
                  return-type: $llvm-void-type,
                  parameter-types: vector(),
                  varargs?: #f);
         let function
           = make(<llvm-function>,
                  name: "llvm.eh.unwind.init",
                  type: make(<llvm-pointer-type>, pointee: function-type),
                  attribute-list: $llvm-intrinsic-default-attribute-list,
                  linkage: #"external");
         method (arguments) function end
       end;
```

And the unwind here:

``` dylan
  op invoke (to, unwind, fnptrval, args :: <sequence>,
             #rest options, #key metadata :: <list> = #(), #all-keys)
    => apply(make, <llvm-invoke-instruction>,
             operands: map(curry(llvm-builder-value, builder),
                           concatenate(vector(to, unwind, fnptrval), args)),
             metadata: builder-metadata(builder, metadata),
             options);
```

And in this:

``` dylan
  %INVOKE opt-calling-conv opt-ret-attrs result-types value-ref
    %LPAREN param-list %RPAREN opt-func-attrs
    %TO %LABEL value-ref
    %UNWIND %LABEL value-ref opt-inst-metadata
    => begin
         let type = arg$4;
         let return-type
           = if (instance?(type, <llvm-pointer-type>))
               let pointee
                 = llvm-type-forward(type.llvm-pointer-type-pointee);
               if (instance?(pointee, <llvm-function-type>))
                 llvm-constrain-type(llvm-value-type(arg$5), type);
                 llvm-type-forward(pointee.llvm-function-type-return-type)
               else
                 type
               end if
             else
               type
             end if;
         llvm-constrain-type(llvm-value-type(arg$12), $llvm-label-type);
         llvm-constrain-type(llvm-value-type(arg$15), $llvm-label-type);
         let param-list = reverse!(arg$7);
         let (return-attributes, function-attributes)
           = munge-attributes(arg$3, arg$9);
         let attribute-list
           = make(<llvm-attribute-list>,
                  return-attributes: return-attributes,
                  function-attributes: function-attributes,
                  parameter-attributes: map(param-attributes, param-list));
         make(<llvm-invoke-instruction>,
              type: return-type,
              attribute-list: attribute-list,
              calling-convention: arg$2,
              operands: concatenate(vector(arg$12, arg$15, arg$5),
                                    map(param-value, param-list)),
              metadata: arg$16)
       end;;
```

Should the `UNWIND` remain there? If so, do I need to keep the `"unwind" => $%UNWIND-token` that was in `llvm-asm-reader.dylan`?
