### PR TITLE
[system] Fix crash from readdir() on 64bit Mac OS X.

### DIFF
--- a/sources/system/arm-linux-magic-numbers.dylan
+++ b/sources/system/arm-linux-magic-numbers.dylan
@@ -21,7 +21,6 @@ define constant $st-ctime-offset = 72;
 define constant $pw-name-offset = 0;
 define constant $pw-dir-offset = 20;
 define constant $gr-name-offset = 0;
-define constant $d-name-offset = 11;
 
 // Used by unix-date-interface.dylan
 define constant $tm-sec-offset = 0;

--- a/sources/system/dump-magic-numbers.c
+++ b/sources/system/dump-magic-numbers.c
@@ -50,8 +50,6 @@ main(void) {
 
 	PRINT_OFFSETOF(struct group, gr_name, "gr-name");
 
-	PRINT_OFFSETOF(struct dirent, d_name, "d-name");
-
 
 	PRINT_USEDBY("unix-date-interface.dylan");
 

--- a/sources/system/file-system/unix-ffi.dylan
+++ b/sources/system/file-system/unix-ffi.dylan
@@ -116,9 +116,10 @@ end function group-name;
 
 define inline-only function dirent-name (dirent :: <machine-word>) => (name :: <byte-string>)
   primitive-raw-as-string
-    (primitive-cast-raw-as-pointer
-       (primitive-machine-word-add(primitive-unwrap-machine-word(dirent),
-                                  integer-as-raw($d-name-offset))))
+    (%call-c-function ("system_dirent_name")
+       (dirent :: <raw-c-pointer>) => (name :: <raw-byte-string>)
+       (primitive-unwrap-machine-word(dirent))
+     end);
 end function dirent-name;
 
 

--- a/sources/system/file-system/unix-file-system.dylan
+++ b/sources/system/file-system/unix-file-system.dylan
@@ -469,7 +469,7 @@ define function %do-directory
   block ()
     directory-fd := primitive-wrap-machine-word
                       (primitive-cast-pointer-as-raw
-			 (%call-c-function ("opendir")
+			 (%call-c-function ("system_opendir")
 			      (path :: <raw-byte-string>) => (dir-fd :: <raw-c-pointer>)
 			    (primitive-string-as-raw(as(<byte-string>, directory)))
 			  end));
@@ -480,7 +480,7 @@ define function %do-directory
     end;
     let dirent = primitive-wrap-machine-word
                    (primitive-cast-pointer-as-raw
-		      (%call-c-function ("readdir")
+		      (%call-c-function ("system_readdir")
 			   (dir-fd :: <raw-c-pointer>) => (dirent :: <raw-c-pointer>)
 			 (primitive-cast-raw-as-pointer
 			    (primitive-unwrap-machine-word(directory-fd)))
@@ -500,7 +500,7 @@ define function %do-directory
       end;
       dirent := primitive-wrap-machine-word
 	          (primitive-cast-pointer-as-raw
-		     (%call-c-function ("readdir")
+		     (%call-c-function ("system_readdir")
 			  (dir-fd :: <raw-c-pointer>) => (dirent :: <raw-c-pointer>)
 			(primitive-cast-raw-as-pointer
 			   (primitive-unwrap-machine-word(directory-fd)))
@@ -517,7 +517,7 @@ define function %do-directory
     if (primitive-machine-word-not-equal?
 	  (primitive-unwrap-machine-word(directory-fd),
 	   integer-as-raw($INVALID_DIRECTORY_FD)))
-      %call-c-function ("closedir") 
+      %call-c-function ("system_closedir") 
           (dir :: <raw-c-pointer>) => (failed? :: <raw-c-signed-int>)
         (primitive-cast-raw-as-pointer(primitive-unwrap-machine-word(directory-fd)))
       end

--- a/sources/system/ppc-darwin-magic-numbers.dylan
+++ b/sources/system/ppc-darwin-magic-numbers.dylan
@@ -21,7 +21,6 @@ define constant $st-ctime-offset = 40;
 define constant $pw-name-offset = 0;
 define constant $pw-dir-offset = 28;
 define constant $gr-name-offset = 0;
-define constant $d-name-offset = 8;
 
 // Used by unix-date-interface.dylan
 define constant $tm-sec-offset = 0;

--- a/sources/system/unix-portability.c
+++ b/sources/system/unix-portability.c
@@ -2,6 +2,7 @@
 #include <signal.h>
 #include <errno.h>
 #include <dlfcn.h>
+#include <dirent.h>
 
 #ifdef __APPLE__
 #include <crt_externs.h>
@@ -67,4 +68,24 @@ int system_spawn(char *program, char **argv, char **envp, char *dir,
 void *system_dlopen(const char *name)
 {
   return dlopen(name, RTLD_NOW | RTLD_GLOBAL);
+}
+
+DIR *system_opendir(const char *dirname)
+{
+  return opendir(dirname);
+}
+
+int system_closedir(DIR *dirp)
+{
+  return closedir(dirp);
+}
+
+struct dirent *system_readdir(DIR *dirp)
+{
+  return readdir(dirp);
+}
+
+const char *system_dirent_name(struct dirent *dirent)
+{
+  return dirent->d_name;
 }

--- a/sources/system/x86-darwin-magic-numbers.dylan
+++ b/sources/system/x86-darwin-magic-numbers.dylan
@@ -21,7 +21,6 @@ define constant $st-ctime-offset = 40;
 define constant $pw-name-offset = 0;
 define constant $pw-dir-offset = 28;
 define constant $gr-name-offset = 0;
-define constant $d-name-offset = 8;
 
 // Used by unix-date-interface.dylan
 define constant $tm-sec-offset = 0;

--- a/sources/system/x86-freebsd-magic-numbers.dylan
+++ b/sources/system/x86-freebsd-magic-numbers.dylan
@@ -21,7 +21,6 @@ define constant $st-ctime-offset = 40;
 define constant $pw-name-offset = 0;
 define constant $pw-dir-offset = 28;
 define constant $gr-name-offset = 0;
-define constant $d-name-offset = 8;
 
 // Used by unix-date-interface.dylan
 define constant $tm-sec-offset = 0;

--- a/sources/system/x86-linux-magic-numbers.dylan
+++ b/sources/system/x86-linux-magic-numbers.dylan
@@ -21,7 +21,6 @@ define constant $st-ctime-offset = 72;
 define constant $pw-name-offset = 0;
 define constant $pw-dir-offset = 20;
 define constant $gr-name-offset = 0;
-define constant $d-name-offset = 11;
 
 // Used by unix-date-interface.dylan
 define constant $tm-sec-offset = 0;

--- a/sources/system/x86_64-darwin-magic-numbers.dylan
+++ b/sources/system/x86_64-darwin-magic-numbers.dylan
@@ -21,7 +21,6 @@ define constant $st-ctime-offset = 64;
 define constant $pw-name-offset = 0;
 define constant $pw-dir-offset = 48;
 define constant $gr-name-offset = 0;
-define constant $d-name-offset = 21;
 
 // Used by unix-date-interface.dylan
 define constant $tm-sec-offset = 0;

--- a/sources/system/x86_64-freebsd-magic-numbers.dylan
+++ b/sources/system/x86_64-freebsd-magic-numbers.dylan
@@ -21,7 +21,6 @@ define constant $st-ctime-offset = 56;
 define constant $pw-name-offset = 0;
 define constant $pw-dir-offset = 48;
 define constant $gr-name-offset = 0;
-define constant $d-name-offset = 8;
 
 // Used by unix-date-interface.dylan
 define constant $tm-sec-offset = 0;

--- a/sources/system/x86_64-linux-magic-numbers.dylan
+++ b/sources/system/x86_64-linux-magic-numbers.dylan
@@ -21,7 +21,6 @@ define constant $st-ctime-offset = 104;
 define constant $pw-name-offset = 0;
 define constant $pw-dir-offset = 32;
 define constant $gr-name-offset = 0;
-define constant $d-name-offset = 19;
 
 // Used by unix-date-interface.dylan
 define constant $tm-sec-offset = 0;


### PR DESCRIPTION
We wrap the readdir and related calls in C so that we allow
the aliases that are set up in the header files to be used. This
keeps everything consistent and using the versions offering 64 bit
inodes and the new versions of the struct dirent.

At the same time, we move dirent-name() to C to keep it consistent
as well and slightly less magical.
