### PR TITLE
[io] Specialize stream-lock on <stream>.

### DIFF
--- a/sources/io/streams/stream.dylan
+++ b/sources/io/streams/stream.dylan
@@ -128,10 +128,10 @@ define inline function read-write?
 end function;
 
 define open generic stream-lock
-    (stream :: <basic-stream>) => (lock :: false-or(<lock>));
+    (stream :: <stream>) => (lock :: false-or(<lock>));
 
-define sealed generic stream-lock-setter
-    (value, the-stream :: <basic-stream>) => (result :: false-or(<lock>));
+define generic stream-lock-setter
+    (value, the-stream :: <stream>) => (result :: false-or(<lock>));
 
 define method stream-lock
     (the-stream :: <basic-stream>) => (result :: false-or(<lock>))


### PR DESCRIPTION
Previously, stream-lock was specialized on `<basic-stream>` which is
where the lock is actually defined in the code. However, lock-stream
and unlock-stream are specialized on `<stream>` and the default
implementation calls stream-lock (which isn't available for all
`<stream>` instances).

This also makes the test for this pass in the io-test-suite.
