### PR TITLE
Improve performance of format-date().

### DIFF
--- a/documentation/release-notes/source/2012.1.rst
+++ b/documentation/release-notes/source/2012.1.rst
@@ -100,6 +100,8 @@ Library Changes
   makes it to the disk, either use ``sychronize-output()``
   or pass ``synchronize?: #t`` to ``force-output()``.
 
+* ``format-date`` from the ``system`` library is faster.
+
 
 Documentation Improvements
 ==========================


### PR DESCRIPTION
Previously, this was doing a lot of concatenation and reallocation.
Using a stream with a pre-sized string contents lets us avoid
much of that.

(This could be improved further, but this was an easy win...)
