### PR TITLE
[build] Allow --with-gc=malloc.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -149,6 +149,15 @@ if test "$cross_compiling" != "yes"; then
           ]
     )
 
+    AS_IF([test x${with_gc} == xmalloc],
+          [
+            GC_CFLAGS="-DGC_USE_MALLOC"
+            GC_LFLAGS=""
+            GC_LIBRARY=""
+            GC_USE_STATIC_BOEHM=false
+            GC_CHOICE="malloc"
+          ]
+    )
     AS_IF([test x${with_gc} == xmps],
           [
             AS_IF([test x${SUPPORT_GC_MPS} == xno],


### PR DESCRIPTION
This isn't a documented option as it is just for compiler hacking
like using valgrind to check for memory errors.
