### PR TITLE
x86-win32 -> x86-windows

### DIFF
--- a/sources/dfmc/llvm-back-end/llvm-targets.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-targets.dylan
@@ -92,21 +92,21 @@ end method;
 
 /// Concrete LLVM back-end subclasses
 
-// x86-win32
+// x86-windows
 
-define class <llvm-x86-win32-back-end> (<llvm-x86-back-end>,
+define class <llvm-x86-windows-back-end> (<llvm-x86-back-end>,
                                         <llvm-windows-back-end>)
 end class;
 
-register-back-end(<llvm-x86-win32-back-end>, #"llvm", #"x86", #"win32");
+register-back-end(<llvm-x86-windows-back-end>, #"llvm", #"x86", #"win32");
 
 define method llvm-back-end-target-triple
-    (back-end :: <llvm-x86-win32-back-end>) => (triple :: <string>);
+    (back-end :: <llvm-x86-windows-back-end>) => (triple :: <string>);
   "i386-unknown-win32"
 end method;
 
 define method llvm-back-end-data-layout
-    (back-end :: <llvm-x86-win32-back-end>) => (layout :: <string>);
+    (back-end :: <llvm-x86-windows-back-end>) => (layout :: <string>);
   "e-p:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-"
     "i64:64:64-f32:32:32-f64:64:64-f80:128:128-v64:64:64-"
     "v128:128:128-a0:0:64-f80:32:32-n8:16:32"


### PR DESCRIPTION
I am on a mission to harmonize namings of platforms ... and as part of that, win32 -> windows since win32 makes little sense when we eventually support 64 bit Windows.
