### PR TITLE
Use -pthread on FreeBSD rather than -lpthread.

### DIFF
--- a/sources/jamfiles/posix-build.jam
+++ b/sources/jamfiles/posix-build.jam
@@ -69,7 +69,7 @@ RTOBJS_c    ?= debug-print.o
 
 # These are passed to the link rules by way of the dylan.lid file
 rtlibs  ?= $(SYSTEM_LIBDIR)/runtime/$(RTOBJS_$(COMPILER_BACK_END))
-	   -lpthread -lm ;
+	   -lm ;
 rtclibs ?= ;
 
 guilflags ?= ;

--- a/sources/jamfiles/x86-freebsd-build.jam
+++ b/sources/jamfiles/x86-freebsd-build.jam
@@ -14,7 +14,7 @@ RTOBJS_harp ?= runtime.o
 #
 # Library search path
 #
-LINKFLAGSEXE ?= -Wl,-z,origin -Wl,-rpath,\\$ORIGIN/../lib/ -lpthread ;
+LINKFLAGSEXE ?= -Wl,-z,origin -Wl,-rpath,\\$ORIGIN/../lib/ -pthread ;
 
 #
 # Common build script

--- a/sources/jamfiles/x86-linux-build.jam
+++ b/sources/jamfiles/x86-linux-build.jam
@@ -26,4 +26,4 @@ include $(SYSTEM_ROOT)/lib/posix-build.jam ;
 #
 # Overrides/redefinitions
 #
-rtlibs += -ldl ;
+rtlibs += -lpthread -ldl ;

--- a/sources/jamfiles/x86_64-linux-build.jam
+++ b/sources/jamfiles/x86_64-linux-build.jam
@@ -18,3 +18,8 @@ LINKFLAGSEXE ?= -Wl,-z,origin -Wl,-rpath,\\$ORIGIN/../lib/ ;
 # Common build script
 #
 include $(SYSTEM_ROOT)/lib/posix-build.jam ;
+
+#
+# Overrides/redefinitions
+#
+rtlibs += -lpthread ;


### PR DESCRIPTION
This also makes Linux specify -lpthread and doesn't
pass -lpthread on OS X (Darwin) any longer as it isn't
needed there.

(I haven't actually tested this as I don't have the means to do so.)
