### PR TITLE
Nicer error message for dswank when no project set

### DIFF
--- a/sources/environment/dswank/dswank.dylan
+++ b/sources/environment/dswank/dswank.dylan
@@ -118,10 +118,14 @@ define swank-function compile-file-for-emacs (filename, #rest foo)
       end;
     end;
   end;
-  run-compiler(*server*, concatenate("build ", *project*.project-name));
-  let notes = compiler-notes-for-emacs();
-  //result is output-pathname, notes, success/failure of compilation
-  list("pathname", notes, "T");
+  if (*project*)
+    run-compiler(*server*, concatenate("build ", *project*.project-name));
+    let notes = compiler-notes-for-emacs();
+    //result is output-pathname, notes, success/failure of compilation
+    list("pathname", notes, "T");
+  else
+    error("A project has not been set");
+  end;
 end;
 
 define swank-function compiler-notes-for-emacs ()


### PR DESCRIPTION
When using DIME and you try to compile the file without setting the
project, you got a method missing error on #f, #f being the missing
project receiving a message.

Added a nil check on _project_ in dswank to throw an error with a more
obvious message, which surfaces back on the Emacs side as:

Evaluation aborted on Error: A project has not been set
