### PR TITLE
[dfmc,dfm output] Clearly indicate CONGRUENT-CALLs.

### DIFF
--- a/sources/dfmc/debug-back-end/print-flow-graph.dylan
+++ b/sources/dfmc/debug-back-end/print-flow-graph.dylan
@@ -197,7 +197,11 @@ define method operation-name (c :: <function-call>)
 end method operation-name;
 
 define method operation-name (c :: <simple-call>)
-  "CALL"
+  if (call-congruent?(c))
+    "CONGRUENT-CALL"
+  else
+    "CALL"
+  end if
 end method operation-name;
 
 define method operation-name (c :: <engine-node-call>)


### PR DESCRIPTION
In practice, this changes CALLi to CONGRUENT-CALLi.

This helps make it clear that a congruent call is happening rather
than a fully generic dispatch (CALLg, etc). This also makes it match
the terminology used in the run-times and generated code more
closely.
