### PR TITLE
Allow easier compiler debugging

### DIFF
--- a/admin/builds/fdmake.pl
+++ b/admin/builds/fdmake.pl
@@ -19,10 +19,12 @@ my $build_logs = $ENV{'OPEN_DYLAN_BUILD_LOGS'};
 my $verbose;
 my $debugger;
 my $gdb;
+my $lldb;
 my $compiler = 'dylan-compiler';
 &GetOptions('verbose' => \$verbose,
             'debugger' => \$debugger,
             'gdb' => \$gdb,
+            'lldb' => \$lldb,
             'compiler=s' => \$compiler);
 
 # Names of libraries we already built successfully.
@@ -150,15 +152,18 @@ sub build_library {
     my $command = $compiler;
     if ($debugger) {
         $command .= " -debugger";
-    } elsif ($gdb) {
-        $command = "gdb --args " . $compiler;
+    } 
+    if ($gdb) {
+        $command = "gdb --args " . $command;
+    } elsif ($lldb) {
+        $command = "lldb -- " . $command;
     }
     if (exists $header->{'target-type'}) {
         $command .= " -target " . $header->{'target-type'};
     }
     $command .= " $library";
 
-    if ($gdb || $debugger) {
+    if ($gdb || $lldb || $debugger) {
         system($command) or die "Couldn't execute $command";
         print "\n";
     }


### PR DESCRIPTION
Allows --debugger and --gdb/--lldb options to be given to fdmake.pl together.

If you set FDMAKE_OPTIONS in the makefile to `--debugger --lldb`, the compiler will break into LLDB when an error happens during the OD build process instead of either just reporting it and ending normally, or ending with an error but no debugger.
