### PR TITLE
[win32 installer] Default to PellesC.

### DIFF
--- a/documentation/release-notes/source/2013.1.rst
+++ b/documentation/release-notes/source/2013.1.rst
@@ -39,3 +39,8 @@ Windows Support
 The 2012.1 release introduced a bug with where settings were
 stored in the Windows registry. This has been corrected.
 
+The Windows installer for Open Dylan now defaults to suggesting the
+Pelles C tools rather than Visual C 6. This is the start of improving
+the new user experience on Windows and having it work out of the
+box.
+

--- a/packages/win32-nsis/choose-build-script.ini
+++ b/packages/win32-nsis/choose-build-script.ini
@@ -12,16 +12,15 @@ Bottom=113
 
 [Field 2]
 Type=RadioButton
-Text=Microsoft Visual C++ 6.0
+Text=Pelles C for Windows (default)
 Left=10
 Right=-5
 Top=14
 Bottom=24
-State=1
 
 [Field 3]
 Type=RadioButton
-Text=Microsoft Visual C++ .NET
+Text=Microsoft Visual C++ 6.0
 Left=10
 Right=-5
 Top=28
@@ -29,7 +28,7 @@ Bottom=38
 
 [Field 4]
 Type=RadioButton
-Text=Microsoft Visual C++ Toolkit 2003 + Microsoft Platform SDK
+Text=Microsoft Visual C++ .NET (experimental)
 Left=10
 Right=-5
 Top=43
@@ -37,7 +36,7 @@ Bottom=54
 
 [Field 5]
 Type=RadioButton
-Text=Microsoft Visual C++ 2005 Express Edition + Microsoft Platform SDK (experimental)
+Text=Microsoft Visual C++ Toolkit 2003 + Microsoft Platform SDK (experimental)
 Left=10
 Right=-5
 Top=59
@@ -45,7 +44,7 @@ Bottom=69
 
 [Field 6]
 Type=RadioButton
-Text=Pelles C for Windows
+Text=Microsoft Visual C++ 2005 Express Edition + Microsoft Platform SDK (experimental)
 Left=10
 Right=-5
 Top=74

--- a/packages/win32-nsis/opendylan.nsi
+++ b/packages/win32-nsis/opendylan.nsi
@@ -147,15 +147,15 @@ Section "${APPNAME} Core" SecOpendylanCore
 
   ;; Display a messagebox if check box was checked
   StrCmp $0 "1" "" +2
-    StrCpy $R0 "x86-win32-vc6-build.jam"
+    StrCpy $R0 "x86-win32-pellesc-build.jam"
   StrCmp $1 "1" "" +2
-    StrCpy $R0 "x86-win32-vc7-build.jam"
+    StrCpy $R0 "x86-win32-vc6-build.jam"
   StrCmp $2 "1" "" +2
     StrCpy $R0 "x86-win32-vc7-build.jam"
   StrCmp $3 "1" "" +2
-    StrCpy $R0 "x86-win32-vc8-build.jam"
+    StrCpy $R0 "x86-win32-vc7-build.jam"
   StrCmp $4 "1" "" +2
-    StrCpy $R0 "x86-win32-pellesc-build.jam"
+    StrCpy $R0 "x86-win32-vc8-build.jam"
 
   WriteRegStr HKCU "${REGISTRY_KEY}\1.0\Build-System" "build-script" \
               "$INSTDIR\lib\$R0"


### PR DESCRIPTION
Re-order choices, putting PellesC at the top and default.
