### PR TITLE
[crt] Use built-ins for counting leading/trailing zeros.

### DIFF
--- a/documentation/release-notes/source/2013.2.rst
+++ b/documentation/release-notes/source/2013.2.rst
@@ -125,6 +125,13 @@ The main reason for this change was ongoing confusion by the way the network
 library initialized itself (calling ``gethostname`` and passing its result
 to ``gethostbyname``, which does not work on all computers).
 
+runtime
+^^^^^^^
+
+The C runtime will now use compiler primitives for the primitives
+``primitive-machine-word-count-low-zeros`` and
+``primitive-machine-word-count-high-zeros``.
+
 System
 ^^^^^^
 

--- a/sources/lib/run-time/c-primitives-math.c
+++ b/sources/lib/run-time/c-primitives-math.c
@@ -479,6 +479,7 @@ DMINT primitive_machine_word_double_divide(DMINT xl, DMINT xh, DMINT y) {
   MV2(q, r);
 }
 
+#ifndef OPEN_DYLAN_COMPILER_GCC_LIKE
 DMINT primitive_machine_word_count_low_zeros(DMINT x) {
   if (x == 0) return(DMINT)(primitive_word_size() * 8);
   DMINT mask4 = (DMINT)0xF;
@@ -504,6 +505,7 @@ DMINT primitive_machine_word_count_high_zeros(DMINT x) {
   int index = (int)(uindex >> (primitive_word_size() * 8 - 4));
   return(DMINT)(count + t[index]);
 }
+#endif
 
 static void multiply_double (DMINT x, DMINT y, DUMINT* zl, DUMINT* zh) {
 #ifdef NO_LONGLONG

--- a/sources/lib/run-time/run-time.h
+++ b/sources/lib/run-time/run-time.h
@@ -1370,8 +1370,13 @@ extern DMINT primitive_unwrap_abstract_integer(D);
 #define primitive_machine_word_bit_field_deposit(f, o, s, x)      (((x) & ~(((1 << (s)) - 1) << (o))) | ((f) << (o)))
 #define primitive_machine_word_bit_field_extract(o, s, x)         (((x) & (((1 << (s)) - 1) << (o))) >> (o))
 
+#ifdef OPEN_DYLAN_COMPILER_GCC_LIKE
+#define primitive_machine_word_count_low_zeros(x) __builtin_ctzl(x)
+#define primitive_machine_word_count_high_zeros(x) __builtin_clzl(x)
+#else
 extern DMINT primitive_machine_word_count_low_zeros(DMINT);
 extern DMINT primitive_machine_word_count_high_zeros(DMINT);
+#endif
 
 #define primitive_machine_word_add(x, y)                  ((x) + (y))
 


### PR DESCRIPTION
This is a re-run of a previous commit, but should be fixed now. It previously failed on 64 bit since I was using the wrong builtin.
