### PR TITLE
[interface-reference] Remove HTML & Text reports.

### DIFF
--- a/sources/environment/reports/html-streams.dylan
+++ b/sources/environment/reports/html-streams.dylan
@@ -151,19 +151,6 @@ define method invoke-with-html-output
 
 end method;
 
-define macro with-html-rubric
-  { with-html-rubric (?streamn:name = ?streamv:expression, ?title:expression)
-      ?body:body
-    end }
- => { invoke-with-html-rubric (?streamv, ?title, method (?streamn) ?body end method)
-       }
-  { with-html-rubric (?stream:name, ?title:expression)
-      ?body:body
-    end }
- => { invoke-with-html-rubic (?stream, ?title, method (?stream) ?body end method)
-       }
-end macro with-html-rubric;
-
 define method invoke-with-html-rubric 
     (stream :: <stream>, title :: <string>, body :: <function>)
  => ()

--- a/sources/environment/reports/library-report.dylan
+++ b/sources/environment/reports/library-report.dylan
@@ -42,7 +42,7 @@ end class <library-report>;
 
 install-report(#"interface-reference", "Library interface reference",
                <library-report>,
-               formats: #[#"text", #"html", #"rst", #"xml"],
+               formats: #[#"rst", #"xml"],
                multi-file?: #t);
 
 define class <module-report> (<namespace-report>)
@@ -74,8 +74,8 @@ end method create-multi-file-report-as;
 define method write-library-report
     (stream :: <stream>, report :: <library-report>)
  => ()
-  if (report.report-multi-file? & (report.report-format ~= #"html"))
-    error(make(<report-error>)) // ---*** we only support multi-file reports for HTML at the moment
+  if (report.report-multi-file?)
+    error(make(<report-error>)) // ---*** We don't support multi-file reports currently.
   end if;
   let library = report.report-project.project-library;
   let stream
@@ -245,12 +245,7 @@ define method write-definition-body
         let stream
           = make(stream-class-for-report(report.report-format),
                  inner-stream: stream);
-        with-html-rubric (istream = stream.inner-stream, // ---*** push this down into HTML method
-                          format-to-string("%s %s",
-                                           definition-name(subreport, module),
-                                           definition-kind(module)))
-          write-definition-report(stream, subreport, module)
-        end with-html-rubric;
+        write-definition-report(stream, subreport, module)
       end with-open-file;
     else
       write-definition-report(stream, subreport, module)
@@ -271,14 +266,9 @@ define method write-definition-body
         let filename = report-object-filename(report, definition);
         with-open-file (stream = filename, direction: #"output")
           let stream
-          = make(stream-class-for-report(report.report-format),
-                 inner-stream: stream);
-          with-html-rubric (istream = stream.inner-stream, // ---*** push this down into HTML method
-                            format-to-string("%s %s",
-                                             definition-name(report, definition),
-                                             definition-kind(definition)))
-            write-definition-report(stream, report, definition)
-          end with-html-rubric;
+            = make(stream-class-for-report(report.report-format),
+                   inner-stream: stream);
+          write-definition-report(stream, report, definition)
         end with-open-file;
       else
         write-definition-report(stream, report, definition);
@@ -553,98 +543,6 @@ define method write-function-parameters-footer
 end method write-function-parameters-footer;
 
 
-/// <TEXT-REPORT-STREAM> methods
-
-define class <text-report-stream> (<report-stream>)
-end class <text-report-stream>;
-
-define method stream-class-for-report
-    (_format == #"text") => (class :: subclass(<report-stream>))
-  <text-report-stream>
-end method stream-class-for-report;
-
-define method write-definition-separator
-    (stream :: <text-report-stream>, report :: <namespace-report>,
-     definition :: <definition-object>)
- => ()
-  format(stream, "%s\n", $report-separator);
-end method write-definition-separator;
-
-define method write-definition-name
-    (stream :: <text-report-stream>, report :: <namespace-report>, namespace :: <namespace-object>)
- => ()
-  format(stream, "%s %s\n\n",
-         definition-kind(namespace),
-         environment-object-primitive-name(report.report-project, namespace));
-end method write-definition-name;
-
-define method write-definition-name
-    (stream :: <text-report-stream>, report :: <module-report>, definition :: <definition-object>)
- => ()
-  let project = report.report-project;
-  let title = definition-name(report, definition);
-  let type = definition-type-description(project, definition);
-  let padding = max(6, $report-width - title.size - type.size);
-  format(stream, "%s%s%s\n",
-         title,
-         make(<byte-string>, fill: ' ', size: padding),
-         type)
-end method write-definition-name;
-
-define method write-superclasses-header
-    (stream :: <text-report-stream>, report :: <module-report>,
-     class :: <class-object>)
- => ()
-  format(stream, "\nSuperclasses:\n\n");
-end method write-superclasses-header;
-
-define method write-superclass
-    (stream :: <text-report-stream>, report :: <module-report>,
-     superclass :: <definition-object>,
-     #key last? :: <boolean> = #f, first? :: <boolean> = #f)
- => ()
-  format(stream, "%s\n", definition-name(report, superclass))
-end method write-superclass;
-
-define method write-init-keywords-header
-    (stream :: <text-report-stream>, report :: <module-report>,
-     class :: <class-object>)
- => ()
-  format(stream, "\nInit-keywords:\n\n");
-end method write-init-keywords-header;
-
-define method write-init-keyword
-    (stream :: <text-report-stream>, report :: <module-report>,
-     keyword :: <symbol>, type :: false-or(<environment-object>))
- => ()
-  format(stream, "  %s:\n", as(<string>, keyword))
-end method write-init-keyword;
-
-define method write-function-name
-    (stream :: <text-report-stream>, report :: <module-report>,
-     function :: <function-object>)
- => ()
-  format(stream, "\n%s ",
-         definition-name(report, function));
-end method write-function-name;
-
-define method write-function-parameter
-    (stream :: <text-report-stream>, report :: <module-report>,
-     parameter :: <parameter>, #key kind :: <argument-kind> = #"input")
- => ()
-  let project = report.report-project;
-  let module = report.report-namespace;
-  let type = parameter.parameter-type;
-  format(stream, "%s :: %s",
-             if (instance?(parameter, <optional-parameter>))
-               parameter.parameter-keyword
-             end
-               | parameter.parameter-name,
-         definition-name(report, type));
-  new-line(stream);
-end method write-function-parameter;
-
-
 /// <RST-REPORT-STREAM> methods
 
 define class <rst-report-stream> (<report-stream>)
@@ -852,196 +750,6 @@ define method write-function-parameter
          definition-name(report, type));
   new-line(stream);
 end method write-function-parameter;
-
-
-/// HTML implementation
-
-/// ----------------------------------------------------------------------
-/// HTML
-
-define class <html-report-stream> (<report-stream>)
-end class <html-report-stream>;
-
-define method initialize (stream :: <html-report-stream>, #key inner-stream)
-  next-method();
-  stream.inner-stream := ensure-html-stream(inner-stream);
-
-end method initialize;
-
-define method ensure-html-stream (stream :: <stream>)
- => (html-stream :: <html-wrapper-stream>)
-  make(<html-wrapper-stream>, inner-stream: stream)
-end method ensure-html-stream;
-
-define method ensure-html-stream (stream :: <html-wrapper-stream>)
- => (html-stream :: <html-wrapper-stream>)
-  stream
-end method ensure-html-stream;
-
-define method write-html (stream :: <html-report-stream>, #rest sequence)
- => ()
-  apply(write-html, stream.inner-stream, sequence)
-end method write-html;
-
-define method stream-class-for-report
-    (_format == #"html") => (class :: subclass(<report-stream>))
-  <html-report-stream>
-end method stream-class-for-report;
-
-define method write-definition-separator
-    (stream :: <html-report-stream>, report :: <namespace-report>,
-     definition :: <definition-object>)
- => ()
-  write-html(stream, #"hr", '\n');
-end method write-definition-separator;
-
-define method write-definition-name
-    (stream :: <html-report-stream>, report :: <namespace-report>,
-     definition :: <definition-object>)
- => ()
-  let title = definition-name(report, definition);
-  write-html(stream,
-             #"h3", make(<html-anchor>, name: title),
-             title, #"/h3", '\n');
-end method write-definition-name;
-
-
-/// HTML section generation
-
-define method write-superclasses-header
-    (stream :: <html-report-stream>, report :: <module-report>,
-     class :: <class-object>)
- => ()
-  write-html(stream, #"p", "Superclasses: ");
-end method write-superclasses-header;
-
-define method write-superclass
-    (stream :: <html-report-stream>, report :: <module-report>,
-     superclass :: <definition-object>,
-     #key last? :: <boolean> = #f, first? :: <boolean> = #f)
- => ()
-  write-object-reference(stream, report, superclass)
-end method write-superclass;
-
-define method write-superclasses-footer
-    (stream :: <html-report-stream>, report :: <module-report>,
-     superclass :: <class-object>)
- => ()
-  new-line(stream)
-end method write-superclasses-footer;
-
-define method write-init-keywords-header
-    (stream :: <html-report-stream>, report :: <module-report>,
-     class :: <class-object>)
- => ()
-  write-html(stream, #"p", "Init-keywords:", '\n', '\n');
-  write-html(stream, #"ul", '\n');
-end method write-init-keywords-header;
-
-define method write-init-keyword
-    (stream :: <html-report-stream>, report :: <module-report>,
-     keyword :: <symbol>, type :: false-or(<environment-object>))
- => ()
-  write-html(stream, #"li", as(<string>, keyword), ':');
-  new-line(stream);
-end method write-init-keyword;
-
-define method write-init-keywords-footer
-    (stream :: <html-report-stream>, report :: <module-report>,
-     class :: <class-object>)
- => ()
-  write-html(stream, #"/ul", '\n');
-  new-line(stream)
-end method write-init-keywords-footer;
-
-define method write-function-name
-    (stream :: <html-report-stream>, report :: <module-report>,
-     function :: <function-object>)
- => ()
-  format(stream, "%s ",
-         definition-name(report, function));
-end method write-function-name;
-
-define method write-function-parameter
-    (stream :: <html-report-stream>, report :: <module-report>,
-     parameter :: <parameter>, #key kind :: <argument-kind> = #"input")
- => ()
-  let project = report.report-project;
-  let module = report.report-namespace;
-  let type = parameter.parameter-type;
-  write-html(stream, #"li",
-             if (instance?(parameter, <optional-parameter>))
-               parameter.parameter-keyword
-             end
-               | parameter.parameter-name,
-             " :: ");
-  print-environment-object-name
-    (stream, project, type, namespace: module);
-  write-html(stream, #"/li", '\n')
-end method write-function-parameter;
-
-define method write-function-parameters-header
-    (stream :: <html-report-stream>, report :: <module-report>,
-     function :: <function-object>, #key kind :: <argument-kind> = #"input")
- => ()
-  write-html(stream, #"ul", '\n');
-end method write-function-parameters-header;
-
-define method write-function-parameters-footer
-    (stream :: <html-report-stream>, report :: <module-report>,
-     function :: <function-object>, #key kind :: <argument-kind> = #"input")
- => ()
-  write-html(stream, #"/ul", '\n')
-end method write-function-parameters-footer;
-
-define method write-definition-contents
-    (stream :: <html-report-stream>, report :: <library-report>,
-     library :: <library-object>)
- => ()
-  next-method();
-  if (report-multi-file?(report))
-    let project = report.report-project;
-    let library = project.project-library;
-    let library-name = environment-object-primitive-name(project, library);
-    with-html-output (stream = stream.inner-stream, format-to-string("%s Library", library-name))
-      write-html(stream, #"ul", '\n');
-      for (report in report.report-children)
-        let module = report.report-namespace;
-        let filename = report-object-filename(report, module);
-        write-html(stream,
-                   #"li", make(<html-reference>, name: filename),
-                   environment-object-primitive-name(project, module),
-                   " Module", #"/a");
-      end for;
-    end with-html-output;
-  end if;
-end method write-definition-contents;
-
-define method write-definition-contents
-    (stream :: <html-report-stream>, report :: <module-report>,
-     module :: <module-object>)
- => ()
-  if (report-multi-file?(report))
-    let project = report.report-project;
-    let module-name = environment-object-primitive-name(project, module);
-    let filename = report-object-filename(report, module);
-    let names = namespace-sorted-names(project, module);
-    write-html(stream, #"ul", '\n');
-    for (name :: <binding-name-object> in names)
-      let definition = name-value(project, name);
-      if (instance?(definition, <definition-object>))
-        let title = definition-name(report, definition);
-        let filename = report-object-filename(report, definition);
-        write-html(stream,
-                   #"li",
-                   make(<html-reference>, name: format-to-string("%s#%s", filename, title)),
-                   title,
-                   #"/a",
-                   '\n');
-      end if;
-    end for;
-  end if;
-end method write-definition-contents;
 
 
 /// <XML-REPORT-STREAM> methods
@@ -1406,30 +1114,6 @@ define method mangle-for-filename
   as(<string>, chars)
 end method mangle-for-filename;
 
-define method write-object-reference
-    (stream :: <html-report-stream>, report :: <module-report>,
-     object :: <environment-object>)
- => ()
-  let reference = html-object-reference(report, object);
-  write-html(stream,
-             make(<html-reference>, name: reference),
-             definition-name(report, object),
-             #"/a")
-end method write-object-reference;
-
-define method html-object-reference
-    (report :: <module-report>, object :: <environment-object>)
- => ()
-  let parent = report.report-parent;
-  let title = definition-name(report, object);
-  if (parent.report-directory)
-    let filename = report-object-filename(report, object);
-    format-to-string("%s#%s", filename, title)
-  else
-    format-to-string("#%s", title)
-  end
-end method html-object-reference;
-
 define function namespace-sorted-names
     (project :: <project-object>, namespace :: <namespace-object>,
      #key internal?)
@@ -1463,12 +1147,6 @@ define method definition-name
     environment-object-display-name(project, definition, namespace)
   end
 end method definition-name;
-
-define method definition-type-description
-    (project :: <project-object>, class :: <definition-object>)
- => (description :: <string>)
-  definition-kind(class)
-end method definition-type-description;
 
 define method definition-kind (object :: <constant-object>)
  => (kind :: <string>)
@@ -1509,20 +1187,6 @@ define method definition-kind (object :: <module-object>)
  => (description :: <string>)
   "Module"
 end method definition-kind;
-
-define method definition-type-description
-    (project :: <project-object>, function :: <generic-function-object>)
- => (description :: <string>)
-    concatenate(generic-function-modifiers(project, function),
-                definition-kind(function))
-end method definition-type-description;
-
-define method definition-type-description
-    (project :: <project-object>, class :: <class-object>)
- => (description :: <string>)
-    concatenate(class-modifiers(project, class),
-                definition-kind(class))
-end method definition-type-description;
 
 define method class-modifiers
     (project :: <project-object>, class :: <class-object>)


### PR DESCRIPTION
These aren't used or supported. The main use case for this is
exporting ReStructuredText to feed into Sphinx. XML remains
as housel wants it.