### PR TITLE
[common-dylan] Use realpath on OS X with _NSGetExecutablePath.

### DIFF
--- a/documentation/release-notes/source/2014.1.rst
+++ b/documentation/release-notes/source/2014.1.rst
@@ -87,6 +87,11 @@ Common Dylan
 
 * The function ``integer-to-string`` is now faster.
 
+* On Mac OS X, application-filename() now returns the full absolute
+  path. It also handles symlinks correctly now. This means that
+  a symlink to a Dylan executable will function correctly as it
+  already did on Linux and FreeBSD.
+
 
 dylan-direct-c-ffi
 ==================

--- a/sources/common-dylan/darwin-common-dylan.lid
+++ b/sources/common-dylan/darwin-common-dylan.lid
@@ -26,7 +26,8 @@ Files: library
        machine-words/signal-overflow
        machine-words/double
        machine-words/unsigned-double
-C-Source-Files: timer_helpers.c
+C-Source-Files: darwin-common-extensions-helper.c
+                timer_helpers.c
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.

--- a/sources/common-dylan/darwin-common-extensions-helper.c
+++ b/sources/common-dylan/darwin-common-extensions-helper.c
@@ -1,0 +1,41 @@
+#include <limits.h>
+#include <mach-o/dyld.h>
+#include <stdlib.h>
+
+extern void *MMAllocMisc(size_t size);
+extern void MMFreeMisc(void *p, size_t size);
+
+unsigned int application_filename_name (char* buffer, size_t capacity) {
+  char buf[PATH_MAX];
+  uint32_t bufferSize = PATH_MAX;
+  char *p = buf;
+
+  if (-1 == _NSGetExecutablePath(p, &bufferSize)) {
+    p = MMAllocMisc(bufferSize);
+    _NSGetExecutablePath(p, &bufferSize);
+  }
+
+  char *real = realpath(p, NULL);
+  size_t realSize = real ? strlen(real) : 0;
+
+  if ((NULL != buffer) && (NULL != real) && (realSize < capacity)) {
+    memcpy(buffer, real, realSize);
+  }
+
+  if (NULL != real) {
+    free(real);
+  }
+
+  if (p != buf) {
+    MMFreeMisc(p, bufferSize);
+  }
+
+  return realSize;
+}
+
+/* We'll do the work twice, but that's the easiest way to make sure
+ * we handle the length correctly.
+ */
+unsigned int application_filename_length () {
+  return application_filename_name(NULL, 0) + 1;
+}


### PR DESCRIPTION
This makes OS X use realpath on the result from _NSGetExecutablePath
so that the resulting application name is the real name, rather than
potentially a symlink. This allows the compiler to be installed as
a symlink to the actual installation rather than needing wrapper
scripts.
