### PR TITLE
Don't locally install the build directory.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -212,10 +212,9 @@ $(prefix)/sources:
 	-rm -r $(prefix)/sources/bootstrap1-registry
 
 install-stage: $(prefix)/sources
-	install -d $(prefix)/bin $(prefix)/databases $(prefix)/lib $(prefix)/lib/runtime $(prefix)/build $(prefix)/build/logs
+	install -d $(prefix)/bin $(prefix)/databases $(prefix)/lib $(prefix)/lib/runtime
 	@echo Installing Open Dylan...
 	cp -R $(abs_builddir)/Bootstrap.3/bin $(prefix)
-	cp -R $(abs_builddir)/Bootstrap.3/build $(prefix)
 	cp -R $(abs_builddir)/Bootstrap.3/databases $(prefix)
 	-cp -R $(abs_builddir)/Bootstrap.3/include $(prefix)
 	cp -R $(abs_builddir)/Bootstrap.3/lib $(prefix)


### PR DESCRIPTION
@hannesm, I don't see why we need to install the build directory ... we used to do it because we had to do a fresh build to get something installed.
