### PR TITLE
[c-linker] Hide module binding symbols which aren't externally visible.

### DIFF
--- a/sources/dfmc/c-linker/c-link-object.dylan
+++ b/sources/dfmc/c-linker/c-link-object.dylan
@@ -21,7 +21,9 @@ end method;
 
 define method emit-definition
     (back-end :: <c-back-end>, stream :: <stream>, o :: <module-binding>) => ()
-  format-emit*(back-end, stream, "~ %;\n", $dylan-type-string, o);
+  let linkage
+    = if (model-externally-visible?(o)) "" else "static " end;
+  format-emit*(back-end, stream, "~~ %;\n", linkage, $dylan-type-string, o);
 end method;
 
 // CODE


### PR DESCRIPTION
This takes a check that the LLVM linker was doing and does it for
the C linker so that a few symbols can be hidden.

In my bootstrap build, this was the change that resulted from this:

````diff
--- ../Bootstrap.1/build/ppml/ppml.c	2015-02-01 23:13:38.000000000 +0700
+++ ../Bootstrap.2/build/ppml/ppml.c	2015-02-01 23:21:18.000000000 +0700
@@ -1126,23 +1126,23 @@
 dylan_value ppml_stringVppml = &Kppml_stringVppml;
 dylan_value Lppml_quote_stringGVppml = &KLppml_quote_stringGVppml;
 dylan_value Lppml_breakGVppml = &KLppml_breakGVppml;
-dylan_value Dbreak_cacheVppml = &KPunboundVKi;
+static dylan_value Dbreak_cacheVppml = &KPunboundVKi;
 dylan_value ppml_breakVppml = &Kppml_breakVppml;
 dylan_value Dline_breakVppml = &KPunboundVKi;
 dylan_value Lppml_break_typeGVppml = &KLppml_break_typeGVppml;
 dylan_value Lppml_blockGVppml = &KLppml_blockGVppml;
 dylan_value ppml_blockVppml = &Kppml_blockVppml;
-dylan_value Dcomma_ppml_separatorVppml = &KPunboundVKi;
+static dylan_value Dcomma_ppml_separatorVppml = &KPunboundVKi;
 dylan_value Lppml_separator_blockGVppml = &KLppml_separator_blockGVppml;
 dylan_value ppml_separator_blockVppml = &Kppml_separator_blockVppml;
 dylan_value Lppml_suspensionGVppml = &KLppml_suspensionGVppml;
 dylan_value ppml_suspensionVppml = &Kppml_suspensionVppml;
 dylan_value Lppml_browser_aware_objectGVppml = &KLppml_browser_aware_objectGVppml;
 dylan_value ppml_browser_aware_objectVppml = &Kppml_browser_aware_objectVppml;
-dylan_value ppml_sb_templateVppml = &KPunboundVKi;
-dylan_value ppml_rb_templateVppml = &KPunboundVKi;
-dylan_value ppml_table_element_templateVppml = &KPunboundVKi;
-dylan_value Tverbose_condition_outputTVppml = &KPunboundVKi;
+static dylan_value ppml_sb_templateVppml = &KPunboundVKi;
+static dylan_value ppml_rb_templateVppml = &KPunboundVKi;
+static dylan_value ppml_table_element_templateVppml = &KPunboundVKi;
+static dylan_value Tverbose_condition_outputTVppml = &KPunboundVKi;
 dylan_value Lppml_printerGVppml = &KLppml_printerGVppml;

 /* Objects */
````
