### PR TITLE
Remove primitive-byte-allocate.

### DIFF
--- a/sources/dfmc/c-back-end/c-primitives.dylan
+++ b/sources/dfmc/c-back-end/c-primitives.dylan
@@ -45,7 +45,6 @@ define generic emit-primitive-call
 //     
 // // Allocation.
 // define &primitive-descriptor primitive-allocate;
-// define &primitive-descriptor primitive-byte-allocate;
 // define &primitive-descriptor primitive-allocate-wrapper;
 // define &primitive-descriptor primitive-object-allocate-filled;
 // define &primitive-descriptor primitive-byte-allocate-filled;

--- a/sources/dfmc/harp-cg/harp-primitives.dylan
+++ b/sources/dfmc/harp-cg/harp-primitives.dylan
@@ -1791,7 +1791,6 @@ define &primitive-descriptor primitive-header-size, emitter: op--word-size;
     
 // Allocation.
 define &primitive-descriptor primitive-allocate;
-define &primitive-descriptor primitive-byte-allocate;
 define &primitive-descriptor primitive-allocate-wrapper;
 define &primitive-descriptor primitive-byte-allocate-filled, emitter: op--byte-allocate-filled;
 define &primitive-descriptor primitive-byte-allocate-filled-terminated, emitter: op--byte-allocate-filled-terminated;

--- a/sources/dfmc/llvm-back-end/llvm-primitives-alloc.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-primitives-alloc.dylan
@@ -231,12 +231,6 @@ define side-effect-free stateful indefinite-extent &runtime-primitive-descriptor
     (number-words :: <raw-integer>) => (pointer :: <raw-pointer>);
   //---*** Fill this in...
 end;
-
-define side-effect-free stateful indefinite-extent &runtime-primitive-descriptor primitive-byte-allocate
-    (number-words :: <raw-integer>, number-bytes :: <raw-integer>)
- => (pointer :: <raw-pointer>)
-  //---*** Fill this in...
-end;
 */
 
 // Allocate a block of memory untraced by the garbage collector

--- a/sources/dfmc/modeling/namespaces.dylan
+++ b/sources/dfmc/modeling/namespaces.dylan
@@ -77,7 +77,6 @@ define &module dylan-primitives
   create
     primitive-allocate,
     primitive-allocate-wrapper,
-    primitive-byte-allocate,
     primitive-object-allocate-filled,
     primitive-byte-allocate-filled,
     primitive-byte-allocate-filled-terminated,

--- a/sources/dfmc/modeling/primitives.dylan
+++ b/sources/dfmc/modeling/primitives.dylan
@@ -111,9 +111,6 @@ define side-effect-free stateless dynamic-extent &primitive primitive-header-siz
 
 define side-effect-free stateful indefinite-extent &primitive primitive-allocate
     (number-words :: <raw-integer>) => (pointer :: <raw-pointer>);
-define side-effect-free stateful indefinite-extent &primitive primitive-byte-allocate
-    (number-words :: <raw-integer>, number-bytes :: <raw-integer>)
- => (pointer :: <raw-pointer>);
 define side-effect-free stateful indefinite-extent &primitive primitive-untraced-allocate
     (number-bytes :: <raw-integer>) => (pointer :: <raw-pointer>);
 define side-effect-free stateful indefinite-extent &primitive primitive-manual-allocate

--- a/sources/harp/native-rtg/alloc-primitives.dylan
+++ b/sources/harp/native-rtg/alloc-primitives.dylan
@@ -371,12 +371,6 @@ define runtime-primitive untraced-allocate
 end runtime-primitive;
 
 
-define runtime-primitive byte-allocate
-  // This one should not be being used any more
-  op--unimplemented-primitive(be);
-end runtime-primitive;
-
-
 /****** Real version which doesn't null terminate
 
 define runtime-primitive byte-allocate-filled


### PR DESCRIPTION
This has been unused for a very long time and hasn't been implemented
in the HARP runtime for a long time.

I am still doing the 3 stage bootstrap to confirm this is a good patch.
