### PR TITLE
[duim,tests] Fix reference to undefined function

### DIFF
--- a/sources/duim/tests/gui/gadgets.dylan
+++ b/sources/duim/tests/gui/gadgets.dylan
@@ -344,7 +344,7 @@ define method make-test-gadgets
          index from 0 by 2)
       let class = gadget-class[0];
       let label = gadget-class[1];
-      let args  = rest(rest(gadget-class));
+      let args  = tail(tail(gadget-class));
       children[index] := make(<label>, label: concatenate(label, ":"));
       let documentation = format-to-string("A test %s", label);
       let gadget


### PR DESCRIPTION
Replace rest with tail.

This was causing the compiler to crash.
