### PR TITLE
[dfmc] Remove unused optimization level stuff.

### DIFF
--- a/documentation/hacker-guide/source/compiler-design.rst
+++ b/documentation/hacker-guide/source/compiler-design.rst
@@ -625,21 +625,6 @@ Convenience functions:
 
 Global state:
 
-The thread-variable ``*optimization-level*`` is meant to be a gross control
-of how much optimization is done.  The constants
-
-.. code-block:: dylan
-
-  define constant $optimization-mandatory = 0;
-  define constant $optimization-low       = 1;
-  define constant $optimization-medium    = 2;
-  define constant $optimization-high      = 3;
-  
-  define constant $optimization-default   = $optimization-medium;
-
-are defined and correspond to the ``optimization:`` option in the define
-compilation-pass macro.
-
 The thread-variable ``*back-end*`` is used with the options back-end: and
 exclude-back-end:.
 

--- a/sources/dfmc/common/common-library.dylan
+++ b/sources/dfmc/common/common-library.dylan
@@ -158,15 +158,7 @@ define module dfmc-common
 
     run-compilation-passes,
 
-    word-size,
-
-    *optimization-level*,
-
-    $optimization-mandatory,
-    $optimization-low,
-    $optimization-medium,
-    $optimization-high,
-    $optimization-default;
+    word-size;
 
     // \compilation-pass-definer,
     // define-compilation-pass!,

--- a/sources/dfmc/common/compilation-pass.dylan
+++ b/sources/dfmc/common/compilation-pass.dylan
@@ -10,16 +10,3 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define open generic run-compilation-passes (code) => code;
   // method definition in management module
-
-
-//// optimization levels
-
-define constant $optimization-mandatory = 0;
-define constant $optimization-low       = 1;
-define constant $optimization-medium    = 2;
-define constant $optimization-high      = 3;
-
-define constant $optimization-default   = $optimization-low;
-
-define thread variable *optimization-level* = $optimization-default;
-


### PR DESCRIPTION
This hasn't been used since 1997 or earlier.
