### PR TITLE
[common-dylan] Rename <timer> to <profiling-timer>.

### DIFF
--- a/documentation/library-reference/source/common-dylan/simple-timers.rst
+++ b/documentation/library-reference/source/common-dylan/simple-timers.rst
@@ -12,7 +12,7 @@ Timers offer microsecond resolution on all supported platforms. Timers
 attempt to be monotonic where that capability is supported by the operating
 system.
 
-.. class:: <timer>
+.. class:: <profiling-timer>
 
    The timer class.
 
@@ -29,7 +29,7 @@ system.
 
    :signature: timer-start timer => ()
 
-   :parameter timer: An instance of :class:`<timer>`.
+   :parameter timer: An instance of :class:`<profiling-timer>`.
 
    See also:
 
@@ -41,7 +41,7 @@ system.
 
    :signature: timer-stop timer => (seconds, microseconds)
 
-   :parameter timer: An instance of :class:`<timer>`.
+   :parameter timer: An instance of :class:`<profiling-timer>`.
    :value seconds: An instance of :drm:`<integer>`.
    :value microseconds: An instance of :drm:`<integer>`.
 
@@ -55,7 +55,7 @@ system.
 
    :signature: timer-accumulated-time timer => (seconds, microseconds)
 
-   :parameter timer: An instance of :class:`<timer>`.
+   :parameter timer: An instance of :class:`<profiling-timer>`.
    :value seconds: An instance of :drm:`<integer>`.
    :value microseconds: An instance of :drm:`<integer>`.
 
@@ -65,5 +65,5 @@ system.
 
    :signature: timer-running? timer => (running?)
 
-   :parameter timer: An instance of :class:`<timer>`.
+   :parameter timer: An instance of :class:`<profiling-timer>`.
    :value running?: An instance of :drm:`<boolean>`.

--- a/documentation/release-notes/source/2014.1.rst
+++ b/documentation/release-notes/source/2014.1.rst
@@ -19,6 +19,12 @@ C Run-time
 ``debug-message`` no longer crashes when printing some conditions.
 
 
+Common Dylan
+============
+
+The ``<timer>`` class has been renamed to ``<profiling-timer>``.
+
+
 Testworks
 =========
 

--- a/sources/common-dylan/library.dylan
+++ b/sources/common-dylan/library.dylan
@@ -37,7 +37,7 @@ define module simple-profiling
 end module simple-profiling;
 
 define module simple-timers
-  create <timer>,
+  create <profiling-timer>,
          timer-start,
          timer-stop,
          timer-accumulated-time,

--- a/sources/common-dylan/macros.dylan
+++ b/sources/common-dylan/macros.dylan
@@ -27,7 +27,7 @@ define macro timing
   { timing ()
       ?body:body
     end }
-    => { let timer = make(<timer>);
+    => { let timer = make(<profiling-timer>);
          timer-start(timer);
          ?body;
          let (seconds, microseconds) = timer-stop(timer);
@@ -145,7 +145,7 @@ end method profiling-type-result;
 define method start-profiling-type
     (state :: <profiling-state>, keyword :: <cpu-profiling-type>) => ()
   unless (element(state, #"cpu-profiling", default: #f))
-    let timer = make(<timer>);
+    let timer = make(<profiling-timer>);
     timer-start(timer);
     state[#"cpu-profiling"] := #t;
     state[#"cpu-profiling-timer"] := timer;

--- a/sources/common-dylan/timers.dylan
+++ b/sources/common-dylan/timers.dylan
@@ -4,14 +4,14 @@ Author:   Bruce Mitchener, Jr.
 License:  See License.txt in this distribution for details.
 Warranty: Distributed WITHOUT WARRANTY OF ANY KIND
 
-define class <timer> (<object>)
+define class <profiling-timer> (<object>)
   slot timer-running? :: <boolean> = #f;
   slot timer-started-seconds :: <machine-word>;
   slot timer-started-nanoseconds :: <machine-word>;
-end class <timer>;
+end class <profiling-timer>;
 
 define method timer-start
-    (timer :: <timer>)
+    (timer :: <profiling-timer>)
  => ()
   timer.timer-running? := #t;
   let (sec, nsec) = %timer-current-time();
@@ -20,7 +20,7 @@ define method timer-start
 end;
 
 define method timer-accumulated-time
-    (timer :: <timer>)
+    (timer :: <profiling-timer>)
  => (second :: <integer>, microseconds :: <integer>)
   if (timer.timer-running?)
     let (sec, nsec) = %timer-current-time();
@@ -31,7 +31,7 @@ define method timer-accumulated-time
 end;
 
 define method timer-stop
-    (timer :: <timer>)
+    (timer :: <profiling-timer>)
  => (seconds :: <integer>, microseconds :: <integer>)
   if (timer.timer-running?)
     let (sec, nsec) = %timer-current-time();


### PR DESCRIPTION
I know this was just introduced and I'm already wanting to rename it, but I didn't like the namespace pollution since `<timer>` could also be used for something that has a callback after a period of time has elapsed.

Given that, I am not sure about renaming the other parts of this API, so I'm interested in hearing what people think.
