### PR TITLE
C-R-T fixes and debug enhancements

### DIFF
--- a/sources/dfmc/c-run-time/posix-threads.h
+++ b/sources/dfmc/c-run-time/posix-threads.h
@@ -8,6 +8,11 @@
  *    Threads portability layer for POSIX
  */
 
+#if __linux__
+/* get pthread_setname_np */
+#define _GNU_SOURCE
+#endif
+
 #include "run-time.h"
 
 #include <stdint.h>


### PR DESCRIPTION
This fixes a <thread> object corruption when using C-R-T that most likely corrupted the thread priority.

It also adds multi-platform support for setting the thread name (used by debuggers).
