### PR TITLE
Remove extra default-build-script.

### DIFF
--- a/sources/environment/commands/internal/module.dylan
+++ b/sources/environment/commands/internal/module.dylan
@@ -20,8 +20,6 @@ define module environment-internal-commands
 	      open-project => env/open-project,
               save-project =>  env/save-project,
               save-project-database =>  env/save-project-database,
-	      default-build-script => env/default-build-script,
-	      default-build-script-setter => env/default-build-script-setter,
               project-compiler-back-end => env/project-compiler-back-end,
               project-compiler-back-end-setter => env/project-compiler-back-end-setter,
               project-compilation-mode => env/project-compilation-mode,

--- a/sources/environment/commands/library.dylan
+++ b/sources/environment/commands/library.dylan
@@ -13,6 +13,7 @@ define library environment-commands
   use io;
   use commands;
 
+  use build-system;
   use environment-protocols;
   use environment-manager;
   use environment-reports;

--- a/sources/environment/commands/module.dylan
+++ b/sources/environment/commands/module.dylan
@@ -116,6 +116,7 @@ define module command-lines
 end module command-lines;
 
 define module environment-commands
+  use build-system;
   use environment-imports;
   use environment-protocols,
     exclude: { <optional-parameter>,

--- a/sources/environment/dfmc/application/library.dylan
+++ b/sources/environment/dfmc/application/library.dylan
@@ -56,8 +56,6 @@ define module dfmc-application
 	      project-other-sources => env/project-other-sources,
 	      open-project => env/open-project,
               save-project => env/save-project,
-	      default-build-script => env/default-build-script,
-	      default-build-script-setter => env/default-build-script-setter,
               project-target-type => env/project-target-type,
               <project-target-type> => env/<project-target-type>,
               project-target-type-setter => env/project-target-type-setter,

--- a/sources/environment/dfmc/module.dylan
+++ b/sources/environment/dfmc/module.dylan
@@ -18,8 +18,6 @@ define module dfmc-environment
               project-other-sources => env/project-other-sources,
 	      open-project => env/open-project,
               save-project =>  env/save-project,
-	      default-build-script => env/default-build-script,
-	      default-build-script-setter => env/default-build-script-setter,
               project-compilation-mode => env/project-compilation-mode,
               project-compilation-mode-setter => env/project-compilation-mode-setter,
               project-target-type => env/project-target-type,

--- a/sources/environment/dfmc/projects/library.dylan
+++ b/sources/environment/dfmc/projects/library.dylan
@@ -34,8 +34,6 @@ define module dfmc-environment-projects
 	      open-project => env/open-project,
               save-project =>  env/save-project,
               save-project-database =>  env/save-project-database,
-	      default-build-script => env/default-build-script,
-	      default-build-script-setter => env/default-build-script-setter,
               project-compilation-mode => env/project-compilation-mode,
               project-compilation-mode-setter => env/project-compilation-mode-setter,
               project-compiler-back-end => env/project-compiler-back-end,

--- a/sources/environment/dfmc/projects/projects.dylan
+++ b/sources/environment/dfmc/projects/projects.dylan
@@ -564,16 +564,6 @@ define sealed method link-project
   end
 end method link-project;
 
-define sealed sideways method env/default-build-script
-    () => (build-script :: <file-locator>)
-  default-build-script()
-end method env/default-build-script;
-
-define sealed sideways method env/default-build-script-setter
-    (build-script :: <file-locator>) => (build-script :: <file-locator>);
-  default-build-script() := build-script
-end method env/default-build-script-setter;
-
 define sealed method env/close-project
     (project-object :: <dfmc-project-object>) => ()
   let project = project-object.project-proxy;

--- a/sources/environment/dswank/library.dylan
+++ b/sources/environment/dswank/library.dylan
@@ -36,8 +36,6 @@ define module dswank
   use environment-protocols,
     exclude: { application-filename,
 	       application-arguments,
-	       default-build-script,
-	       default-build-script-setter,
 	       run-application };
   use build-system;
   use command-lines;

--- a/sources/environment/protocols/module.dylan
+++ b/sources/environment/protocols/module.dylan
@@ -483,7 +483,6 @@ define module environment-protocols
          parse-project-source,
          build-project,
          clean-project,
-         default-build-script, default-build-script-setter,
          link-project,
          note-user-project-opened;
 

--- a/sources/environment/protocols/project-objects.dylan
+++ b/sources/environment/protocols/project-objects.dylan
@@ -363,11 +363,6 @@ define open generic link-project
           build-script, target, force?, unify?, release?, messages)
  => ();
 
-define open generic default-build-script
-    () => (build-script :: <file-locator>);
-define open generic default-build-script-setter
-    (build-script :: <file-locator>) => (build-script :: <file-locator>);
-
 
 /// Source records
 

--- a/sources/project-manager/registry-projects/registry-projects-library.dylan
+++ b/sources/project-manager/registry-projects/registry-projects-library.dylan
@@ -36,7 +36,7 @@ define module registry-projects-internal
   use format-out;
   use operating-system, rename: {load-library => os/load-library};
   use file-system;
-  use build-system, exclude: {default-build-script, default-build-script-setter};
+  use build-system;
 
   use file-source-records;
   use dfmc-project-compilation;


### PR DESCRIPTION
The generic in environment-protocols just existed to route to the
same thing in build-system, so get rid of the overhead / duplication.
