### PR TITLE
[crt, cbe]: Move GC_INIT to the runtime init.

### DIFF
--- a/sources/dfmc/c-linker/c-gluefile.dylan
+++ b/sources/dfmc/c-linker/c-gluefile.dylan
@@ -10,15 +10,12 @@ define sideways method emit-mainfile
   let c-file = #f;
   with-build-area-output (stream = ld, base: "_main", type: "c")
     write(stream, "#include <stdlib.h>\n");
-    write(stream, "#include <gc/gc.h>\n\n");
     write(stream, "#include \"run-time.h\"\n\n");
 
     format(stream, "int main (int argc, char *argv[]) {\n");
     format(stream, "  extern void %s ();\n", glue-name(lib-name));
     format(stream, "  extern D %s;\n", command-arguments-name());
     format(stream, "  extern D %s;\n", command-name-name());
-
-    format(stream, "  GC_INIT();\n");
 
     write (stream, "  D args = primitive_make_vector((argc > 0) ? argc - 1 : 0);\n");
     write (stream, "  int i;\n");

--- a/sources/dfmc/c-run-time/run-time.c
+++ b/sources/dfmc/c-run-time/run-time.c
@@ -4759,7 +4759,7 @@ void _Init_Run_Time ()
 #endif
 
     // initialize GC and thread subsystems
-    GC_init();
+    GC_INIT();
     initialize_threads_primitives();
     GC_set_max_heap_size(MAX_HEAP_SIZE);
 


### PR DESCRIPTION
- We don't want gc/gc.h to be a compile time requirement for people
  using Dylan.
- GC_INIT here wasn't getting called at the right time anyway due
  to so much (everything) happening in constructor functions.
- This may have an impact if we support Android or AIX or Cygwin
  but that would have other issues anyway.
