### PR TITLE
Fixes to collection tests

### DIFF
--- a/sources/dylan/tests/collections.dylan
+++ b/sources/dylan/tests/collections.dylan
@@ -834,9 +834,9 @@ define method test-element
               element(collection, -1, default: default),
               default);
   unless (type == <object>)
-    check-condition(format-to-string("%s element wrong default type errors", name),
-                    <error>,
-                    element(collection, -1, default: #"wrong-default-type"));
+    check-equal(format-to-string("%s element wrong default type allowed", name),
+                element(collection, -1, default: #"wrong-default-type"),
+                #"wrong-default-type");
   end unless;
   for (key in key-sequence(collection))
     check-equal(format-to-string("%s element %=", name, key),

--- a/sources/dylan/tests/specification.dylan
+++ b/sources/dylan/tests/specification.dylan
@@ -280,15 +280,17 @@ define protocol-spec collections ()
   function head-setter (<object>, <pair>) => (<object>);
   function tail-setter (<object>, <pair>) => (<object>);
   open generic-function add (<sequence>, <object>) => (<sequence>);
-  open generic-function add! (<sequence>, <object>) => (<sequence>);
+  //--- DRM defines add! for <sequence>, but OD supports it for all <collection>.
+  open generic-function add! (<collection>, <object>) => (<collection>);
   open generic-function add-new
       (<sequence>, <object>, #"key", #"test") => (<sequence>);
   open generic-function add-new!
       (<sequence>, <object>, #"key", #"test") => (<sequence>);
   open generic-function remove 
       (<sequence>, <object>, #"key", #"test", #"count") => (<sequence>);
+  //--- DRM defines remove! for <sequence>, but OD supports it for all <collection>.
   open generic-function remove!
-      (<sequence>, <object>, #"key", #"test", #"count") => (<sequence>);
+      (<collection>, <object>, #"key", #"test", #"count") => (<collection>);
   open generic-function push (<deque>, <object>) => (<object>);
   open generic-function pop (<deque>) => (<object>);
   open generic-function push-last (<deque>, <object>) => (<object>);


### PR DESCRIPTION
Collections test suite was incorrect for `element`: the return value does not need to be the element type of the collection if `default:` is used.

Collections test suite was too strict with `add!` and `remove!`: OD implements them on `<collection>`, not just `<sequence>`.
