### PR TITLE
[dfmc-reader] Remove unused <template-closure>

### DIFF
--- a/sources/dfmc/reader/fragments.dylan
+++ b/sources/dfmc/reader/fragments.dylan
@@ -1406,9 +1406,6 @@ define method nested-fragment?
   values(#t, #f, #f);
 end method;
 
-// TODO: Remove. This for backward compatibility only.
-define constant <template-closure> = <template>;
-
 define sealed domain make (subclass(<template>));
 define sealed domain initialize (<template>);
 

--- a/sources/dfmc/reader/reader-library.dylan
+++ b/sources/dfmc/reader/reader-library.dylan
@@ -216,7 +216,7 @@ define module dfmc-reader
       <template-macro-call-fragment>;
 
   export
-    <template>, <template-closure>, template-fragments;
+    <template>, template-fragments;
 
   //// Fragment source location utilities.
 


### PR DESCRIPTION
This was marked for removal in 1997. Safe now.
