### PR TITLE
condition-to-string should never return #f.

### DIFF
--- a/sources/common-dylan/format.dylan
+++ b/sources/common-dylan/format.dylan
@@ -547,11 +547,11 @@ end function string-to-machine-word;
 /// Condition/string conversion
 
 define open generic condition-to-string
-    (condition :: <condition>) => (string :: false-or(<string>));
+    (condition :: <condition>) => (string :: <string>);
 
 define method condition-to-string
-    (condition :: <condition>) => (string :: false-or(<string>))
-  #f
+    (condition :: <condition>) => (string :: <string>)
+  concatenate("Condition of class ", condition.object-class-name, " occured")
 end method condition-to-string;
 
 define method condition-to-string
@@ -572,12 +572,7 @@ define method print-pretty-name
     (buffer :: <string-buffer>, condition :: <condition>)
  => ()
   let message = condition-to-string(condition);
-  if (message)
-    print-string(buffer, message)
-  else
-    print-format(buffer, "Condition of class %s occurred",
-		 object-class-name(condition))
-  end
+  print-string(buffer, message)
 end method print-pretty-name;
 
 

--- a/sources/common-dylan/tests/specification.dylan
+++ b/sources/common-dylan/tests/specification.dylan
@@ -83,7 +83,7 @@ define module-spec common-extensions ()
   // Conditions
   open abstract class <format-string-condition> (<condition>);
   open abstract primary class <simple-condition> (<condition>);
-  open generic-function condition-to-string (<condition>) => (false-or(<string>));
+  open generic-function condition-to-string (<condition>) => (<string>);
   open abstract class <arithmetic-error> (<error>);
   sealed instantiable class <division-by-zero-error> (<arithmetic-error>);
   sealed instantiable class <arithmetic-overflow-error> (<arithmetic-error>);

--- a/sources/databases/sql-odbc/diagnostic.dylan
+++ b/sources/databases/sql-odbc/diagnostic.dylan
@@ -34,7 +34,7 @@ define function return-code-name(return-code :: <object>)
 end function;
 
 define method condition-to-string(diag-error :: <odbc-diagnostic-error>)
- => (string :: false-or(<string>))
+ => (string :: <string>)
   format-to-string("ODBC Diagnostic Error - Return-code: (%=) %=\n",
                    diag-error.diagnostic-return-code,
                    return-code-name(diag-error.diagnostic-return-code));
@@ -46,7 +46,7 @@ define sealed class <odbc-diagnostic-warning> (<odbc-diagnostic-problem>,
 end class;
 
 define method condition-to-string(diag-warning :: <odbc-diagnostic-warning>)
- => (string :: false-or(<string>))
+ => (string :: <string>)
   format-to-string("ODBC Diagnostic Warning - \n"
                    "  Return-code: (%=) %=\n",
                    diag-warning.diagnostic-return-code,
@@ -60,7 +60,7 @@ define sealed concrete class <odbc-unexpected-return-code> (<error>)
 end class;
 
 define method condition-to-string(cond :: <odbc-unexpected-return-code>)
- => (string :: false-or(<string>))
+ => (string :: <string>)
   format-to-string("ODBC Unexpected Return Code - \n"
                    "  Return-code: (%=) %=\n",
                    cond.unexpected-return-code,

--- a/sources/databases/sql/conditions.dylan
+++ b/sources/databases/sql/conditions.dylan
@@ -45,6 +45,6 @@ end class <unhandled-diagnostic>;
 
 define method condition-to-string
     (condition :: <unhandled-diagnostic>)
- => (string :: false-or(<string>))
+ => (string :: <string>)
   format-to-string("Database error: %s\n", condition.diagnostic.message-text)
 end method condition-to-string;

--- a/sources/databases/sql/diagnostic.dylan
+++ b/sources/databases/sql/diagnostic.dylan
@@ -269,7 +269,7 @@ end method;
 
 define method condition-to-string
     (diag :: <diagnostic>)
- => (string :: false-or(<string>))
+ => (string :: <string>)
   let diag-string :: <string> = make(<string>);
   let test-diag = diag;
   while (test-diag ~= #f)

--- a/sources/lib/ssl/examples/ssl-smtp-client/ssl-smtp-client.dylan
+++ b/sources/lib/ssl/examples/ssl-smtp-client/ssl-smtp-client.dylan
@@ -27,7 +27,7 @@ end class;
 
 define method condition-to-string
     (cond :: <smtp-error>)
- => (string :: false-or(<string>))
+ => (string :: <string>)
   format-to-string("%=: %s", cond.object-class, cond.smtp-error-response)
 end;
 

--- a/sources/network/smtp-client/smtp-client.dylan
+++ b/sources/network/smtp-client/smtp-client.dylan
@@ -27,7 +27,7 @@ end class;
 
 define method condition-to-string
     (cond :: <smtp-error>)
- => (string :: false-or(<string>))
+ => (string :: <string>)
   format-to-string("%=: %s", cond.object-class, cond.smtp-error-response)
 end;
 


### PR DESCRIPTION
It was handled gracefully in print-pretty-name, but not in
default-last-handler, which then tried to concatenate(#f, "\n") and
failed.

I rather changed the GF to return always a <string> and the default
implementation on <condition> returns the string which was used in
print-pretty-name.
