### PR TITLE
[dfmc] Clean up #"default-open" code.

### DIFF
--- a/sources/dfmc/common/common-library.dylan
+++ b/sources/dfmc/common/common-library.dylan
@@ -153,7 +153,6 @@ define module dfmc-common
     current-library-in-context?,
     current-back-end,
     current-back-end-name,
-    current-compilation-mode,
     current-processor-name, current-os-name,
     compiling-dylan-library?,
 

--- a/sources/dfmc/common/common.dylan
+++ b/sources/dfmc/common/common.dylan
@@ -63,7 +63,6 @@ define compiler-open generic current-top-level-library-description?
 define compiler-open generic current-library-in-context? (ld) => (well? :: <boolean>);
 define compiler-open generic current-back-end () => (back-end);
 define compiler-open generic current-back-end-name () => (name :: false-or(<symbol>));
-define compiler-open generic current-compilation-mode () => (mode :: <symbol>);
 define compiler-open generic current-processor-name () => (name :: <symbol>);
 define compiler-open generic current-os-name () => (name :: <symbol>);
 define compiler-open generic compiling-dylan-library? () => (well? :: <boolean>);

--- a/sources/dfmc/conversion/define-generic.dylan
+++ b/sources/dfmc/conversion/define-generic.dylan
@@ -61,6 +61,8 @@ define method form-equivalent-method-definition
   // TODO: CORRECTNESS: Do this analysis in the method computation, and
   // compute a different class of method that looks like a generic
   // function too so that the difference can't be determined at run-time.
+  //---*** The default-open hack is long gone, is there something to
+  //       clean up here?
   if (form-sealable?(form) & form-implicitly-defined?(form)
         & ~form-compile-stage-only?(form))
     form-single-modifying-simple-method-definition(form);

--- a/sources/dfmc/definitions/define-class.dylan
+++ b/sources/dfmc/definitions/define-class.dylan
@@ -259,13 +259,6 @@ define property <class-sealed-property> => sealing: = $form-sealing/sealed
   value dynamic       = $form-sealing/dynamic;
 end property;
 
-//define property <class-sealed-property-default-open> => sealing: = $form-sealing/open
-//  value sealed        = $form-sealing/sealed;
-//  value open          = $form-sealing/open;
-//  value compiler-open = $form-sealing/compiler-open;
-//  value dynamic       = $form-sealing/dynamic;
-//end property;
-
 define property <class-abstract-property> => abstract?: = #f
   value abstract = #t;
   value concrete = #f;
@@ -286,16 +279,7 @@ define constant class-adjectives-default-sealed
 	   <class-primary-property>,
            <class-made-inline-property>);
 
-//define constant class-adjectives-default-open
-//    = list(<class-sealed-property-default-open>,
-//	   <class-abstract-property>,
-//	   <class-primary-property>,
-//           <class-made-inline-property>);
-
 define function class-adjectives ()
-//  let mode = current-compilation-mode();
-//  if (mode == #"default-open") class-adjectives-default-open
-//  else class-adjectives-default-sealed end
   class-adjectives-default-sealed
 end function;
 

--- a/sources/dfmc/definitions/define-generic.dylan
+++ b/sources/dfmc/definitions/define-generic.dylan
@@ -92,17 +92,6 @@ define property <generic-sideways-property> => sideways?: = #f
   value sideways = #t;
 end property;
 
-//define property <generic-sealed-property-default-open> => sealing: = $form-sealing/open
-//  value sealed        = $form-sealing/sealed;
-//  value open          = $form-sealing/open;
-//  value compiler-open = $form-sealing/compiler-open;
-//  value dynamic       = $form-sealing/dynamic;
-//end property;
-
-//define property <generic-sideways-property-default-open> => sideways?: = #t
-//  value sideways = #t;
-//end property;
-
 define property <generic-dynamic-extent-property> => dynamic-extent: = #f
   value dynamic-extent = #t;
 end property;
@@ -118,16 +107,7 @@ define constant generic-adjectives-default-sealed
          <generic-dynamic-extent-property>,
          <generic-inline-property>);
 
-//define constant generic-adjectives-default-open
-//  = list(<generic-sealed-property-default-open>, 
-//         <generic-sideways-property-default-open>,
-//         <generic-dynamic-extent-property>,
-//         <generic-inline-property>); 
-
 define function generic-adjectives ()
-//  let mode = current-compilation-mode();
-//  if (mode  == #"default-open") generic-adjectives-default-open
-//  else generic-adjectives-default-sealed end
   generic-adjectives-default-sealed
 end function;
 

--- a/sources/dfmc/namespace/libraries.dylan
+++ b/sources/dfmc/namespace/libraries.dylan
@@ -730,10 +730,6 @@ define sideways method current-back-end-name () => (name :: false-or(<symbol>))
   end;
 end method;
 
-define sideways method current-compilation-mode () => (mode :: <symbol>)
-  library-description-compilation-mode(current-library-description())
-end method;
-
 define sideways method current-processor-name () => (name :: <symbol>)
   library-description-processor-name(current-library-description())
 end method;

--- a/sources/dfmc/namespace/library-description.dylan
+++ b/sources/dfmc/namespace/library-description.dylan
@@ -567,11 +567,6 @@ define function library-description-compilation-mode-setter
     // don't need to retract anything.
     unless (mode == #"loose" & ld.library-forms-dynamic?)
       retract-library-compilation(ld);
-      if (mode == #"default-open" |
-	    ld.library-description-compilation-mode == #"default-open")
-	// HACK: clear out parsing info, since default-open used during parsing
-	retract-library-parsing(ld);
-      end;
     end;
     ld.library-description-compilation-mode-slot := mode;
     ld.library-forms-dynamic? := (mode == #"loose");


### PR DESCRIPTION
This code has been disabled since 1999 (it couldn't happen then).
Also, remove current-compilation-mode() as it is no longer used
now that this is gone.
