### PR TITLE
Remove locking on stream while formatting.

### DIFF
--- a/sources/io/format.dylan
+++ b/sources/io/format.dylan
@@ -49,7 +49,7 @@ define method format-to-string (control-string :: <byte-string>, #rest args)
   // use a smaller string to collect the contents.
   let s :: <byte-string-stream>
     = make(<byte-string-stream>,
-	   contents: make(<byte-string>, size: 32), direction: #"output");
+	   contents: make(<byte-string>, size: 32), direction: #"output", stream-lock: #f);
   apply(format, s, control-string, args);
   s.stream-contents
 end method;
@@ -155,7 +155,8 @@ define method format (stream :: <stream>, control-string :: <byte-string>,
 	    let s :: <byte-string-stream>
 	      = make(<byte-string-stream>,
 		     contents: make(<byte-string>, size: 80),
-		     direction: #"output");
+		     direction: #"output",
+		     stream-lock: #f);
 	    if (do-dispatch(control-string[field-spec-end], s,
 			    element(args, arg-i, default: #f)))
 	      arg-i := arg-i + 1;

--- a/sources/system/date.dylan
+++ b/sources/system/date.dylan
@@ -346,7 +346,8 @@ define method format-date (format :: <string>, date :: <date>)
     end;
   let date-stream = make(<string-stream>,
                          contents: make(<string>, size: 64),
-                         direction: #"output");
+                         direction: #"output",
+                         stream-lock: #f);
   let format? :: <boolean> = #f;
   let use-dots? :: <boolean> = #f;
   for (char in format)


### PR DESCRIPTION
By default, streams create a lock when they're created. This lock
is then used to synchronize access to the stream in various situations.

Even when contention on a given stream isn't high, this lock can
have some impact on performance due to creating contention on a
lock within the Boehm GC when using the C backend. This is because
the lock's constructor registers a finalizer, which grabs the GC
lock.

When we're formatting to a string or formatting a date, we know
that other threads won't be using this internal string-stream, so
we can disable locking on it safely.

This provides a substantial performance improvement to the HTTP
server under load.
