### PR TITLE
[OS X] Fix memory scribble.

### DIFF
--- a/sources/common-dylan/darwin-common-extensions.dylan
+++ b/sources/common-dylan/darwin-common-extensions.dylan
@@ -14,8 +14,8 @@ define constant $KERN_PROCARGS2 = 49;
 // This allocates an appropriately sized data buffer for you
 define function darwin-sysctl
   (mib :: <vector>) => (ret :: false-or(<byte-string>))
-  let rmib = make(<byte-string>, size: size(mib), fill: '\0');
   let wsize = raw-as-integer(primitive-word-size());
+  let rmib = make(<byte-string>, size: size(mib) * wsize, fill: '\0');
   let rosize = make(<byte-string>, size: wsize, fill: '\0');
 
   // create the real mib vector


### PR DESCRIPTION
The buffer being allocated for use with sysctl was not the right
size and so it would trash the memory after the end of the buffer.

Fixes issue #433.
