### PR TITLE
[dfmc] Move emit-dfm to base <back-end> class

### DIFF
--- a/sources/dfmc/back-end/back-end-library.dylan
+++ b/sources/dfmc/back-end/back-end-library.dylan
@@ -118,6 +118,7 @@ define module dfmc-back-end
     emit-reference,
     emit-indirect-reference,
     emit-all,
+    emit-dfm,
 
     initialize-back-end, \with-back-end-initialization,
 

--- a/sources/dfmc/back-end/back-end.dylan
+++ b/sources/dfmc/back-end/back-end.dylan
@@ -10,6 +10,19 @@ define variable *retract-dfm?* = #t;
 define compiler-open generic emit-all 
     (back-end :: <back-end>, record, #rest flags, #key, #all-keys);
 
+define compiler-open generic emit-dfm
+  (back-end :: <back-end>, stream, object, #rest flags, #key, #all-keys) => ();
+
+define method emit-dfm (back-end :: <back-end>, stream :: <stream>, o :: <&iep>,
+                        #rest flags, #key form?, force-emit?, #all-keys) => ()
+  print-method(stream, o.function);
+  format(stream, "\n");
+end method emit-dfm;
+
+define method emit-dfm (back-end :: <back-end>, stream :: <stream>, o,
+                        #rest flags, #key, #all-keys) => ()
+end method emit-dfm;
+
 // TODO: I guess emit-code should be exported too, but each back-end
 // currently just defines a local emit-code generic.
 // define compiler-open generic emit-code

--- a/sources/dfmc/c-back-end/c-back-end.dylan
+++ b/sources/dfmc/c-back-end/c-back-end.dylan
@@ -220,14 +220,3 @@ define method retract-local-methods-in-heap(heap) => ()
     end for;
   end if;
 end method;
-
-define method emit-dfm (back-end :: <c-back-end>, stream :: <stream>, o :: <&iep>, 
-			#rest flags, #key form?, force-emit?, #all-keys) => ()
-
-  print-method(stream, o.function);
-  format(stream, "\n");
-end method emit-dfm;
-
-define method emit-dfm (back-end :: <c-back-end>, stream :: <stream>, o,
-			#rest flags, #key, #all-keys) => ()
-end method emit-dfm;

--- a/sources/dfmc/harp-cg/harp-emit.dylan
+++ b/sources/dfmc/harp-cg/harp-emit.dylan
@@ -152,18 +152,6 @@ define method emit-code
   // do nothing
 end method;
 
-define method emit-dfm
-    (back-end :: <harp-back-end>, stream :: <stream>, o :: <&iep>, 
-     #rest flags, #key form?, force-emit?, #all-keys)
- => ();
-  print-method(stream, o.function);
-  format(stream, "\n");
-end method emit-dfm;
-
-define method emit-dfm (back-end :: <harp-back-end>, stream :: <stream>, o,
-                         #rest flags, #key, #all-keys) => ()
-end method emit-dfm;
-
 define constant $system-init-code-tag = "for_system";
 define constant $user-init-code-tag = "for_user";
 

--- a/sources/dfmc/llvm-back-end/llvm-emit.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-emit.dylan
@@ -83,18 +83,3 @@ define method retract-local-methods-in-heap(heap :: <model-heap>) => ()
     end if;
   end for;
 end method;
-
-
-/// DFM output
-
-define method emit-dfm
-    (back-end :: <llvm-back-end>, stream :: <stream>, o :: <&iep>, 
-     #rest flags, #key form?, force-emit?, #all-keys)
- => ();
-  print-method(stream, o.function);
-  format(stream, "\n");
-end method emit-dfm;
-
-define method emit-dfm (back-end :: <llvm-back-end>, stream :: <stream>, o,
-                         #rest flags, #key, #all-keys) => ()
-end method emit-dfm;


### PR DESCRIPTION
Not sure if emit-dfm generic should be open though, since it's currently not specialized by any back-end and I don't think it'll need to be...
