### PR TITLE
[dpkg] Changed rpath configuration for third stage bootstrap during Debian package generation.

### DIFF
--- a/packages/unix/debian/generate_deb.rb
+++ b/packages/unix/debian/generate_deb.rb
@@ -2,26 +2,26 @@
 # Run in a source directory. Make sure debian/changelog is updated if needed.
 # When building for x86 (32 bit), make sure MPS sources are available in the mps-kit subdirectory.
 # When building for x86_64, make sure you increase the stack size (eg, ulimit -s 20000)
- 
+
 # Required dependencies:
 # sudo apt-get install automake gcc libgc-dev rubygems ruby-dev
 # sudo gem install fpm
 
 require 'fileutils'
 include FileUtils
- 
+
 # Create staging area
 STAGING_DIR=`mktemp -d`.chomp
 INSTALL_DIR="/usr/lib/opendylan"
 
 additional_fpm_flags=""
 configure_flags="--prefix=#{INSTALL_DIR}"
- 
+
 mkdir_p "#{STAGING_DIR}/usr/bin"
- 
+
 #system("make clean 2> /dev/null") # Clean up in case we start from a dirty directory
 system("./autogen.sh") # Will return errors, but safe to ignore
- 
+
 # Add MPS configure flag for 32 bit x86
 if(`uname -m` =~ /i686/)
   configure_flags << " --with-gc=mps --with-gc-path=#{Dir.pwd}/mps-kit"
@@ -30,12 +30,12 @@ else
   configure_flags << " --with-gc=boehm"
   jamfile="sources/jamfiles/x86_64-linux-build.jam"
 end
- 
+
 # Add libgc dependency for 64 bit x86
 if(`uname -m` =~ /x86_64/)
   additional_fpm_flags << ' -d "libgc-dev (>= 0)"'
 end
- 
+
 # Configure and build first 2 stages
 puts "Configuring with #{configure_flags}"
 system("./configure #{configure_flags}") || exit(1)
@@ -57,10 +57,10 @@ end
 
 # Build the last stage with the modified rpath jamfile
 system("make 3-stage-bootstrap") || exit(1)
- 
+
 # Install into staging area
 system("make install DESTDIR=#{STAGING_DIR}") || exit(1)
- 
+
 # Strip all the libraries and binaries
 needs_stripping = Dir["#{STAGING_DIR}/usr/lib/opendylan/lib/*.so"] + Dir["#{STAGING_DIR}/usr/lib/opendylan/bin/*"]
 needs_stripping.each do |f|
@@ -77,12 +77,12 @@ Dir["../lib/opendylan/bin/*"].each { |f| FileUtils.ln_s(f, File.basename(f)) }
 Dir.chdir srcdir
 
 VERSION=`./Bootstrap.3/bin/dylan-compiler -shortversion`.chomp
- 
+
 # Generate the actual deb package
 FPM_CMD=<<EOF
 fpm -s dir -t deb -n opendylan --deb-changelog packages/unix/debian/changelog -v #{VERSION} -C #{STAGING_DIR} -p opendylan-VERSION_ARCH.deb \
     -d "gcc (>= 0)" -d "libc6-dev (>= 0)" #{additional_fpm_flags} -m "Wim Vander Schelden <wim@fixnum.org>" \
-    --license MIT --url "http://opendylan.org/" --vendor "Dylan Hackers" --description "A Dylan compiler 
+    --license MIT --url "http://opendylan.org/" --vendor "Dylan Hackers" --description "A Dylan compiler
     Dylan is a multi-paradigm programming language. It is a
     object-oriented language and is well suited for a
     functional style of programming.
@@ -93,8 +93,8 @@ EOF
 
 puts FPM_CMD
 system(FPM_CMD) || exit(1)
- 
+
 rm_rf STAGING_DIR
- 
+
 # Check the generated package for problems
 #system("lintian *.deb")


### PR DESCRIPTION
This allows the packages to be used inside a chroot without a /proc filesystem, and is more in line
with debian packaging conventions. Since the first and second stage of the bootstrap still use a
relative rpath, building packages still requires a proper /proc mount.
