### PR TITLE
[dfmc] Fix outputting to the profile area.

### DIFF
--- a/sources/dfmc/namespace/library-description.dylan
+++ b/sources/dfmc/namespace/library-description.dylan
@@ -991,7 +991,7 @@ define method profile-area-output-locator (ld :: <library-description>,
   when (directory)
     ensure-directories-exist(directory);
   end;
-  let directory = directory & as(<directory-locator>, directory);
+  let directory = directory & locator-directory(directory);
   if (name)
     make(<file-locator>, directory: directory, name: name)
   elseif (base)


### PR DESCRIPTION
When outputting to the profile area, the profile location is a locator,
and we want to look at the locator's directory rather than try
to convert it to a directory as if it were a string.
