### PR TITLE
free_tlv_vector should free what is passed in.

### DIFF
--- a/sources/dfmc/c-run-time/posix-threads.c
+++ b/sources/dfmc/c-run-time/posix-threads.c
@@ -120,9 +120,8 @@ void *make_tlv_vector(int n)
   return vector;
 }
 
-void free_tlv_vector()
+void free_tlv_vector(D *vector)
 {
-  D *vector = get_tlv_vector();
   size_t size;
 
   // compute actual (byte) size


### PR DESCRIPTION
free_tlv_vector is only used from one function (used twice) and in both cases, it passes the value that should be freed in.
