### PR TITLE
Handle directories in working-directory-setter

### DIFF
--- a/sources/system/file-system/file-system.dylan
+++ b/sources/system/file-system/file-system.dylan
@@ -446,7 +446,7 @@ end function working-directory;
 define generic working-directory-setter (new-working-directory :: <pathname>)
  => (new-working-directory :: <pathname>);
 
-define method working-directory-setter (new-working-directory :: <file-system-locator>)
+define method working-directory-setter (new-working-directory :: <file-system-directory-locator>)
  => (new-working-directory :: <pathname>)
   %working-directory-setter(new-working-directory)
 end method working-directory-setter;
@@ -458,7 +458,7 @@ end method working-directory-setter;
 
 define method working-directory-setter (new-working-directory :: <string>)
  => (new-working-directory :: <pathname>)
-  working-directory-setter(as(<file-system-directory-locator>, new-working-directory))
+  working-directory-setter(as(<file-system-locator>, new-working-directory))
 end method working-directory-setter;
 
 


### PR DESCRIPTION
This fixes a bug that was causing an error when trying to set the
working directory with a `<string>` type.

To reproduce, try to set the working directory (using
`working-directory() := ...` also presents the same error)

```
working-directory-setter("/Users/dan/repos/");
```

And the error was

```
No applicable method, applying {<incremental-generic-function>: string-as-locator} to {<simple-object-vector>: {<class>: <file-system-directory-locator>}, "/Users/dan/repos/"}.
No applicable method, applying {function  0x44a76c} to #[{class
<file-system-directory-locator> 0x44ddc0}, "/Users/dan/repos/"].
```

The change edits the types in the generic `working-directory-setter` so
that the `file-system-locator` impl handles
`file-system-directory-locator` instead and the `string` impl creates a
`file-system-locator` (instead of `file-system-directory-locator`) from
the string.

The changes mirror the format used in the other directory
functions (`directory-empty?` for example).