### PR TITLE
At least on my FreeBSD the struct timeval consists of two longs

### DIFF
--- a/sources/network/unix-sockets/sockets-extras.dylan
+++ b/sources/network/unix-sockets/sockets-extras.dylan
@@ -10,8 +10,8 @@ define simple-C-mapped-subtype <C-buffer-offset> (<C-char*>)
 end;
 
 define C-struct <timeval>
-  slot tv-sec-value :: <C-int>;
-  slot tv-usec-value :: <C-int>;
+  slot tv-sec-value :: <C-long>;
+  slot tv-usec-value :: <C-long>;
   c-name: "timeval";
 end;
 


### PR DESCRIPTION
(thus 64bit on my amd64 system).

Any operating system which does this differently? Linux? MacOSX?