### PR TITLE
[common-dylan] Print function signatures rather than specializers.

### DIFF
--- a/documentation/release-notes/source/2014.1.rst
+++ b/documentation/release-notes/source/2014.1.rst
@@ -128,6 +128,10 @@ Common Dylan
   a symlink to a Dylan executable will function correctly as it
   already did on Linux and FreeBSD.
 
+* The routine used for printing function signatures when displaying
+  an error / condition now shows a more accurate signature rather
+  than only the function specializers.
+
 
 Debugging
 =========

--- a/sources/common-dylan/format.dylan
+++ b/sources/common-dylan/format.dylan
@@ -715,10 +715,35 @@ define function print-method
   print-string(buffer, ": ");
   print-string(buffer, primitive-name(object));
   let specializers = function-specializers(object);
+  let (_, rest, keywords) = function-arguments(object);
   print-string(buffer, " (");
-  unless (empty?(specializers))
-    print-elements(buffer, specializers, print-function: print-specializer)
-  end;
+  unless (empty?(specializers) & ~rest & empty?(keywords))
+    print-elements(buffer, specializers, print-function: print-specializer);
+    if (rest)
+      if (~empty?(specializers))
+        print-string(buffer, ", ");
+      end if;
+      print-string(buffer, "#rest");
+    end if;
+    if (keywords)
+      if (rest | ~empty?(specializers))
+        print-string(buffer, ", ");
+      end if;
+      print-elements(buffer, keywords, print-function: print-keyword);
+    end if;
+  end unless;
+  print-string(buffer, ") => (");
+  let (value-types, values-rest) = function-return-values(object);
+  unless (empty?(value-types))
+    print-elements(buffer, value-types, print-function: print-specializer);
+    if (values-rest)
+      print-string(buffer, ", ");
+    end if;
+  end unless;
+  if (values-rest)
+    print-string(buffer, "#rest ");
+    print-specializer(buffer, values-rest);
+  end if;
   print-string(buffer, ")}");
 end function print-method;
 
@@ -745,3 +770,8 @@ define method print-specializer
   print-pretty-name(buffer, subclass-class(type));
   print-string(buffer, ")")
 end method print-specializer;
+
+define function print-keyword
+    (buffer :: <string-buffer>, object :: <symbol>) => ()
+  print-format(buffer, "%s:", as-lowercase(as(<string>, object)));
+end function print-keyword;


### PR DESCRIPTION
This is useful when looking at errors / conditions when they're
displayed.
