### PR TITLE
[c-ffi,dfmc-back-end] Fix nested structs by value.

### DIFF
--- a/sources/dfmc/back-end/heaps.dylan
+++ b/sources/dfmc/back-end/heaps.dylan
@@ -2139,13 +2139,13 @@ end method;
 
 define method maybe-claim-heap-element-references-internal
     (heap :: <model-heap>, element :: <&raw-aggregate-type>, ct?) => ()
-  do-record-external-heap-element-reference(heap, element, ct?);
   // only trace any raw aggregate types embedded in this one.
   for (member in element.raw-aggregate-members)
     if (instance?(member.member-raw-type, <&raw-aggregate-type>))
       maybe-claim-heap-element-references(heap, member.member-raw-type, ct?);
     end;
   end;
+  do-record-external-heap-element-reference(heap, element, ct?);
 end;
 
 define method maybe-claim-heap-element

--- a/sources/lib/c-ffi/test/main.c
+++ b/sources/lib/c-ffi/test/main.c
@@ -358,3 +358,14 @@ long OMGW_width(OLEMENUGROUPWIDTHS strct, int index)
 {
   return(strct.width[index]);
 }
+
+struct NVGcolor {
+  struct {
+    float r,g,b,a;
+  };
+};
+typedef struct NVGcolor NVGcolor;
+
+void process_nvg_color(NVGcolor color)
+{
+}

--- a/sources/lib/c-ffi/test/tests.dylan
+++ b/sources/lib/c-ffi/test/tests.dylan
@@ -1208,6 +1208,37 @@ define test struct-by-value ()
   end;
 end;
 
+// test for nested structs by value. This is extracted from
+// a bug found while writing bindings for nanovg.
+define C-struct <color-components>
+  slot color-components$r :: <C-float>;
+  slot color-components$g :: <C-float>;
+  slot color-components$b :: <C-float>;
+  slot color-components$a :: <C-float>;
+end;
+
+define C-struct <NVGcolor>
+  slot NVGcolor$_anon-field :: <color-components>;
+  pointer-type-name: <NVGcolor*>;
+end;
+
+ignore(NVGcolor$_anon-field, NVGcolor$_anon-field-setter);
+ignore(color-components$r, color-components$r-setter);
+ignore(color-components$g, color-components$g-setter);
+ignore(color-components$b, color-components$b-setter);
+ignore(color-components$a, color-components$a-setter);
+
+define c-function process-nvg-color
+  parameter color :: <NVGColor>;
+  c-name: "process_nvg_color";
+end;
+
+define test nested-structs-by-value ()
+  // All we care about is being able to actually compile this
+  let c = make(<NVGColor*>);
+  process-nvg-color(c);
+end;
+
 
 // --------------
 // top level test suite.
@@ -1232,7 +1263,8 @@ define suite c-ffi-suite ()
   test c-dylan-object-test;
   test bug-393;
   test bug-414;
-  test struct-by-value
+  test struct-by-value;
+  test nested-structs-by-value;
 end suite c-ffi-suite;
 
 /// The dylan top level for the tests


### PR DESCRIPTION
In maybe-claim-heap-element-references-internal, when processing
a raw aggregate type (used for values whose type is a C struct
or union and not a pointer to a struct/union), process the member
types first, if necessary, then the type itself.

This ensures that they're in the heap-referenced-objects list
in the correct order and then emitted in C in the correct order
in emit-typedefs in the C backend.  Without doing this, the C
output will be incorrect and compilation will fail.