### PR TITLE
Switch back from malloc/free to MMAllocMisc/MMFreeMisc.

### DIFF
--- a/sources/common-dylan/darwin-common-extensions.dylan
+++ b/sources/common-dylan/darwin-common-extensions.dylan
@@ -123,7 +123,7 @@ define function get-application-filename
   let bufsiz :: <integer> = 128;
   let size = primitive-wrap-machine-word
     (primitive-cast-pointer-as-raw
-       (%call-c-function ("malloc")
+       (%call-c-function ("MMAllocMisc")
           (nbytes :: <raw-c-unsigned-long>) => (p :: <raw-c-pointer>)
           (integer-as-raw(4))
        end));
@@ -151,9 +151,9 @@ define function get-application-filename
     end;
     #f
   cleanup
-    %call-c-function ("free")
-      (p :: <raw-c-pointer>) => (void :: <raw-c-void>)
-        (primitive-cast-raw-as-pointer(primitive-unwrap-machine-word(size)))
+    %call-c-function ("MMFreeMisc")
+      (p :: <raw-c-pointer>, nbytes :: <raw-c-unsigned-long>) => (void :: <raw-c-void>)
+        (primitive-cast-raw-as-pointer(primitive-unwrap-machine-word(size)), integer-as-raw(4))
     end
   end
 end function;

--- a/sources/common-dylan/timers.dylan
+++ b/sources/common-dylan/timers.dylan
@@ -49,7 +49,7 @@ define macro with-storage
          block ()
            ?name := primitive-wrap-machine-word
                       (primitive-cast-pointer-as-raw
-                         (%call-c-function ("malloc")
+                         (%call-c-function ("MMAllocMisc")
                             (nbytes :: <raw-c-unsigned-long>) => (p :: <raw-c-pointer>)
                             (integer-as-raw(?size))
                           end));
@@ -61,9 +61,10 @@ define macro with-storage
          cleanup
            if (primitive-machine-word-not-equal?
                  (primitive-unwrap-machine-word(?name), integer-as-raw(0)))
-             %call-c-function ("free")
-               (p :: <raw-c-pointer>) => (void :: <raw-c-void>)
-                 (primitive-cast-raw-as-pointer(primitive-unwrap-machine-word(?name)))
+             %call-c-function ("MMFreeMisc")
+               (p :: <raw-c-pointer>, nbytes :: <raw-c-unsigned-long>) => (void :: <raw-c-void>)
+                 (primitive-cast-raw-as-pointer(primitive-unwrap-machine-word(?name)),
+                  integer-as-raw(?size))
              end;
              #f
            end


### PR DESCRIPTION
This fixes the Win32 build not finding malloc/free since we don't
use the C runtime there.

This means that building without bootstrapping will now require
Open Dylan 2013.1 since the C run-time didn't include
MMAllocMisc/MMFreeMisc until that release.
