### PR TITLE
Remove unused run-application primitive.

### DIFF
--- a/sources/dfmc/c-back-end/c-primitives.dylan
+++ b/sources/dfmc/c-back-end/c-primitives.dylan
@@ -327,7 +327,6 @@ define generic emit-primitive-call
 // // Terminal
 // 
 // // Operating System
-// define &primitive-descriptor primitive-run-application;
 // define &primitive-descriptor primitive-exit-application;
 // define &primitive-descriptor primitive-start-timer;
 // define &primitive-descriptor primitive-stop-timer;

--- a/sources/dfmc/harp-cg/harp-primitives.dylan
+++ b/sources/dfmc/harp-cg/harp-primitives.dylan
@@ -2173,7 +2173,6 @@ define &primitive-descriptor primitive-preboot-symbols;
 // Terminal
 
 // Operating System
-define &primitive-descriptor primitive-run-application;
 define &primitive-descriptor primitive-exit-application;
 define &primitive-descriptor primitive-start-timer;
 define &primitive-descriptor primitive-stop-timer;

--- a/sources/dfmc/modeling/namespaces.dylan
+++ b/sources/dfmc/modeling/namespaces.dylan
@@ -441,7 +441,6 @@ define &module dylan-primitives
 
   // Operating System
   create
-    primitive-run-application,
     primitive-exit-application,
     primitive-start-timer,
     primitive-stop-timer;

--- a/sources/dfmc/modeling/primitives.dylan
+++ b/sources/dfmc/modeling/primitives.dylan
@@ -607,8 +607,6 @@ define raw-field-primitive c-int <raw-c-unsigned-int>;
 
 /// OPERATING SYSTEM
 
-define side-effecting stateless dynamic-extent &primitive primitive-run-application
-    (command :: <raw-byte-string>) => (code :: <raw-integer>);
 define side-effecting stateless dynamic-extent &primitive primitive-exit-application
     (code :: <raw-integer>) => ();
 define side-effecting stateless dynamic-extent &primitive primitive-start-timer () => ();

--- a/sources/harp/linux-rtg/os-primitives.dylan
+++ b/sources/harp/linux-rtg/os-primitives.dylan
@@ -42,17 +42,3 @@ define used-by-client unix-runtime-primitive exit-application
   op--call-c(be, ExitProcess-ref, status);
   ins--rts-and-drop(be, 0);
 end unix-runtime-primitive;
-
-
-define c-fun runtime-external system-ref   = "system";
-
-define unix-runtime-primitive run-application
-  // On entry: c-string-command-line
-  //    
-  // On exit: raw-integer-status
-  arg0 command;
-
-  op--call-c(be, system-ref, command);
-  ins--rts-and-drop(be, 0);
-end unix-runtime-primitive;
-

--- a/sources/harp/native-rtg/core-module.dylan
+++ b/sources/harp/native-rtg/core-module.dylan
@@ -24,7 +24,6 @@ define module native-rtg
     genop--start-timer,
     genop--stop-timer,
     genop--exit-application,
-    genop--run-application,
     genop--spy-fixup-imported-dylan-data,
     genop--spy-fixup-unimported-dylan-data,
     genop--spy-exit-application,

--- a/sources/harp/native-rtg/module.dylan
+++ b/sources/harp/native-rtg/module.dylan
@@ -24,7 +24,6 @@ define module native-rtg
     genop--start-timer,
     genop--stop-timer,
     genop--exit-application,
-    genop--run-application,
     genop--spy-fixup-imported-dylan-data,
     genop--spy-fixup-unimported-dylan-data,
     genop--spy-exit-application,

--- a/sources/harp/native-rtg/os-primitives.dylan
+++ b/sources/harp/native-rtg/os-primitives.dylan
@@ -32,6 +32,3 @@ define generic-runtime-primitive stop-timer;
 
 define used-by-client generic-runtime-primitive exit-application;
 
-
-define generic-runtime-primitive run-application;
-

--- a/sources/harp/pentium-win32-rtg/os-primitives.dylan
+++ b/sources/harp/pentium-win32-rtg/os-primitives.dylan
@@ -17,7 +17,6 @@ define win-fun runtime-external win-QueryFrequency = "QueryPerformanceFrequency"
 
 // define win-fun runtime-external win-CreateProcess  = "CreateProcess",             data:  "40";
 define win-fun runtime-external win-ExitProcess    = "ExitProcess",               data:  "4";
-define win-fun runtime-external win-Exec           = "WinExec",                   data:  "8";
 
 
 define runtime-variable counter-start-lo     = "%counter_start_lo";
@@ -87,23 +86,5 @@ define used-by-client win32-runtime-primitive exit-application
   // On exit: entire process is terminated
   arg0 status;
   op--stdcall-c(be, win-ExitProcess, status);
-  ins--rts-and-drop(be, 0);
-end win32-runtime-primitive;
-
-
-define win32-runtime-primitive run-application
-  // On entry: c-string-command-line
-  //    
-  // On exit: raw-integer-status
-
-  result result;
-  arg0 arg0;
-  nreg name;
-  tag done, ok;
-
-  ins--move(be, name, arg0);
-  // Call the Windows function
-  let sw_shownormal = 1;
-  op--stdcall-c(be, win-Exec, name, sw_shownormal);
   ins--rts-and-drop(be, 0);
 end win32-runtime-primitive;


### PR DESCRIPTION
There is code elsewhere for running applications. A primitive to
do so isn't required (or used).
