### PR TITLE
Use size_t for MMAllocMisc / MMFreeMisc.

### DIFF
--- a/sources/common-dylan/timers.dylan
+++ b/sources/common-dylan/timers.dylan
@@ -50,7 +50,7 @@ define macro with-storage
            ?name := primitive-wrap-machine-word
                       (primitive-cast-pointer-as-raw
                          (%call-c-function ("MMAllocMisc")
-                            (nbytes :: <raw-c-unsigned-long>) => (p :: <raw-c-pointer>)
+                            (nbytes :: <raw-c-size-t>) => (p :: <raw-c-pointer>)
                             (integer-as-raw(?size))
                           end));
            if (primitive-machine-word-equal?
@@ -62,7 +62,7 @@ define macro with-storage
            if (primitive-machine-word-not-equal?
                  (primitive-unwrap-machine-word(?name), integer-as-raw(0)))
              %call-c-function ("MMFreeMisc")
-               (p :: <raw-c-pointer>, nbytes :: <raw-c-unsigned-long>) => (void :: <raw-c-void>)
+               (p :: <raw-c-pointer>, nbytes :: <raw-c-size-t>) => (void :: <raw-c-void>)
                  (primitive-cast-raw-as-pointer(primitive-unwrap-machine-word(?name)),
                   integer-as-raw(?size))
              end;

--- a/sources/lib/run-time/run-time.h
+++ b/sources/lib/run-time/run-time.h
@@ -1186,8 +1186,8 @@ extern void primitive_replaceX
  * be freed explicitly.
  */
 
-extern void *MMAllocMisc(unsigned long size);
-extern void MMFreeMisc(void *p, unsigned long size);
+extern void *MMAllocMisc(size_t size);
+extern void MMFreeMisc(void *p, size_t size);
 extern void *dylan__malloc__misc(size_t size);
 extern void *dylan__malloc__ambig(size_t size);
 extern void *mps__malloc(size_t size);

--- a/sources/system/unix-operating-system.dylan
+++ b/sources/system/unix-operating-system.dylan
@@ -15,7 +15,7 @@ define macro with-storage
            ?name := primitive-wrap-machine-word
                       (primitive-cast-pointer-as-raw
                          (%call-c-function ("MMAllocMisc")
-                            (nbytes :: <raw-c-unsigned-long>) => (p :: <raw-c-pointer>)
+                            (nbytes :: <raw-c-size-t>) => (p :: <raw-c-pointer>)
                             (integer-as-raw(?size))
                           end));
            if (primitive-machine-word-equal?
@@ -27,7 +27,7 @@ define macro with-storage
            if (primitive-machine-word-not-equal?
                  (primitive-unwrap-machine-word(?name), integer-as-raw(0)))
              %call-c-function ("MMFreeMisc")
-               (p :: <raw-c-pointer>, nbytes :: <raw-c-unsigned-long>) => (void :: <raw-c-void>)
+               (p :: <raw-c-pointer>, nbytes :: <raw-c-size-t>) => (void :: <raw-c-void>)
                  (primitive-cast-raw-as-pointer(primitive-unwrap-machine-word(?name)),
                   integer-as-raw(?size))
              end;
@@ -379,7 +379,7 @@ define function run-application
         cleanup
           if (environment)
             %call-c-function ("MMFreeMisc")
-              (p :: <raw-c-pointer>, nbytes :: <raw-c-unsigned-long>) => (void :: <raw-c-void>)
+              (p :: <raw-c-pointer>, nbytes :: <raw-c-size-t>) => (void :: <raw-c-void>)
                 (primitive-cast-raw-as-pointer(primitive-unwrap-machine-word(envp)),
                  integer-as-raw(envp-size))
             end;
@@ -504,7 +504,7 @@ define function make-envp
     = primitive-wrap-machine-word
         (primitive-cast-pointer-as-raw
            (%call-c-function ("MMAllocMisc")
-              (nbytes :: <raw-c-unsigned-long>) => (p :: <raw-c-pointer>)
+              (nbytes :: <raw-c-size-t>) => (p :: <raw-c-pointer>)
               (integer-as-raw(envp-size))
             end));
   for (i :: <integer> from 0, item keyed-by key in temp-table)


### PR DESCRIPTION
run-time.h: Proper declaration using size_t. This makes it match
  the other headers (like mm.h) and the various implementations
  which all already use size_t.

timers.dylan, unix-operating-system.dylan: Use ``<raw-c-size-t>`` rather
  than ``<raw-c-unsigned-long>`` for calling MMAllocMisc and MMFreeMisc.
  This makes the generated C match the declaration from run-time.h.