### PR TITLE
[dylan] debug-message is now a dispatch-free function.

### DIFF
--- a/documentation/release-notes/source/2013.2.rst
+++ b/documentation/release-notes/source/2013.2.rst
@@ -69,6 +69,10 @@ dylan-extensions
 
 The ``debug-name`` method now has a specialization for ``<slot-descriptor>``.
 
+The ``debug-message`` method is now a function and doesn't perform any
+generic dispatch, making it safe to use it almost anywhere, including
+within the dispatch code.
+
 I/O
 ^^^
 

--- a/sources/dylan/debugging.dylan
+++ b/sources/dylan/debugging.dylan
@@ -37,11 +37,14 @@ define sealed inline method debugging-part?
 end method debugging-part?;
 
 /// DEBUG MESSAGE
-
-define sealed method debug-message
-    (format-string :: <string>, #rest format-args) => ()
-  primitive-debug-message(as(<byte-string>, format-string), format-args);
-end method debug-message;
+///
+/// This is a function and is set up to avoid any generic dispatch
+/// so that it can be used at any point in time, including inside
+/// dispatch.
+define function debug-message
+    (format-string :: <byte-string>, #rest format-args) => ()
+  primitive-debug-message(format-string, format-args);
+end function debug-message;
 
 /// DEBUG OUT
 ///


### PR DESCRIPTION
The debug-message method is now a function and doesn't perform any
generic dispatch, making it safe to use it almost anywhere, including
within the dispatch code.
