### PR TITLE
[system] Remove #"write-date" file property.

### DIFF
--- a/documentation/library-reference/source/system/file-system.rst
+++ b/documentation/library-reference/source/system/file-system.rst
@@ -321,8 +321,7 @@ File-System module.
    :parameter file: An instance of :class:`<pathname>`.
    :parameter #key key: One of ``#"author"``, ``#"size"``,
      ``#"creation-date"``, ``#"access-date"``, ``#"modification-date"``,
-     ``#"write-date"``, ``#"readable?"``, ``#"writeable?"``,
-     ``#"executable?"``.
+     ``#"readable?"``, ``#"writeable?"``, ``#"executable?"``.
    :value property: The value of the property specified by *key*. The
      type of the value returned depends on the value of *key*: see the
      description for details.
@@ -349,8 +348,6 @@ File-System module.
        +--------------------------+-------------------------------+
        | ``#"modification-date"`` | :class:`<date>`               |
        +--------------------------+-------------------------------+
-       | ``#"write-date"``        | :class:`<date>`               |
-       +--------------------------+-------------------------------+
        | ``#"readable?"``         | :drm:`<boolean>`              |
        +--------------------------+-------------------------------+
        | ``#"writeable?"``        | :drm:`<boolean>`              |
@@ -361,8 +358,7 @@ File-System module.
      Not all platforms implement all of the above keys. Some platforms
      may support additional keys. The ``#"author"`` key is supported on
      all platforms but may return ``#f`` if it is not meaningful on a
-     given platform. The ``#"modification-date"`` and ``#"write-date"``
-     keys are identical. Use of an unsupported key signals an error.
+     given platform. Use of an unsupported key signals an error.
 
      All keys listed above are implemented by Win32, though note that
      ``#"author"`` always returns ``#f``.
@@ -384,8 +380,7 @@ File-System module.
    :parameter file: An instance of :class:`<pathname>`.
    :parameter key: One of ``#"author"``, ``#"size"``,
      ``#"creation-date"``, ``#"access-date"``, ``#"modification-date"``,
-     ``#"write-date"``, ``#"readable?"``, ``#"writeable?"``,
-     ``#"executable?"``.
+     ``#"readable?"``, ``#"writeable?"``, ``#"executable?"``.
    :value new-value: The type of this depends on the value of *key*. See
      the description for details.
 
@@ -412,8 +407,6 @@ File-System module.
        +--------------------------+-------------------------------+
        | ``#"modification-date"`` | :class:`<date>`               |
        +--------------------------+-------------------------------+
-       | ``#"write-date"``        | :class:`<date>`               |
-       +--------------------------+-------------------------------+
        | ``#"readable?"``         | :drm:`<boolean>`              |
        +--------------------------+-------------------------------+
        | ``#"writeable?"``        | :drm:`<boolean>`              |
@@ -426,8 +419,7 @@ File-System module.
      value of *key*.
 
      Not all platforms implement all of the above keys. Some platforms may
-     support additional keys. The ``#"modification-date"`` and ``#"write-date"``
-     keys are identical. Use of an unsupported key signals an error.
+     support additional keys. Use of an unsupported key signals an error.
 
      The only property that can be set on Win32 is ``#"writeable?"``.
 

--- a/documentation/release-notes/source/2014.1.rst
+++ b/documentation/release-notes/source/2014.1.rst
@@ -165,6 +165,8 @@ system
 * The function ``format-date`` is now faster.
 * The ``copy-file`` method on Unix no longer fails when the path contains
   spaces.
+* The ``#"write-date`` file property has been removed. It was identical to
+  ``#"modification-date"``, so use that instead.
 
 
 Testworks

--- a/sources/lib/source-records/flat-file-source-records.dylan
+++ b/sources/lib/source-records/flat-file-source-records.dylan
@@ -43,7 +43,7 @@ end method;
 
 define function unique-file-id-iso(location :: <locator>)
  => (id :: <string>)
-  let date :: <date> = file-property(location, #"write-date");
+  let date :: <date> = file-property(location, #"modification-date");
   as-iso8601-string(date)
 end;
 

--- a/sources/project-manager/projects/lid-projects.dylan
+++ b/sources/project-manager/projects/lid-projects.dylan
@@ -376,7 +376,7 @@ define method initialize (project :: <lid-project>, #rest keys,
   unless (library-name & lid-file-info)
     assert(lid-location, "<lid-project>: lid-location not supplied");
     project-lid-location(project) := lid-location;
-    project-lid-date(project) := file-property(lid-location, #"write-date");
+    project-lid-date(project) := file-property(lid-location, #"modification-date");
     let (library-name, files, properties) = read-lid-data(lid-location);
     project-lid-library-name(project) := library-name;
     project-lid-file-info(project) := properties;

--- a/sources/project-manager/registry-projects/registry-projects.dylan
+++ b/sources/project-manager/registry-projects/registry-projects.dylan
@@ -184,7 +184,7 @@ define method update-project-files (project :: <registry-project>) => ()
   // TODO: this needs to update database location if library-name
   // has changed
   let lid-location = project.project-lid-location;
-  let lid-date = file-property(lid-location, #"write-date");
+  let lid-date = file-property(lid-location, #"modification-date");
   unless (project.project-lid-date = lid-date)
     let (library-name, files, properties) = read-lid-data(lid-location);
     let build-settings = lid-build-settings(lid-location, properties);

--- a/sources/system/file-system/file-system.dylan
+++ b/sources/system/file-system/file-system.dylan
@@ -225,7 +225,6 @@ define generic file-properties
 define method file-properties
     (file :: <file-system-locator>) => (properties :: <explicit-key-collection>)
   let properties = %file-properties(file);
-  properties[#"write-date"] := properties[#"modification-date"];
   properties
 end method file-properties;
 
@@ -249,11 +248,6 @@ define method file-property (file :: <string>, key :: <symbol>) => (value)
 end method file-property;
 
 define generic %file-property (file :: <file-system-locator>, key :: <symbol>) => (value);
-
-define method %file-property (file :: <file-system-locator>, key == #"write-date")
- => (write-date :: false-or(<date>))
-  %file-property(file, #"modification-date")
-end method %file-property;
 
 define method %file-property (file :: <file-system-locator>, key :: <symbol>) => (value)
   error(make(<file-system-error>,
@@ -279,12 +273,6 @@ end method file-property-setter;
 
 define generic %file-property-setter
     (new-value, file :: <pathname>, key :: <symbol>) => (new-value);
-
-define method %file-property-setter 
-    (new-write-date :: false-or(<date>), file :: <file-system-locator>, key == #"write-date")
- => (new-write-date :: false-or(<date>))
-  %file-property-setter(new-write-date, file, #"modification-date")
-end method %file-property-setter;
 
 define method %file-property-setter
     (new-value, file :: <file-system-locator>, key :: <symbol>) => (new-value)


### PR DESCRIPTION
This was identical to #"modification-date", so there was no need
for it.
