### PR TITLE
posix-threads.c: Include pthread_np.h on FreeBSD to get pthread_set_name...

### DIFF
--- a/sources/lib/run-time/posix-threads.c
+++ b/sources/lib/run-time/posix-threads.c
@@ -38,6 +38,10 @@
 /* get prctl */
 #include <sys/prctl.h>
 #endif
+#ifdef OPEN_DYLAN_PLATFORM_FREEBSD
+/* get pthread_set_name_np */
+#include <pthread_np.h>
+#endif
 
 
 static void timespec_add_msecs(struct timespec *tp, long msecs) {

--- a/sources/lib/run-time/unix-support.c
+++ b/sources/lib/run-time/unix-support.c
@@ -61,16 +61,15 @@ int mps_lib_fputs_(const char *s, int end, FILE *stream)
 }
 
 // this is our stack walker, used in SIGTRAP
-static long getebp () {
 #ifdef OPEN_DYLAN_ARCH_X86
+static long getebp () {
     long ebp;
     asm("mov (%%ebp), %0"
         :"=r"(ebp));
     return ebp;
-#else
     return 0;
-#endif
 }
+#endif
 
 void walkstack() {
 #ifdef OPEN_DYLAN_ARCH_X86


### PR DESCRIPTION
..._np prototype

unix-support: hide getebp behind ifdef OPEN_DYLAN_ARCH_X86 to get rid of the unused function warning
