### PR TITLE
Make <cpl-differ> a program-warning, rather than a serious-program-warni...

### DIFF
--- a/sources/dfmc/conversion/define-class-mop.dylan
+++ b/sources/dfmc/conversion/define-class-mop.dylan
@@ -1002,7 +1002,7 @@ define function ^compute-class-precedence-list (c :: <&class>)
   c3;
 end function ^compute-class-precedence-list;
 
-define serious-program-warning <cpl-differ>
+define program-warning <cpl-differ>
   slot class-name, init-keyword: class-name:;
   slot dylan-linearization, init-keyword: dylan-linearization:;
   slot cthree-linearization, init-keyword: cthree-linearization:;


### PR DESCRIPTION
...ng

Since 2012.1 is released, we have a release where the CPL difference
between DRM and C3 is a serious. According to discussions on hackers@
(especially https://lists.opendylan.org/pipermail/hackers/2011-December/006279.html)
we should remove the warning.

My plan is to ship next release with a warning, and afterwards
remove that entirely
