### PR TITLE
add -lpthread to LINKFLAGSEXE, fixes #237

### DIFF
--- a/sources/jamfiles/x86-freebsd-build.jam
+++ b/sources/jamfiles/x86-freebsd-build.jam
@@ -14,7 +14,7 @@ RTOBJS_harp ?= runtime.o
 #
 # Library search path
 #
-LINKFLAGSEXE ?= -Wl,-z,origin -Wl,-rpath,\\$ORIGIN/../lib/ ;
+LINKFLAGSEXE ?= -Wl,-z,origin -Wl,-rpath,\\$ORIGIN/../lib/ -lpthread ;
 
 #
 # Common build script


### PR DESCRIPTION
otherwise the linker complains about missing symbols (on FreeBSD-8 at least)
