### PR TITLE
dfmc: Warn (don't crash) on invalid inherited slot specifications.

### DIFF
--- a/documentation/release-notes/source/2012.1.rst
+++ b/documentation/release-notes/source/2012.1.rst
@@ -314,6 +314,9 @@ between classes in different files would result in compilation errors.
 The compiler would crash when the ``dimensions:`` keyword was not given
 when constructing an ``<array>``.
 
+The compiler now warns rather than crashes on invalid inherited slot
+specifications.
+
 C Back-end Changes
 ==================
 


### PR DESCRIPTION
Previously, if someone specified additional slot adjectives on
an inherited slot, the compiler would crash. This turns it into
a warning.

Fixes #200.
