### PR TITLE
Move emit-object for <&engine-node>.

### DIFF
--- a/sources/dfmc/back-end/emit-object.dylan
+++ b/sources/dfmc/back-end/emit-object.dylan
@@ -36,12 +36,6 @@ define method emit-object
   // nothing to emit -- all in run-time
 end method;
 
-define method emit-object
-    (back-end :: <back-end>, stream :: <stream>, o :: <&engine-node>) => (object);
-  ^engine-node-callback(o);
-  next-method()
-end method;
-
 
 /// EMIT-NAME
 

--- a/sources/dfmc/c-back-end/c-emit-object.dylan
+++ b/sources/dfmc/c-back-end/c-emit-object.dylan
@@ -51,6 +51,17 @@ define method emit-reference
   emit-reference(back-end, stream, raw-type-marker())
 end method;
 
+// WORK AROUND TO PREVENT WARNINGS
+
+// Previously, this code was specialized on <back-end>, but
+// then we'd get ambiguous method warnings.
+
+define method emit-object
+    (back-end :: <c-back-end>, stream :: <stream>, o :: <&engine-node>) => (object);
+  ^engine-node-callback(o);
+  next-method();
+end method;
+
 // RAW VALUES
 
 define method emit-object

--- a/sources/dfmc/harp-cg/harp-main.dylan
+++ b/sources/dfmc/harp-cg/harp-main.dylan
@@ -2747,6 +2747,18 @@ define sideways method emit-reference
   emit-reference(back-end, stream, raw-type-marker())
 end method;
 
+// WORK AROUND TO PREVENT WARNINGS
+
+// Previously, this code was specialized on <back-end>, but
+// then we'd get ambiguous method warnings.
+
+define method emit-object
+    (back-end :: <harp-back-end>, stream :: <stream>, o :: <&engine-node>) => (object);
+  ^engine-node-callback(o);
+  next-method()
+end method;
+
+
 // RAW VALUES
 
 define sideways method emit-object


### PR DESCRIPTION
Previously, this generated a number of warnings due to ambiguous
methods.

Fixes #276.
