### PR TITLE
[dfmc-conditions] with-simple-abort-retry-restart allows non-constant expressions

### DIFF
--- a/sources/dfmc/conditions/native-hacks.dylan
+++ b/sources/dfmc/conditions/native-hacks.dylan
@@ -18,10 +18,10 @@ define macro with-simple-abort-retry-restart
            block () 
              ?body
            exception (r :: <simple-restart>, 
-                      init-arguments: #[format-string:, ?abort])
+                      init-arguments: vector(format-string:, ?abort))
              #f
            exception (r :: <simple-restart>, 
-                      init-arguments: #[format-string:, ?retry])
+                      init-arguments: vector(format-string:, ?retry))
              _loop_()
            end
          end;


### PR DESCRIPTION
This is from my work in progress on restoring compilation passes.

This is required when the macro is used like:

``` dylan
with-simple-abort-retry-restart
    (format-to-string("Abort %s and continue.", pass.name),
     format-to-string("Restart %s.", pass.name))
  ...
end;
```
