### PR TITLE
[crt] Fix <byte-vector> initialization.

### DIFF
--- a/documentation/release-notes/source/2013.1.rst
+++ b/documentation/release-notes/source/2013.1.rst
@@ -56,6 +56,11 @@ types from within other libraries and applications.
 The ``table-extensions`` module now exports ``<case-insensitive-string-table>``,
 which is a table whose keys are strings and checked without case sensitivity.
 
+Testing
+-------
+
+Unit tests have been added to the ``byte-vector`` module.
+
 Bug Fixes
 =========
 
@@ -80,3 +85,11 @@ directory, if any.
 Warnings are now formatted in more standard way so that tools like
 Emacs can parse them, for example to jump to the source of the next
 error.
+
+
+Construction of byte vector instances
+-------------------------------------
+
+When using the C backend ``fill:`` keyword parameter in ``<byte-vector>``
+instance construction was not working properly and caused the byte vector to
+be initialized with a wrong value. This has been corrected.

--- a/sources/common-dylan/tests/byte-vector.dylan
+++ b/sources/common-dylan/tests/byte-vector.dylan
@@ -10,9 +10,40 @@ define byte-vector constant-test <byte> ()
   //---*** Fill this in...
 end constant-test <byte>;
 
+define sideways method make-test-instance (class == <byte-vector>) => (object)
+  make(<byte-vector>, size: 1);
+end method make-test-instance;
+
 define byte-vector class-test <byte-vector> ()
-  //---*** Fill this in...
+  check-condition("make(<byte-vector>, size: 0, fill: 256) signals <type-error>",
+                  <type-error>, make(<byte-vector>, size: 0, fill: 256));
+  check-condition("make(<byte-vector>, size: 1, fill: 256) signals <type-error>",
+                  <type-error>, make(<byte-vector>, size: 1, fill: 256));
+
+  test-byte-vector-size-and-fill(0, 0);
+  test-byte-vector-size-and-fill(0, 1);
+  test-byte-vector-size-and-fill(0, 255);
+  test-byte-vector-size-and-fill(1, 0);
+  test-byte-vector-size-and-fill(1, 1);
+  test-byte-vector-size-and-fill(1, 255);
+  test-byte-vector-size-and-fill(2, 0);
+  test-byte-vector-size-and-fill(2, 1);
+  test-byte-vector-size-and-fill(2, 255);
+  test-byte-vector-size-and-fill(3, 0);
+  test-byte-vector-size-and-fill(3, 1);
+  test-byte-vector-size-and-fill(3, 255);
 end class-test <byte-vector>;
+
+define method test-byte-vector-size-and-fill
+    (vector-size :: <integer>, fill :: <byte>)
+ => ()
+    let v = make(<byte-vector>, size: size, fill: fill);
+    let name = format-to-string("vector-size-%d-fill-%d", vector-size, fill);
+    check-equal(format-to-string("%s empty?", name), v.empty?, vector-size == 0);
+    check-equal(format-to-string("%s.size = %d", name, vector-size), v.size, vector-size);
+    check-true(format-to-string("%s fill = %d", name, fill),
+               every?(method (b) b == fill end, v));
+end method test-byte-vector-size-and-fill;
 
 define byte-vector function-test copy-bytes ()
   // ---*** Fill this in.

--- a/sources/dfmc/c-run-time/run-time.c
+++ b/sources/dfmc/c-run-time/run-time.c
@@ -272,9 +272,8 @@ D primitive_byte_allocate_filled
   D* object = primitive_byte_allocate(size, repeated_size + 1);
   instance_header_setter(class_wrapper, object);
   primitive_fillX(object, 1, 0, number_slots, fill_value);
-  primitive_fill_bytesX
-    (object, repeated_size_offset + 1, 0, repeated_size,
-     (unsigned char)R(repeated_fill_value));
+  primitive_fill_bytesX(object, repeated_size_offset + 1, 0, repeated_size,
+                        repeated_fill_value);
   ((char*)(&object[repeated_size_offset + 1]))[repeated_size] = (char)0;
   if (repeated_size_offset > 0) {
     object[repeated_size_offset] = I(repeated_size);


### PR DESCRIPTION
Remove conversion of fill value to raw, since it is already in raw format.
