### PR TITLE
[io] Allow <machine-word> to print as an integer.

### DIFF
--- a/sources/io/buffered-format.dylan
+++ b/sources/io/buffered-format.dylan
@@ -179,6 +179,13 @@ define method buffered-format-integer
   print(arg, stream)
 end method buffered-format-integer;
 
+///---*** KLUDGE: Temporary method until we have better numerics.
+define method buffered-format-integer
+    (arg :: <machine-word>, radix :: limited(<integer>, min: 2, max: 36),
+     stream :: <buffered-stream>, sb :: <buffer>) => ()
+  print(arg, stream)
+end method buffered-format-integer;
+
 define method buffered-format-integer
     (arg :: <integer>, radix :: limited(<integer>, min: 2, max: 36),
      stream :: <buffered-stream>, sb :: <buffer>) => ()

--- a/sources/io/format.dylan
+++ b/sources/io/format.dylan
@@ -271,6 +271,15 @@ define method format-integer (arg :: <double-integer>,
   print(arg, stream)
 end method;
 
+///---*** KLUDGE: Temporary method until we have better numerics.
+define method format-integer
+    (arg :: <machine-word>,
+     radix :: limited(<integer>, min: 2, max: 36),
+     stream :: <stream>)
+ => ()
+  print(arg, stream)
+end method;
+
 define method format-integer (arg :: <integer>,
                               radix :: limited(<integer>, min: 2, max: 36),
                               stream :: <stream>) => ()


### PR DESCRIPTION
This is a temporary workaround similar to what is in place
for <double-integer> until we have better numerics.
