### PR TITLE
Add warnings for issues with sealing domains

### DIFF
--- a/documentation/release-notes/source/2015.1.rst
+++ b/documentation/release-notes/source/2015.1.rst
@@ -19,6 +19,25 @@ C-FFI
   using this construct would result in a compilation error in the generated
   C code.
 
+Compiler
+========
+
+* The compiler emits warnings for issues with ``define sealed domain``:
+
+  * Incorrect number of type specializers provided. The number of type
+    specializers must match the number of required parameters for the
+    generic function.
+  * Type specializers are not subtypes of the corresponding required
+    argument of the generic function.
+
+    For example, this is useful for catching an incorrect sealing of
+    ``make``:
+
+    .. code-block:: dylan
+
+       define sealed domain make (<my-class>); // Wrong
+       define sealed domain make (singleton(<my-class>)); // Correct
+
 system
 ======
 

--- a/documentation/release-notes/source/2015.1.rst
+++ b/documentation/release-notes/source/2015.1.rst
@@ -38,6 +38,9 @@ Compiler
        define sealed domain make (<my-class>); // Wrong
        define sealed domain make (singleton(<my-class>)); // Correct
 
+  * Previously, ``define domain`` was accepted without warning. This is
+    not valid Dylan syntax as it should be ``define sealed domain``.
+
 system
 ======
 

--- a/sources/dfmc/conversion/define-domain-mop.dylan
+++ b/sources/dfmc/conversion/define-domain-mop.dylan
@@ -16,6 +16,15 @@ define program-warning <domain-visible-to-sibling-libraries>
     variable-name;
 end program-warning;
 
+define serious-program-warning <domain-types-not-valid>
+  slot condition-variable-name,
+    init-keyword: variable-name:;
+  slot condition-problem,
+    required-init-keyword: problem:;
+  format-string "Domain types for %= are not valid - %s.";
+  format-arguments variable-name, problem;
+end serious-program-warning;
+
 define method check-model (d :: <&domain>) => ()
   let gf = ^domain-generic-function(d);
   // Leakage check.
@@ -28,6 +37,15 @@ define method check-model (d :: <&domain>) => ()
          source-location: model-source-location(d),
          variable-name:   model-variable-name(d));
   end;
+  if (gf)
+    let (ok?, problem) = ^domain-types-match-generic?(d, gf);
+    if (~ok?)
+      note(<domain-types-not-valid>,
+           source-location: model-source-location(d),
+           variable-name:   model-variable-name(d),
+           problem:         problem);
+    end if;
+  end if;
 end method;
 
 define function ^domain-sideways? 
@@ -40,3 +58,27 @@ define function ^domain-generic-function (object :: <&domain>)
   let model = binding & binding-model-object(binding, default: #f);
   model
 end function;
+
+define function ^domain-types-match-generic?
+    (d :: <&domain>, gf :: type-union(<&generic-function>, <&method>))
+ => (ok? :: <boolean>, reason)
+  block (return)
+    let gf-sig = ^function-signature(gf);
+    let gf-required = gf-sig.^signature-required;
+    let domain-types = ^domain-types(d);
+
+    // They have the same number of required arguments.
+    if (gf-sig.^signature-number-required ~= size(domain-types))
+      return(#f, "they don't have the same number of required arguments");
+    end if;
+
+    // Each of the domain's type specializers is a subtype of the
+    // corresponding parameter specializer of the generic function.
+    unless (every?(^subtype?, domain-types, gf-required))
+      return(#f, "some of the method's required parameter specializers "
+                 "aren't subtypes of their counterparts in the generic");
+    end unless;
+
+    values(#t, "valid")
+  end block;
+end;

--- a/sources/dfmc/definitions/define-domain.dylan
+++ b/sources/dfmc/definitions/define-domain.dylan
@@ -41,9 +41,21 @@ define &definition domain-definer
     => do-define-domain(form, mods, name, domain-types);
 end &definition;
 
+define serious-program-warning <domain-missing-sealed-adjective>
+  slot condition-variable,
+    required-init-keyword: variable:;
+  format-string "This domain on %s is missing the 'sealed' adjective.";
+  format-arguments variable;
+end serious-program-warning;
+
 define function do-define-domain
     (form, mods, name, domain-types) => (forms)
   let (options, adjectives) = parse-domain-adjectives(name, mods);
+  if (~member?(#"sealed", adjectives))
+    note(<domain-missing-sealed-adjective>,
+         source-location: fragment-source-location(form),
+         variable: name);
+  end if;
   let domain-types = parse-domain-types(domain-types);
   let tlf 
     = apply(make, <domain-definition>, 
@@ -88,7 +100,8 @@ end property;
 define constant domain-adjectives
   = list(<domain-sealed-property>, <domain-sideways-property>);
 
-define function parse-domain-adjectives (name, adjectives-form) => (initargs)
+define function parse-domain-adjectives (name, adjectives-form)
+ => (initargs, adjectives)
   parse-property-adjectives
     (domain-adjectives, adjectives-form, name)
 end function;

--- a/sources/dylan/list.dylan
+++ b/sources/dylan/list.dylan
@@ -895,9 +895,9 @@ end method reduce;
 
 // Seal everything else.
 
-define domain fill! (<list>, <object>);
-define domain sort! (<list>);
-define domain sort  (<list>);
+define sealed domain fill! (<list>, <object>);
+define sealed domain sort! (<list>);
+define sealed domain sort  (<list>);
 
 
 // HACK: some copy-downs (if only copy downs worked for keyword methods

--- a/sources/dylan/list.dylan
+++ b/sources/dylan/list.dylan
@@ -895,7 +895,7 @@ end method reduce;
 
 // Seal everything else.
 
-define domain fill! (<list>);
+define domain fill! (<list>, <object>);
 define domain sort! (<list>);
 define domain sort  (<list>);
 

--- a/sources/dylan/vector.dylan
+++ b/sources/dylan/vector.dylan
@@ -658,7 +658,7 @@ define macro limited-vector-shared-definer
          define sealed domain add-new ("<simple-" ## ?name ## "-vector>", <object>);
          define sealed domain add-new! ("<simple-" ## ?name ## "-vector>", <object>);
          define sealed domain member? (<object>, "<simple-" ## ?name ## "-vector>");
-         define sealed domain fill! ("<simple-" ## ?name ## "-vector>");
+         define sealed domain fill! ("<simple-" ## ?name ## "-vector>", <object>);
          define sealed domain remove ("<simple-" ## ?name ## "-vector>", <object>);
          define sealed domain remove! ("<simple-" ## ?name ## "-vector>", <object>);
          define sealed domain sort ("<simple-" ## ?name ## "-vector>");


### PR DESCRIPTION
This also includes fixes for most of the issues turned up by these new warnings. One warning that remains and is not yet fixed is:

````
.../sources/io/streams/native-speed.dylan:76-77: Serious warning - Domain types
    for do-next-output-buffer are not valid - "some of the method's required
    parameter specializers aren't subtypes of their counterparts in the generic".
````
