### PR TITLE
Update MPS license.

### DIFF
--- a/License.txt
+++ b/License.txt
@@ -26,15 +26,37 @@ A copy of this license may be obtained here:
 https://raw.github.com/dylan-lang/opendylan/master/License.txt
 
 
-Ravenbrook's Memory Pool System (MPS) binaries may be included in
-binary distributions of Open Dylan.  They are covered under the
-following license:
+Memory Pool System Kit Open Source License
+==========================================
 
-               MEMORY POOL SYSTEM OPEN SOURCE LICENSE
+This is the license under which the Memory Pool System Kit is available as
+open source.
 
-Copyright (C) 2001-2002 Ravenbrook Limited <http://www.ravenbrook.com/>.
-All rights reserved.  This is an open source license.  Contact
-Ravenbrook for commercial licensing options.
+**It is not the only way the MPS is licensed.**
+
+If the licensing terms aren't suitable for you (for example, you're
+developing a closed-source commercial product or a compiler run-time
+system) you can easily license the MPS under different terms from
+Ravenbrook.  Please write to us <mps-questions@ravenbrook.com> for more
+information.
+
+The open source license for the MPS is the [Sleepycat License][] also
+known as the "Berkeley Database License".  This license is
+[GPL compatible][] and [OSI approved][].  The MPS is "multi licensed" in
+a manner similar to MySQL.
+
+[Sleepycat License]: https://en.wikipedia.org/wiki/Sleepycat_License
+[GPL compatible]: http://www.gnu.org/licenses/license-list.html
+[OSI approved]: http://opensource.org/licenses/sleepycat
+
+
+License
+-------
+
+Copyright (C) 2001-2012 Ravenbrook Limited <http://www.ravenbrook.com/>.
+All rights reserved.  This is the open source license for the Memory
+Pool System, but it is not the only one.  Contact Ravenbrook
+<mps-questions@ravenbrook.com> if you would like a different license.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -70,7 +92,20 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+Exceptions
+----------
+
+### Open Dylan
+
+Software that makes use of the Memory Pool System only via the Dylan
+programming language using the Open Dylan implementation and any
+accompanying software is exempt from clause 3 of the license, provided
+that the Dylan program is not providing memory management services.  For
+the avoidance of doubt, this exemption does not apply to software
+directly using a copy of the Memory Pool System received as part of the
+Open Dylan source code.
+
 ---
 
-$Id: //info.ravenbrook.com/project/mps/master/license.txt#2 $
-
+$Id: //info.ravenbrook.com/project/mps/master/license.txt#5 $


### PR DESCRIPTION
Ravenbrook has kindly updated their license for MPS granting
us an exception to one of the clauses as well as adding some
clarifying text.

This updated license is part of their 1.110 release and has been
backported to the 1.108 branch as well.
