### PR TITLE
Make the slot primitive in a <primitive-call> constant, the

### DIFF
--- a/sources/dfmc/flow-graph/computation.dylan
+++ b/sources/dfmc/flow-graph/computation.dylan
@@ -614,11 +614,11 @@ define method make (c :: subclass(<function-call>),
   f
 end;
 
-
 /// PRIMITIVE CALL
 
 define graph-class <primitive-call> (<call>)
-  slot primitive :: false-or(<&primitive>), required-init-keyword: primitive:;
+  constant slot primitive :: false-or(<&primitive>),
+    required-init-keyword: primitive:;
 end graph-class;
 
 /// SIMPLE CALL -- a direct call to a function, with explicit arguments

--- a/sources/dfmc/flow-graph/flow-graph-library.dylan
+++ b/sources/dfmc/flow-graph/flow-graph-library.dylan
@@ -149,9 +149,9 @@ define module dfmc-flow-graph
     call-congruent?, call-congruent?-setter,
     <stack-vector>,
     <function-call>,
-    // *** function, function-setter,
+    // *** function, function-setter
     <primitive-call>,
-    primitive, primitive-setter,
+    primitive,
     <primitive-indirect-call>,
     <c-variable-pointer-call>,
       c-variable, c-variable-setter,

--- a/sources/dfmc/optimization/check.dylan
+++ b/sources/dfmc/optimization/check.dylan
@@ -141,33 +141,6 @@ define method inlined-inline-only-function?
   end;
 end method;
 
-define method check-optimized-computations (c :: <function-call>)
-  let f = function-value(c);
-  if (f)
-    if (model-compile-stage-only?(f) | inlined-inline-only-function?(f))
-      // format-out("Doing: %=\n", f);
-      if (instance?(f, <&generic-function>))
-        // format-out("Going for the copy...\n");
-        let copy
-          = find-inline-copy
-              (form-compilation-record(*current-dependent*), f);
-        // format-out("Made the copy.\n");
-        simplify-call-to-call-to-object!(c, copy);
-      elseif (instance?(f, <&method>))
-        // format-out("Going for the method copy...\n");
-        let copy
-          = find-inline-copy
-              (form-compilation-record(*current-dependent*), f);
-        // format-out("Made the copy.\n");
-        simplify-call-to-call-to-object!(c, copy);
-      else
-        // break("Function in function-call is %=", f);
-        #f
-      end;
-    end;
-  end;
-end method;
-
 // We want to copy a complete method so we use the standard dfm copier
 // except we force the top level method to be copied, even though it
 // has a definition.

--- a/sources/dfmc/optimization/dispatch.dylan
+++ b/sources/dfmc/optimization/dispatch.dylan
@@ -1487,15 +1487,6 @@ define function required-argument-type-estimates
   end;
 end;
 
-// Compute a reference to the given function and destructively modify the
-// call to refer to it rather than to what it currently refers to.
-
-define method simplify-call-to-call-to-object!
-    (call :: <function-call>, f :: <&function>) => ()
-  let ref-temp = make-object-reference(f);
-  replace-call-function!(call, ref-temp);
-end method;
-
 define method method-call-arguments
     (call :: <simple-call>, func :: <&lambda>)
  => (first-c :: false-or(<computation>), last-c :: false-or(<computation>),
@@ -1555,13 +1546,6 @@ define method method-call-arguments
  => (first-c :: false-or(<computation>), last-c :: false-or(<computation>),
      arguments :: <argument-sequence>)
   values(#f, #f, arguments(call))
-end method;
-
-define method replace-call-function!
-    (call :: <function-call>, temp :: <value-reference>) => ()
-  remove-user!(call.function, call);
-  add-user!(temp, call);
-  call.function := temp
 end method;
 
 define function incf-static-dispatch-count ()


### PR DESCRIPTION
setter was not used at all.

Also, remove dead code which set the function slot (unfortunately,
the inline-copier in check.dylan:210/215 uses the function-setter)

this has been tested with a 3 stage bootstrap on FreeBSD/amd64 (thus using C backend)
