### PR TITLE
[dfmc-modeling] Fix ^known-disjoint? crash with singletons and unions.

### DIFF
--- a/sources/dfmc/modeling/singletons.dylan
+++ b/sources/dfmc/modeling/singletons.dylan
@@ -85,10 +85,10 @@ end method ^known-disjoint?;
 
 define method ^known-disjoint? (t1 :: <&singleton>, t2 :: <&union>)
  => (known-disjoint? :: <boolean>)
-  ^known-disjoint?(t1.^singleton-object, t2)
+  ^known-disjoint?(t1, t2.^union-type1) & ^known-disjoint?(t1, t2.^union-type2)
 end method ^known-disjoint?;
 
 define method ^known-disjoint? (t1 :: <&union>, t2 :: <&singleton>)
  => (known-disjoint? :: <boolean>)
-  ^known-disjoint?(t1, t2.^singleton-object)
+  ^known-disjoint?(t1.^union-type1, t2) & ^known-disjoint?(t1.^union-type2, t2)
 end method ^known-disjoint?;


### PR DESCRIPTION
We can't check ^known-disjoint? with the value of a singleton as this
may not be a type and ^known-disjoint? is defined on <type> and not
<object>.

This corrects an error made in commit 64c58256781aa34e1bdbe7c39ab9bdcf09148f28.
