### PR TITLE
Don't emit invalid character literals.

### DIFF
--- a/documentation/release-notes/source/2014.1.rst
+++ b/documentation/release-notes/source/2014.1.rst
@@ -49,6 +49,10 @@ Compiler
   visualization `can be seen here
   <https://opendylan.org/~hannes/test4.avi>`_.
 
+* The C back-end would emit character constants that current versions
+  of clang considered an error. The C back-end now generates a better
+  representation.
+
 C-FFI
 =====
 

--- a/sources/dfmc/c-back-end/c-back-end-library.dylan
+++ b/sources/dfmc/c-back-end/c-back-end-library.dylan
@@ -40,7 +40,6 @@ define module dfmc-c-back-end
     c-repeated-type-name,
     c-local-mangle, c-global-mangle, c-raw-mangle,
     format-emit, format-emit*,
-    emit-raw-character-data,
     emit-lambda-interface,
     emit-parameters;
 end module;

--- a/sources/dfmc/c-back-end/c-emit-object.dylan
+++ b/sources/dfmc/c-back-end/c-emit-object.dylan
@@ -144,18 +144,20 @@ define method emit-raw-character-data // !@#$ should be <byte-character>
     (back-end :: <c-back-end>, stream :: <stream>, c :: <character>)
  => ()
   select (c) 
-    '\\' => write(stream, "\\\\");
-    '\"' => write(stream, "\\\"");
-    '\'' => write(stream, "\\'");
-    '\n' => write(stream, "\\n");
-    '\f' => write(stream, "\\f");
-    '\t' => write(stream, "\\t");
-    '\r' => write(stream, "\\r");
+    '\\' => write(stream, "'\\\\'");
+    '\"' => write(stream, "'\\\"'");
+    '\'' => write(stream, "'\\''");
+    '\n' => write(stream, "'\\n'");
+    '\f' => write(stream, "'\\f'");
+    '\t' => write(stream, "'\\t'");
+    '\r' => write(stream, "'\\r'");
     otherwise =>
       if (c.graphic?)
+	write-element(stream, '\'');
 	write-element(stream, c);
+	write-element(stream, '\'');
       else
-	format(stream, "\\x%x", as(<integer>, c));
+	format(stream, "0x%x", as(<integer>, c));
       end if;
   end select
 end method;
@@ -163,9 +165,9 @@ end method;
 define method emit-object // !@#$ should be <byte-character>
     (back-end :: <c-back-end>, stream :: <stream>, c :: <character>)
  => ()
-  write(stream, "C('");
+  write(stream, "C(");
   emit-raw-character-data(back-end, stream, c);
-  write(stream, "')");
+  write(stream, ")");
 end method;
 
 /*

--- a/sources/dfmc/c-linker/c-link-object.dylan
+++ b/sources/dfmc/c-linker/c-link-object.dylan
@@ -129,6 +129,33 @@ define method emit-object-slot
   // write(stream, " */");
 end method;
 
+define constant $delete-character = as(<character>, 127);
+
+define method graphic? (character :: <character>)
+  let code :: <integer> = as(<integer>, character);
+  code >= as(<integer>, ' ') & code < as(<integer>, $delete-character)
+end method graphic?;
+
+define method emit-raw-character-data
+    (back-end :: <c-back-end>, stream :: <stream>, c :: <byte-character>)
+ => ()
+  select (c)
+    '\\' => write(stream, "\\\\");
+    '\"' => write(stream, "\\\"");
+    '\'' => write(stream, "\\'");
+    '\n' => write(stream, "\\n");
+    '\f' => write(stream, "\\f");
+    '\t' => write(stream, "\\t");
+    '\r' => write(stream, "\\r");
+    otherwise =>
+      if (c.graphic?)
+        write-element(stream, c);
+      else
+        format(stream, "\\x%x", as(<integer>, c));
+      end if;
+  end select
+end method;
+
 define method emit-object-slot
     (back-end :: <c-back-end>, stream :: <stream>, 
      class, slotd :: <&repeated-slot-descriptor>, o) => ()


### PR DESCRIPTION
Current clang (3.4) fails on '\xFFFF' as a character literal.

Fixes #695.
