### PR TITLE
Fix limited collection vs singleton subtype.

### DIFF
--- a/sources/dfmc/modeling/singletons.dylan
+++ b/sources/dfmc/modeling/singletons.dylan
@@ -53,6 +53,13 @@ define method ^subtype? (t1 :: <&type>, t2 :: <&singleton>)
   #f
 end method ^subtype?;
 
+// Tiebreaker
+
+define method ^subtype? (t1 :: <&limited-collection-type>, t2 :: <&singleton>)
+ => (subtype? :: <boolean>)
+  #f
+end method ^subtype?;
+
 //// Disjointness relationships.
 
 define method ^known-disjoint? 

--- a/sources/dylan/singleton.dylan
+++ b/sources/dylan/singleton.dylan
@@ -102,6 +102,12 @@ define method subtype? (t :: <type>, s :: <singleton>)
   #f
 end method subtype?;
 
+// Tiebreaker
+
+define method subtype? (t :: <limited-collection-type>, s :: <singleton>)
+ => (subtype? :: <boolean>)
+  #f
+end method subtype?;
 
 define method subjunctive-subtype? (s1 :: <singleton>, s2 :: <singleton>,
                                     scu :: <subjunctive-class-universe>)
@@ -122,6 +128,12 @@ end method subjunctive-subtype?;
 
 
 define method subjunctive-subtype? (t :: <type>, s :: <singleton>,
+                                    scu :: <subjunctive-class-universe>)
+ => (subtype? :: <boolean>)
+  #f
+end method subjunctive-subtype?;
+
+define method subjunctive-subtype? (t :: <limited-collection-type>, s :: <singleton>,
                                     scu :: <subjunctive-class-universe>)
  => (subtype? :: <boolean>)
   #f


### PR DESCRIPTION
Given that <type> can not be a subtype of <singleton> and the only
thing defined as a possible subtype of a singleton is another
identical singleton, it makes sense to have this also result
in a result of `#f`.

This fixes this runtime warning:

```
  Warning: Method specificity of unorderable methods
      {<pair>:
        {<simple-method>: ??? (<&type>, <&singleton>)},
        {<simple-method>: ??? (<&limited-collection-type>, <&type>)}}
  applying
      {<sealed-generic-function>: ^subtype?}
  to
      {<simple-object-vector>: {<&limited-sequence-type>}, {<&singleton>}}
  was determined with arbitrary and capricious rules.
```
