### PR TITLE
find-registries() now takes platform-name.

### DIFF
--- a/sources/environment/commands/internal/registries.dylan
+++ b/sources/environment/commands/internal/registries.dylan
@@ -100,8 +100,8 @@ end command-property registries;
 define method show-property
     (context :: <environment-context>, property :: <registries-property>)
  => ()
-  let (processor, os) = default-platform-info();
-  let registries = find-registries(processor, os);
+  let platform-name = target-platform-name();
+  let registries = find-registries(platform-name);
   for (registry in registries)
     message(context, "  %s", registry)
   end

--- a/sources/environment/dswank/dswank.dylan
+++ b/sources/environment/dswank/dswank.dylan
@@ -82,7 +82,7 @@ define swank-function list-all-package-names (t)
             end;
           end;
         end;
-  let regs = find-registries($machine-name, $os-name);
+  let regs = find-registries(target-platform-name());
   let reg-paths = map(registry-location, regs);
   for (reg-path in reg-paths)
     if (file-exists?(reg-path))

--- a/sources/environment/dswank/library.dylan
+++ b/sources/environment/dswank/library.dylan
@@ -12,6 +12,7 @@ define library dswank
   use lisp-reader;
   use environment-commands;
   use environment-protocols;
+  use build-system;
   use commands;
   use environment-internal-commands;
   use source-records;
@@ -35,7 +36,10 @@ define module dswank
   use environment-protocols,
     exclude: { application-filename,
 	       application-arguments,
+	       default-build-script,
+	       default-build-script-setter,
 	       run-application };
+  use build-system;
   use command-lines;
   use commands;
   use source-records;

--- a/sources/project-manager/registry-projects/defaults.dylan
+++ b/sources/project-manager/registry-projects/defaults.dylan
@@ -31,21 +31,20 @@ define function make-registry-from-path
 	      personal?: personal?))
 end;
 
-define function find-registries(architecture, os)
+define function find-registries(platform-name)
   let registries = project-dynamic-environment(#"registries");
   if (registries)
     registries
   else
     project-dynamic-environment(#"registries") 
-      := find-registries-internal(architecture, os)
+      := find-registries-internal(platform-name)
   end
 end;
 
 define function find-registries-internal
-    (architecture, os)
+    (platform-name)
  => (registries :: <sequence>);
   debug-out(#"project-manager", "Finding registries");
-  let platform = platform-namestring(architecture, os);
   let generic-personal-registries = #();
   let platform-personal-registries = #();
   let personal-path = lookup-personal-registries();
@@ -55,7 +54,7 @@ define function find-registries-internal
                     "Making personal registries for %s",
                     as(<string>, path));
 	  let (platform-registry, generic-registry)
-	    = make-registry-from-path(path, platform, personal?: #t);
+	    = make-registry-from-path(path, platform-name, personal?: #t);
 	  platform-personal-registries 
 	    := add!(platform-personal-registries, platform-registry);
 	  generic-personal-registries
@@ -70,7 +69,7 @@ define function find-registries-internal
                   "Making system registries for %s",
                   as(<string>, path));
 	let (platform-registry, generic-registry) 
-	  = make-registry-from-path(path, platform, personal?: #t);
+	  = make-registry-from-path(path, platform-name, personal?: #t);
         //XXX: set to #f here to prevent rebuilds all over the place
 	platform-system-registries
 	  := add!(platform-system-registries, platform-registry);
@@ -93,7 +92,7 @@ end class <registry-entry-not-found-error>;
 
 define function compute-library-location (key, architecture, os)
   let platform = platform-namestring(architecture, os);
-  let registries = find-registries(architecture, os);
+  let registries = find-registries(platform);
 
   let (lid-location, registry)
     = find-library-locator(key, registries);


### PR DESCRIPTION
It previously took architecture/operating system parameters which
we're working to get away from.
