### PR TITLE
[dfmc-modeling] Disable ambiguous generic warnings for ^subtype?, ^known...

### DIFF
--- a/sources/dfmc/modeling/modeling-library.dylan
+++ b/sources/dfmc/modeling/modeling-library.dylan
@@ -57,7 +57,7 @@ end module;
 define module-with-models dfmc-modeling
   use dylan;
   use dylan-extensions,
-    import: { $machine-word-size, immutable-vector };
+    import: { $machine-word-size, immutable-vector, *permissibly-ambiguous-generics* };
   use machine-word-lowlevel,
     import: { coerce-integer-to-machine-word,
 	      machine-word-logior,

--- a/sources/dfmc/modeling/types.dylan
+++ b/sources/dfmc/modeling/types.dylan
@@ -34,7 +34,7 @@ define generic ^instance? (object :: <model-value>, type :: <&type>)
 define generic ^subtype? (t1 :: <&type>, t2 :: <&type>)
  => (subtype? :: <boolean>);
 
-// *permissibly-ambiguous-generics* := add(*permissibly-ambiguous-generics*, ^subtype?);
+*permissibly-ambiguous-generics* := add(*permissibly-ambiguous-generics*, ^subtype?);
 
 
 define generic ^base-type (type :: <&type>)
@@ -46,7 +46,7 @@ define generic ^type-equivalent? (t1 :: <&type>, t2 :: <&type>)
 define generic ^known-disjoint? (t1 :: <&type>, t2 :: <&type>)
  => (disjoint? :: <boolean>);
 
-// *permissibly-ambiguous-generics* := add(*permissibly-ambiguous-generics*, ^known-disjoint?);
+*permissibly-ambiguous-generics* := add(*permissibly-ambiguous-generics*, ^known-disjoint?);
 
 //// Top rules
 


### PR DESCRIPTION
...-disjoint?.

This work was originally done by gsb in 1998 but not enabled entirely.
