### PR TITLE
[duim,gkt] Always use a new cairo surface when drawing

### DIFF
--- a/sources/duim/gtk/gtk-medium.dylan
+++ b/sources/duim/gtk/gtk-medium.dylan
@@ -176,8 +176,8 @@ define inline method get-gcontext
     let widget = medium.medium-sheet.sheet-mirror.mirror-widget;
     drawable := widget.gtk-widget-get-window;
     medium-drawable(medium) := drawable;
-    %context(medium) := gdk-cairo-create(drawable);
   end;
+  %context(medium) := gdk-cairo-create(drawable);
   values(drawable, %context(medium))
 end method get-gcontext;
 


### PR DESCRIPTION
This fixes the crash when clearing in scribble.

I'm not sure if we really need to put all the code in the gdk-lock.
