### PR TITLE
[deuce] Fix out-of-bounds dline access.

### DIFF
--- a/sources/deuce/display.dylan
+++ b/sources/deuce/display.dylan
@@ -991,7 +991,7 @@ define sealed method update-display-lines
               // then the line we just computed will only be partially displayed.
               // In that case, we don't display it at all unless it would be
               // the only line on the screen.
-              if (line-y > max-y)
+              if (line-y >= max-y)
                 when ($display-partial-lines? | zero?(n-lines))
                   inc!(n-lines)
                 end;


### PR DESCRIPTION
This could get into a situation where, for example, max-y would be
99, line-y would be continually iterating and increasing and line-height
would be 1, since this was happening in terminal mode.

This is clearly an error in the code as this would happen when resizing:

```
  let new-size :: <integer>
    = min(max-y, floor(max(ceiling/(max-y, 10), n-slots * 1.5)));
  let new-lines :: <simple-object-vector>
    = make(<simple-object-vector>, size: new-size);
```

and then after new-lines is moved to be lines:

```
  dline := lines[n-lines];
```

So, n-lines needs to be less than max-y and not potentially equal
to it. When line-height is 1, n-lines and line-y are growing at
the same rate and it is more clear that line-y must also remain
less than (and not less than or equal to) max-y.
