### PR TITLE
[conversion] Fix warning by minor code restructuring.

### DIFF
--- a/sources/dfmc/conversion/convert.dylan
+++ b/sources/dfmc/conversion/convert.dylan
@@ -2042,6 +2042,7 @@ define method ^make-signature-argument-reference
   let arg = ^make-signature-argument(sig-t, argument-index);
   if (vector-index)
     ^vector-element-reference(arg, vector-index)
+      | error("argument reference %d beyond limit", vector-index)
   else
     arg
   end if


### PR DESCRIPTION
We know that the old version of this code is safe, but the compiler
can't know that for sure. This restructuring makes it safe in
the ideas of the compiler and the programmer.
