### PR TITLE
Unix io buffer size

### DIFF
--- a/sources/io/unix-file-accessor.dylan
+++ b/sources/io/unix-file-accessor.dylan
@@ -8,6 +8,8 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 // Native file accessor class for POSIX platforms
 
+define constant $preferred-buffer-size = 1024 * 16;
+
 define sealed class <native-file-accessor> (<external-file-accessor>)
   slot file-descriptor :: false-or(<integer>) = #f,
     init-keyword: file-descriptor:;
@@ -61,8 +63,8 @@ define method accessor-open
        file-size: initial-file-size = #f, // :: false-or(<integer>)?
      #all-keys) => ()
   accessor.file-descriptor := initial-file-descriptor;
-  let (preferred-size, positionable?) = unix-fd-info(initial-file-descriptor);
-  accessor.accessor-preferred-buffer-size := preferred-size;
+  accessor.accessor-preferred-buffer-size := $preferred-buffer-size;
+  let positionable? = unix-fd-positionable?(initial-file-descriptor);
   accessor.accessor-positionable? := positionable?;
   if (positionable? & ~initial-file-position)
     accessor.file-position := unix-lseek(initial-file-descriptor, 0, $seek_cur);

--- a/sources/io/unix-interface.dylan
+++ b/sources/io/unix-interface.dylan
@@ -95,16 +95,16 @@ define function unix-fsync (fd :: <integer>) => (result :: <integer>)
   end
 end function unix-fsync;
 
-define function unix-fd-info
+define function unix-fd-positionable?
     (fd :: <integer>)
- => (preferred-size :: <integer>, positionable? :: <boolean>);
+ => (positionable? :: <boolean>);
   let info :: <integer>
-    = raw-as-integer(%call-c-function ("io_fd_info")
+    = raw-as-integer(%call-c-function ("io_fd_positionable")
                        (fd :: <raw-c-unsigned-int>) => (result :: <raw-c-signed-int>)
                        (integer-as-raw(fd))
                      end);
-  values(logand(info, lognot(1)), odd?(info))
-end function unix-fd-info;
+  ~zero?(info)
+end function unix-fd-positionable?;
 
 define function unix-isatty
     (fd :: <integer>) 

--- a/sources/io/unix-portability.c
+++ b/sources/io/unix-portability.c
@@ -12,11 +12,11 @@ long io_lseek (int fd, long offset, int whence) {
   return lseek(fd, offset, whence);
 }
 
-int io_fd_info(int fd) {
+int io_fd_positionable(int fd) {
   struct stat st;
   if (fstat(fd, &st) < 0) {
     return -1;
   }
 
-  return st.st_blksize | ((st.st_mode & S_IFMT) == S_IFREG);
+  return (st.st_mode & S_IFMT) == S_IFREG;
 }


### PR DESCRIPTION
This makes the Unix code buffer the same amount as on Windows.

For comparison, musl libc buffers 1k and eglibc buffers 8k (thanks @promovicz).
