### PR TITLE
[doc] Fix toc sidebar from changing width

### DIFF
--- a/documentation/_themes/opendylan-docs/layout.html
+++ b/documentation/_themes/opendylan-docs/layout.html
@@ -94,7 +94,7 @@
           {%- endblock %}
         </div>
         <div class="doc-sidebar span3">
-          <div class="pinned">
+          <div class="pinned span3">
             <div class="related">
               <ul class="breadcrumb">
                 <li>&nbsp</li>

--- a/documentation/_themes/opendylan-docs/static/opendylan.org/css/opendylan-docs.css
+++ b/documentation/_themes/opendylan-docs/static/opendylan.org/css/opendylan-docs.css
@@ -145,5 +145,5 @@ div.doc-sidebar li.toctree-l1.current li.toctree-l2 a {
 }
 
 div.doc-sidebar .pinned { height: 100%; overflow-y: hidden; }
-div.doc-sidebar .pinned.pin-set { position: fixed; width: 220px; height: 100%; top: 50px; z-index: 99; }
+div.doc-sidebar .pinned.pin-set { position: fixed; height: 100%; top: 50px; z-index: 99; }
 div.doc-sidebar .pinned:hover { overflow-y: auto !important; }


### PR DESCRIPTION
This is a first change, just to remove the annoying behavior we have now. 

If you want to use the bootstrap's affix style we have to:
- change the output of the `toctree()` function
  or
- add the style to mimic the affix style
