### PR TITLE
[dylan] Add debug-name for <slot-descriptor>.

### DIFF
--- a/documentation/release-notes/source/2013.2.rst
+++ b/documentation/release-notes/source/2013.2.rst
@@ -64,6 +64,11 @@ Now, it reports::
 Libraries
 ---------
 
+dylan-extensions
+^^^^^^^^^^^^^^^^
+
+The ``debug-name`` method now has a specialization for ``<slot-descriptor>``.
+
 I/O
 ^^^
 

--- a/sources/dylan/slot-descriptor.dylan
+++ b/sources/dylan/slot-descriptor.dylan
@@ -68,6 +68,10 @@ define generic as-slot-descriptor-class (allocation);
 
 //// RUN-TIME
 
+define method debug-name (slot-descriptor :: <slot-descriptor>)
+  slot-descriptor.slot-getter & debug-name(slot-descriptor.slot-getter)
+end method debug-name;
+
 define method getter=
     (descriptor-1 :: <slot-descriptor>, descriptor-2 :: <slot-descriptor>)
   descriptor-1.slot-getter == descriptor-2.slot-getter


### PR DESCRIPTION
This matches the `^debug-name` that is available for `<&slot-descriptor>`.
