### PR TITLE
Remove references to the access() mechanism from the emulator.

### DIFF
--- a/sources/dfmc/flow-graph/closure.dylan
+++ b/sources/dfmc/flow-graph/closure.dylan
@@ -13,7 +13,6 @@ define method analyze-environments
     (f :: <&lambda>) => (changed? :: <boolean>);
   compute-closure(f.environment);
   // convert-closure(f.environment);
-  // access(dfmc-back-end, print-method-out)(f);
   for (entry in f.environment.entries)
     analyze-block(f.environment, entry);
   end for;

--- a/sources/dfmc/management/interactive-driver.dylan
+++ b/sources/dfmc/management/interactive-driver.dylan
@@ -28,32 +28,6 @@ define method note-definitions-updated (layer :: <interactive-layer>) => ()
   // Interactive compilation doesn't invalidate databases.
 end method;
 
-/*
-in: dfmc-debug;
-
-define function itest-sr (text, #key module = "internal")
- make(access(projects-implementation,<string-template-source-record>),
-      contents: as(<byte-vector>,text),
-      module: as(<symbol>, module),
-      name: "Test");
-end function;
-
-define function itest (text, #key module = "internal",
-		                  library = "dylan",
-		                  target = list("New target"))
-  execute-source
-    (lookup-interactive-context(target, lookup-library-description(library)),
-     #"no-context",
-     list(itest-sr(text, module: module)));
-end function;
-
-define function htest (text, #key module = "functional-extensions-internals",
-		                  library = "functional-extensions",
-		                  target = list("New target"))
-  itest(text, module: module, library: library, target: target)
-end function;
-*/
-
 define function ensure-layer-compiled (layer :: <interactive-layer>, flags, #key heap? = #t)
   ensure-library-models-computed(layer);
   // ensure-library-models-finished(layer);

--- a/sources/dfmc/namespace/interactive-namespace.dylan
+++ b/sources/dfmc/namespace/interactive-namespace.dylan
@@ -599,7 +599,7 @@ end function;
 
 
 define method shadow-model-properties (p :: <model-properties>)
-//  DEBUG-ASSERT(object-class(p) == access(dfmc-common,<mapped-model-properties>));
+  // p should actually be <mapped-model-properties> (or was at one point in history)
   shadow-properties(p)
 end method;
 

--- a/sources/dfmc/typist/typist-algebra.dylan
+++ b/sources/dfmc/typist/typist-algebra.dylan
@@ -503,7 +503,6 @@ define function show-union-stats (#key data = *type-estimate-union-args*) => ()
     add!(arg-types, object-class(arg1));
     add!(arg-types, object-class(arg2));
     // *** Arrgh.  So we can call with-testing-context, so we can do algebra.
-    let do-with-testing-context = access(dfmc-testing, do-with-testing-context);
     with-testing-context (#f)
       case
         type-estimate-subtype?(arg1, arg2) => left-subtype  := left-subtype  + 1;

--- a/sources/dfmc/typist/typist-types.dylan
+++ b/sources/dfmc/typist/typist-types.dylan
@@ -513,7 +513,6 @@ define variable *limited-instances* = #();
 // *** Performance analysis code.
 define function show-singleton-stats(#key data = *limited-instances*) => ()
   // Investigate the singletons.
-  let do-with-testing-context = access(dfmc-testing, do-with-testing-context);
   with-testing-context (#f)
     let n-classes = 0;
     let n-strings = 0;

--- a/sources/project-manager/user-projects/README.txt
+++ b/sources/project-manager/user-projects/README.txt
@@ -1,12 +1,6 @@
 User-project library
 --------------------
 
-Developers: to continue using the old setup:
-
-access(projects-implementation, *default-project-class*) := <registry-project>;
-
-Otherwise the setup is as follows:
-
 All registry projects are system projects and will not be recompiled
 (usually ;-).
 


### PR DESCRIPTION
This allowed code to access things defined in other libraries
when using the emulator (I think).
