### PR TITLE
[configure] Check more directories for libgc.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -209,8 +209,7 @@ if test "$cross_compiling" != "yes"; then
                                              GC_LIBRARY="${with_gc_path}/lib/${GC_LIB_NAME}"
                                            ],
                                            [])
-                          ])
-                    AS_IF([test x${GC_LIBRARY} = x],
+                          ],
                           [
                             LIB_DIRECTORIES="/usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64 /usr/lib/${MULTIARCH}"
                             for lib_directory in ${LIB_DIRECTORIES};
@@ -235,7 +234,7 @@ fi
 
 AS_IF([test x${GC_CHOICE}x${GC_USE_STATIC_BOEHM}x${GC_LIBRARY} = xboehmxtruex],
       [
-        AC_MSG_ERROR([Could not find ${GC_LIB_NAME}. Please specify the path to the Boehm GC installation via --with-gc-path])
+        AC_MSG_ERROR([Could not find ${GC_LIB_NAME}. Please specify the path to the Boehm GC installation via --with-gc-path, or omit --with-gc-path to search the default directories.])
       ])
 AS_IF([test x${GC_CHOICE} = x],
       [


### PR DESCRIPTION
Use a list and a for loop to find the gc library file. We now
also check in /usr/lib64 and /usr/local/lib64 by default.

If there are 32 bit systems that also have a lib64, there might
be issues with this if there is a /usr/lib64/libgc.\* but we wanted
to find /usr/local/lib/libgc.\* instead. I'm not sure that this
would be an issue in actual practice.

Fixes #833.
