### PR TITLE
Remove usage of log10, rather use a direct comparison

### DIFF
--- a/sources/lib/run-time/heap-utils.c
+++ b/sources/lib/run-time/heap-utils.c
@@ -1,6 +1,5 @@
 #include "heap-utils.h"
 
-#include <math.h>
 #include <stdlib.h>
 #ifdef OPEN_DYLAN_PLATFORM_UNIX
 #include <signal.h>
@@ -229,7 +228,6 @@ void display_integer (int integer, mps_lib_FILE *stream)
       return;
   }
   for (power = 10000000; power > 0; power = power / 10) {
-    int exponent = (int)(log10(power));
     int digit = remainder / power;
     remainder = remainder % power;
     if (digit == 0) {
@@ -238,7 +236,7 @@ void display_integer (int integer, mps_lib_FILE *stream)
       leading = 0;
       mps_lib_fputc('0' + digit, stream);
     };
-    if ((exponent == 6) || (exponent == 3)) {
+    if ((power == 1000000) || (exponent == 1000)) {
       if (digit == 0) {
 	mps_lib_fputc(leading ? ' ' : ',', stream);
       } else {


### PR DESCRIPTION
We no longer need to link against libm now

This is completely untested at the moment
