### PR TITLE
Eliminate redundant type checks for keyword arguments.

### DIFF
--- a/documentation/release-notes/source/2012.1.rst
+++ b/documentation/release-notes/source/2012.1.rst
@@ -300,6 +300,9 @@ This has been fixed and the resulting code can run in 50-80% of the
 time that it previously took. This is particularly true for users
 of the I/O libraries which make heavy use of unwind-protect.
 
+The C back-end was previously performing 2 type checks on keyword
+arguments. It now correctly only performs this check once.
+
 Shared Library Initialization
 -----------------------------
 

--- a/sources/dfmc/c-back-end/c-emit-computation.dylan
+++ b/sources/dfmc/c-back-end/c-emit-computation.dylan
@@ -1315,20 +1315,24 @@ end method;
 define constant $primitive-type-check-string
   = c-raw-mangle("primitive-type-check");
 
-define method emit-computation
-    (b :: <c-back-end>, s :: <stream>, d :: <integer>, c :: <keyword-check-type>)
-  // MUST EMIT THESE CAUSE THEY CHECK FOR THINGS LIKE SIZE :: <INTEGER> FOR VECTOR
-  format-emit(b, s, d, "\t~(@, @);\n", 
-              $primitive-type-check-string,
-              c.computation-value, c.type);
-  next-method();
+define method emit-check-type?
+    (back-end :: <c-back-end>, c :: <check-type>)
+ => (well? :: <boolean>)
+  // Don't emit type checks for the Dylan library
+  ~compiling-dylan-library?()
+end method;
+
+define method emit-check-type?
+    (back-end :: <c-back-end>, c :: <keyword-check-type>)
+ => (well? :: <boolean>)
+  // We must emit these cause they check for things like size :: <integer>
+  // for vector()
+  #t
 end method;
 
 define method emit-computation
     (b :: <c-back-end>, s :: <stream>, d :: <integer>, c :: <check-type>)
-  if (compiling-dylan-library?())
-    // don't emit type checks for the Dylan library
-  else
+  if (emit-check-type?(b, c))
     format-emit(b, s, d, "\t~(@, @);\n", 
                 $primitive-type-check-string,
                 c.computation-value, c.type);


### PR DESCRIPTION
This is the same fix that housel applied to the HARP backend in
2de1aec7895eba7c197dfcc6da46810f22240ce9.

Fixes #267.
