### PR TITLE
[c-run-time] MMAllocMisc/MMAllocFree to use unsigned long to match generated code

### DIFF
--- a/sources/lib/run-time/run-time.h
+++ b/sources/lib/run-time/run-time.h
@@ -1173,8 +1173,8 @@ extern void primitive_replaceX
  * be freed explicitly.
  */
 
-extern void *MMAllocMisc(size_t size);
-extern void MMFreeMisc(void *p, size_t size);
+extern void *MMAllocMisc(unsigned long size);
+extern void MMFreeMisc(void *p, unsigned long size);
 extern void *dylan__malloc__misc(size_t size);
 extern void *dylan__malloc__ambig(size_t size);
 extern void *mps__malloc(size_t size);


### PR DESCRIPTION
This fixes a build error when cross-compiling for ARM.

Conflicts:
    sources/lib/run-time/run-time.h
