### PR TITLE
Avoid executable stacks on Linux and FreeBSD.

### DIFF
--- a/sources/harp/gnu-as-outputter/gnu-as-outputter.dylan
+++ b/sources/harp/gnu-as-outputter/gnu-as-outputter.dylan
@@ -418,6 +418,15 @@ define method output-footer
   outputter.finished-outputting? := #t;
 end method;
 
+
+define method output-footer
+      (be :: <harp-back-end>, outputter :: <harp-elf-as-outputter>) => ()
+  let stream = outputter.destination;
+  format(stream, ".section .note.GNU-stack,\"\",@progbits\n");
+  next-method();
+end method;
+
+
 define method output-code-start
       (be :: <harp-back-end>, outputter :: <harp-gnu-as-outputter>) => ()
   // Fixup data

--- a/sources/jamfiles/x86-freebsd-build.jam
+++ b/sources/jamfiles/x86-freebsd-build.jam
@@ -10,9 +10,10 @@ include $(SYSTEM_ROOT)/lib/config.jam ;
 CCFLAGS  += -DOPEN_DYLAN_PLATFORM_UNIX -DOPEN_DYLAN_PLATFORM_FREEBSD -m32 ;
 
 #
-# Library search path
+# Library search path and turn off executable stacks
 #
-LINKFLAGSEXE ?= -Wl,-z,origin -Wl,-rpath,\\$ORIGIN/../lib/ -pthread ;
+LINKFLAGSEXE ?= -Wl,-z,origin -Wl,-rpath,\\$ORIGIN/../lib/ -pthread -Wl,-z,noexecstack ;
+LINKFLAGSDLL ?= -Wl,-z,noexecstack ;
 
 #
 # Common build script

--- a/sources/jamfiles/x86-linux-build.jam
+++ b/sources/jamfiles/x86-linux-build.jam
@@ -10,9 +10,10 @@ include $(SYSTEM_ROOT)/lib/config.jam ;
 CCFLAGS  += -DOPEN_DYLAN_PLATFORM_UNIX -DOPEN_DYLAN_PLATFORM_LINUX -m32 ;
 
 #
-# Library search path
+# Library search path and turn off executable stacks
 #
-LINKFLAGSEXE ?= -Wl,-z,origin -Wl,-rpath,\\$ORIGIN/../lib/ ;
+LINKFLAGSEXE ?= -Wl,-z,origin -Wl,-rpath,\\$ORIGIN/../lib/ -Wl,-z,noexecstack ;
+LINKFLAGSDLL ?= -Wl,-z,noexecstack ;
 
 #
 # Common build script


### PR DESCRIPTION
Because we're generating assembly, we need for this section to
be present in the executable. We can also force it via the linker
flag.

Note that the generated .o files in the repo will need to be
regenerated with this section present at some point. (But the
linker flag keeps us safe for now.)
