### PR TITLE
io: added a force-out function next to format-out

### DIFF
--- a/sources/io/format-out.dylan
+++ b/sources/io/format-out.dylan
@@ -9,3 +9,8 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 define method format-out (format-string :: <string>, #rest args) => ()
   apply(format, *standard-output*, format-string, args)
 end method;
+
+define method force-out () => ()
+  force-output(*standard-output*);
+end method;
+

--- a/sources/io/library.dylan
+++ b/sources/io/library.dylan
@@ -328,7 +328,8 @@ define module standard-io
 end module standard-io;
 
 define module format-out
-  create format-out;
+  create format-out,
+    force-out;
 end module format-out;
 
 define module io-internals


### PR DESCRIPTION
This alleviates the need to import both force-output (streams) and _standard-output_ (standard-io).
