### PR TITLE
[jvm] #416 - fixing the inheritance, removed four SWs

### DIFF
--- a/sources/lib/java/vm-code-generation/java-emit-class.dylan
+++ b/sources/lib/java/vm-code-generation/java-emit-class.dylan
@@ -304,8 +304,8 @@ define function mark-as-implementing (cls :: <java-class>, inter :: <java-interf
   add! (cls.interfaces, make (<java-class-constant>, java-class: inter))
 end;
 
-define class <java-concrete-class> (<java-class>) end;
-define class <java-concrete-interface> (<java-interface>) end;
+define class <java-concrete-class> (<java-class>, <java-concrete-class-or-interface>) end;
+define class <java-concrete-interface> (<java-interface>, <java-concrete-class-or-interface>) end;
 
 //define class <java-concrete-class> (<java-class>, <java-concrete-class-or-interface>)
 //  sealed slot interfaces = make (<stretchy-vector>); // see mark-as-implementing


### PR DESCRIPTION
Supposedly fixed the inheritance DAG for `<java-class>` and `<java-interface>`. 

Fixed four SWs, made `rm Bootstrap.2/bin/dylan-compiler; make` pass. Hasn't made it _start_, though — that's for the following changes, I hope.
