### PR TITLE
[io] Add format-err, force-err.

### DIFF
--- a/documentation/library-reference/source/io/format-out.rst
+++ b/documentation/library-reference/source/io/format-out.rst
@@ -11,9 +11,9 @@ Introduction
 The Format-Out module is a convenient repackaging of two libraries that
 provides a simple way to send text to the platform’s standard output
 stream. For this purpose, Format-Out uses the Format module and the
-Standard-IO module and defines the functions :gf:`format-out` and
-:gf:`force-out`. The Format-Out module exports all the identifiers
-described in this document.
+Standard-IO module and defines the functions :gf:`format-out`,
+:gf:`force-out`, :gf:`format-err`, and :gf:`force-err`. The Format-Out
+module exports all the identifiers described in this document.
 
 :doc:`format` and :doc:`standard-io` give full details of the Format and
 Standard-IO libraries.
@@ -74,6 +74,60 @@ This section contains a reference entry for each item exported from the
    :description:
 
      Forces pending output from :var:`*standard-output*` to the operating
+     system using :gf:`force-output`.
+
+     This function is thread-safe.
+
+.. generic-function:: format-err
+
+   Formats its arguments on the standard error.
+
+   :signature: format-err *control-string* #rest *arguments* => ()
+
+   :parameter control-string: An instance of :drm:`<string>`.
+   :parameter #rest arguments: Instances of :drm:`<object>`.
+
+   :description:
+
+     Calls the :gf:`format` function from the *format* module on
+     :var:`*standard-error*` from the *standard-io* module,
+     *control-string*, and *arguments*.
+
+     This function is thread-safe.
+
+   See also
+
+   - :gf:`format`
+   - :var:`*standard-error*`
+
+.. method:: format-err
+   :sealed:
+   :specializer: <byte-string>
+
+   Formats its arguments on the standard error.
+
+   :signature: format-err *control-string* #rest *arguments* => ()
+
+   :parameter control-string: An instance of :drm:`<byte-string>`.
+   :parameter #rest arguments: Instances of :drm:`<object>`.
+
+   :description:
+
+     Formats its arguments on the standard error. There is one method for
+     :gf:`format-err`, and it is specialized to instances of :drm:`<byte-string>`.
+
+     This function is thread-safe.
+
+.. function:: force-err
+
+   Forces pending output from :var:`*standard-error*` to the operating
+   system.
+
+   :signature: force-err () => ()
+
+   :description:
+
+     Forces pending output from :var:`*standard-error*` to the operating
      system using :gf:`force-output`.
 
      This function is thread-safe.

--- a/documentation/release-notes/source/2014.1.rst
+++ b/documentation/release-notes/source/2014.1.rst
@@ -119,6 +119,14 @@ hash-algorithms
 * The library now builds on Windows.
 
 
+IO
+==
+
+* New functions ``format-err`` and ``force-err`` have been added that
+  do the same thing as ``format-out`` and ``force-out``, but operate
+  on ``*standard-error*`` rather than ``*standard-output*``.
+
+
 make-dylan-app
 ==============
 

--- a/sources/io/format-out.dylan
+++ b/sources/io/format-out.dylan
@@ -18,3 +18,14 @@ define method force-out () => ()
   end;
 end method;
 
+define method format-err (format-string :: <string>, #rest args) => ()
+  with-stream-locked (*standard-error*)
+    apply(format, *standard-error*, format-string, args);
+  end;
+end method;
+
+define method force-err () => ()
+  with-stream-locked (*standard-error*)
+    force-output(*standard-error*);
+  end;
+end method;

--- a/sources/io/library.dylan
+++ b/sources/io/library.dylan
@@ -331,6 +331,8 @@ end module standard-io;
 define module format-out
   create format-out,
     force-out;
+  create format-err,
+    force-err;
 end module format-out;
 
 define module io-internals


### PR DESCRIPTION
These are the same as format-out and force-out, but operate on
_standard-error_ instead of _standard-output_.
