### PR TITLE
Add a -verbose flag to dylan-compiler.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -43,7 +43,7 @@ check-submodules:
 
 3-stage-bootstrap: check-submodules
 	$(MAKE) 3-stage-bootstrap-reentry \
-	  BOOTSTRAP_2_COMPILER="$(abs_builddir)/Bootstrap.1/bin/dylan-compiler -build"
+	  BOOTSTRAP_2_COMPILER="$(abs_builddir)/Bootstrap.1/bin/dylan-compiler -build -verbose"
 3-stage-bootstrap-reentry: bootstrap-stage-1 bootstrap-stage-2 bootstrap-stage-3
 
 ###
@@ -52,7 +52,7 @@ check-submodules:
 
 2-stage-bootstrap: check-submodules
 	$(MAKE) 2-stage-bootstrap-reentry \
-	  BOOTSTRAP_2_COMPILER="$(abs_builddir)/Bootstrap.1/bin/dylan-compiler -build"
+	  BOOTSTRAP_2_COMPILER="$(abs_builddir)/Bootstrap.1/bin/dylan-compiler -build -verbose"
 2-stage-bootstrap-reentry: bootstrap-stage-1 bootstrap-stage-2
 
 ###
@@ -61,7 +61,7 @@ check-submodules:
 
 1-stage-bootstrap: check-submodules
 	$(MAKE) 1-stage-bootstrap-reentry \
-	  BOOTSTRAP_2_COMPILER="$(DYLANCOMPILER)"
+	  BOOTSTRAP_2_COMPILER="$(DYLANCOMPILER) -verbose"
 1-stage-bootstrap-reentry: bootstrap-stage-2
 
 ###
@@ -206,7 +206,7 @@ BOOTSTRAP_3_ENV = \
 BOOTSTRAP_3_LIBRARIES = dylan-compiler parser-compiler dswank make-dylan-app
 
 BOOTSTRAP_3_COMPILER = \
-	$(abs_builddir)/Bootstrap.2/bin/dylan-compiler -build
+	$(abs_builddir)/Bootstrap.2/bin/dylan-compiler -build -verbose
 
 $(abs_builddir)/Bootstrap.3:
 	mkdir $(abs_builddir)/Bootstrap.3

--- a/configure.ac
+++ b/configure.ac
@@ -83,6 +83,14 @@ done
 AC_CHECK_PROGS(DYLANCOMPILER, dylan-compiler opendylan minimal-console-compiler, no)
 test "$DYLANCOMPILER" = no && AC_MSG_ERROR([
 dylan-compiler, opendylan or minimal-console-compiler is required to bootstrap Open Dylan. Please download and install a build from http://opendylan.org/download/index.html])
+# In 2013.2 and later we need -verbose so fdmake.pl gets warning count summaries.
+AC_MSG_CHECKING(if $DYLANCOMPILER supports the -verbose flag)
+if $DYLANCOMPILER -version -verbose >/dev/null 2>&1 ; then
+  DYLANCOMPILER="$DYLANCOMPILER -verbose"
+  AC_MSG_RESULT(yes)
+else
+  AC_MSG_RESULT(no)
+fi
 test "$DYLANCOMPILER" = dylan-compiler && DYLANCOMPILER="$DYLANCOMPILER -build"
 test "$DYLANCOMPILER" = opendylan && DYLANCOMPILER="$DYLANCOMPILER -build"
 test "$DYLANCOMPILER" = minimal-console-compiler && DYLANCOMPILER="$DYLANCOMPILER -build"

--- a/sources/environment/commands/build.dylan
+++ b/sources/environment/commands/build.dylan
@@ -131,6 +131,8 @@ define class <abstract-link-command> (<project-command>)
     init-keyword: subprojects?:;
   constant slot %unify? :: <boolean> = #f,
     init-keyword: unify?:;
+  constant slot %verbose? :: <boolean> = #f,
+    init-keyword: verbose?:;
 end class <abstract-link-command>;
 
 define class <build-project-command> (<abstract-link-command>)
@@ -160,13 +162,14 @@ define command-line build => <build-project-command>
   keyword target :: <symbol> = "the target [dll or executable]";
   flag force         = "force relink the executable [off by default]";
   flag unify         = "combine the libraries into a single executable [off by default]";
+  flag verbose       = "show verbose output [off by default]";
 end command-line build;
 
 define method do-execute-command
     (context :: <environment-context>, command :: <build-project-command>)
  => ()
   let project = command.%project | context.context-project;
-  let messages = #"internal";
+  let messages = if (command.%verbose?) #"internal" else #"external" end;
   block ()
     if (build-project
           (project,
@@ -176,7 +179,7 @@ define method do-execute-command
            save-databases?:      command.%save?,
            messages:             messages,
            output:               command.%output,
-           progress-callback:    curry(note-build-progress, context),
+           progress-callback:    curry(note-build-progress, context, command.%verbose?),
            warning-callback:     curry(note-compiler-warning, context),
            error-handler:        curry(compiler-condition-handler, context)))
       if (command.%link?)
@@ -192,7 +195,7 @@ define method do-execute-command
            process-subprojects?: command.%subprojects?,
            unify?:               command.%unify?,
            messages:             messages,
-           progress-callback:    curry(note-build-progress, context),
+           progress-callback:    curry(note-build-progress, context, command.%verbose?),
            error-handler:        curry(compiler-condition-handler, context))
       end;
       message(context, "Build of '%s' completed", project.project-name)
@@ -205,22 +208,22 @@ define method do-execute-command
 end method do-execute-command;
 
 define method note-build-progress
-    (context :: <environment-context>,
+    (context :: <environment-context>, verbose? :: <boolean>,
      position :: <integer>, range :: <integer>,
      #key heading-label, item-label)
  => ()
   let project-context = context.context-project-context;
-  // let last-heading = project-context.context-last-heading;
-  // Let's not show headings
-  // if (heading-label & ~empty?(heading-label) & heading-label ~= last-heading)
-  //   project-context.context-last-heading := heading-label;
-  //   message(context, "%s", heading-label)
-  // end;
+  let last-heading = project-context.context-last-heading;
+  if (heading-label & ~empty?(heading-label) & heading-label ~= last-heading)
+    project-context.context-last-heading := heading-label;
+    message(context, "%s", heading-label)
+  end;
+
   let last-item-label = project-context.context-last-item-label;
-  if (item-label & ~empty?(item-label) & item-label ~= last-item-label)
+  if (verbose? & item-label & ~empty?(item-label) & item-label ~= last-item-label)
     project-context.context-last-item-label := item-label;
-    message(context, "%s", item-label)
-  end
+    message(context, "%s", item-label);
+  end;
 end method note-build-progress;
 
 define method note-compiler-warning
@@ -321,6 +324,7 @@ define command-line link => <link-project-command>
   flag force       = "force relink the executable [off by default]";
   flag subprojects = "link subprojects as well if necessary [on by default]";
   flag unify       = "combine the libraries into a single executable [off by default]";
+  flag verbose     = "show verbose output [off by default]";
 end command-line link;
 
 define method do-execute-command
@@ -330,14 +334,14 @@ define method do-execute-command
   let project = command.%project | context.context-project;
   let build-script
     = command.%build-script | project-context.context-build-script;
-  let messages = #"internal";
+  let messages = if (command.%verbose?) #"internal" else #"external" end;
   link-project(project,
                build-script:         build-script,
                target:               command.%target,
                force?:               command.%force?,
                process-subprojects?: command.%subprojects?,
                unify?:               command.%unify?,
-               progress-callback:    curry(note-build-progress, context),
+               progress-callback:    curry(note-build-progress, context, command.%verbose?),
                error-handler:        curry(compiler-condition-handler, context),
                messages:             messages)
 end method do-execute-command;

--- a/sources/environment/commands/general.dylan
+++ b/sources/environment/commands/general.dylan
@@ -138,7 +138,7 @@ define class <project-context> (<server-context>)
   slot context-build-script :: <file-locator> = default-build-script(),
     init-keyword: build-script:;
   slot context-properties :: <list> = #();
-  // slot context-last-heading :: false-or(<string>) = #f;
+  slot context-last-heading :: false-or(<string>) = #f;
   slot context-last-item-label :: false-or(<string>) = #f;
 end class <project-context>;
 

--- a/sources/environment/console/command-line.dylan
+++ b/sources/environment/console/command-line.dylan
@@ -49,6 +49,8 @@ define abstract class <basic-main-command> (<basic-command>)
     init-keyword: target:;
   constant slot %force? :: <boolean> = #f,
     init-keyword: force?:;
+  constant slot %verbose? :: <boolean> = #f,
+    init-keyword: verbose?:;
   constant slot %unify? :: <boolean> = #f,
     init-keyword: unify?:;
   constant slot %save? :: <boolean> = #t,
@@ -95,6 +97,7 @@ define method execute-main-command
 	save?:       command.%save?,
 	link?:       #f,
 	release?:    command.%release?,
+	verbose?:    command.%verbose?,
 	subprojects: command.%subprojects?,
         output:      begin
                        let output = make(<stretchy-object-vector>);

--- a/sources/environment/console/compiler-command-line.dylan
+++ b/sources/environment/console/compiler-command-line.dylan
@@ -25,6 +25,7 @@ define command-line main => <main-command>
   flag shortversion     = "displays the shortversion";
   flag debugger         = "enter the debugger if this program crashes";
   flag echo-input       = "echoes all input to the console";
+  flag verbose          = "show verbose output";
 
   flag import           = "import the project";
   flag build            = "build the project";


### PR DESCRIPTION
 By default compilation is non-verbose.  See https://gist.github.com/cgay/6217601 for examples of both.

I think this is good to go now.
