### PR TITLE
[Windows] Fix location of registry settings.

### DIFF
--- a/documentation/release-notes/source/2013.1.rst
+++ b/documentation/release-notes/source/2013.1.rst
@@ -33,3 +33,9 @@ Runtime Improvements
 The C run-time no longer attempts to drop into a debugger if you allocate
 more than roughly 100M of memory in a single allocation.
 
+Windows Support
+===============
+
+The 2012.1 release introduced a bug with where settings were
+stored in the Windows registry. This has been corrected.
+

--- a/sources/lib/release-info/functional-settings.dylan
+++ b/sources/lib/release-info/functional-settings.dylan
@@ -13,14 +13,34 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 // the Open Dylan compiler.  Maybe they should be called something
 // like <dylan-hackers-settings>? --tc
 
-define settings <open-dylan-local-settings>
+define settings <general-open-dylan-local-settings>
     (<local-software-settings>)
+  key-name "Open Dylan";
+end settings <general-open-dylan-local-settings>;
+
+define settings <unversioned-open-dylan-local-settings>
+    (<general-open-dylan-local-settings>)
+  key-name "Open Dylan";
+end settings <unversioned-open-dylan-local-settings>;
+
+define settings <open-dylan-local-settings>
+    (<unversioned-open-dylan-local-settings>)
   key-name "1.0";
   slot library-packs :: <machine-word> = as(<machine-word>, 0);
 end settings <open-dylan-local-settings>;
 
-define settings <open-dylan-user-settings>
+define settings <general-open-dylan-user-settings>
     (<current-user-software-settings>)
+  key-name "Open Dylan";
+end settings <general-open-dylan-user-settings>;
+
+define settings <unversioned-open-dylan-user-settings>
+    (<general-open-dylan-user-settings>)
+  key-name "Open Dylan";
+end settings <unversioned-open-dylan-user-settings>;
+
+define settings <open-dylan-user-settings>
+    (<unversioned-open-dylan-user-settings>)
   key-name "1.0";
 end settings <open-dylan-user-settings>;
 


### PR DESCRIPTION
This was broken in commit d428759ee928aa0e4ea96eef177c3f331ba646c2
resulting in the installer setting some settings that the IDE was
then not reading.
