### PR TITLE
[dfmc] Remove *retract-dfm?* variable.

### DIFF
--- a/sources/dfmc/back-end/back-end-library.dylan
+++ b/sources/dfmc/back-end/back-end-library.dylan
@@ -107,7 +107,6 @@ define module dfmc-back-end
     heap-stats,
     single-heap-stats,
     diff-heap-stats,
-    *retract-dfm?*,
 
     library-imported-object?,
     library-imported-binding?,

--- a/sources/dfmc/back-end/back-end.dylan
+++ b/sources/dfmc/back-end/back-end.dylan
@@ -5,8 +5,6 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
-define variable *retract-dfm?* = #t;
-
 define compiler-open generic emit-all
     (back-end :: <back-end>, record, #rest flags, #key, #all-keys);
 

--- a/sources/dfmc/c-back-end/c-back-end.dylan
+++ b/sources/dfmc/c-back-end/c-back-end.dylan
@@ -211,13 +211,11 @@ end method;
 // Must retract local methods only after code generation of compilation-record
 
 define method retract-local-methods-in-heap(heap) => ()
-  if (*retract-dfm?*)
-    for (literal in heap.heap-defined-object-sequence)
-      if (instance?(literal, <&iep>) & ~lambda-top-level?(literal))
-        // format-out?("\nRETRACTING %=\n", literal);
-        retract-method-dfm(literal);
-        retract-method-dfm(literal.function);
-      end if;
-    end for;
-  end if;
+  for (literal in heap.heap-defined-object-sequence)
+    if (instance?(literal, <&iep>) & ~lambda-top-level?(literal))
+      // format-out?("\nRETRACTING %=\n", literal);
+      retract-method-dfm(literal);
+      retract-method-dfm(literal.function);
+    end if;
+  end for;
 end method;

--- a/sources/dfmc/c-back-end/c-emit-object.dylan
+++ b/sources/dfmc/c-back-end/c-emit-object.dylan
@@ -765,11 +765,9 @@ define method emit-code (back-end :: <c-back-end>, o :: <&iep>)
     emit-lambda(back-end, stream, o);
     o.code := stream-contents-as(<byte-string>, stream);
     // format-out("%s\n", o.code);
-    if (*retract-dfm?*)
-      if (lambda-top-level?(o))
-        retract-method-dfm(o);
-        retract-method-dfm(o.function);
-      end if;
+    if (lambda-top-level?(o))
+      retract-method-dfm(o);
+      retract-method-dfm(o.function);
     end if;
   end unless;
 end method;

--- a/sources/dfmc/harp-cg/harp-emit.dylan
+++ b/sources/dfmc/harp-cg/harp-emit.dylan
@@ -97,7 +97,7 @@ define method retract-local-methods-in-heap(heap :: <model-heap>) => ()
       let code-vec  = code & ~empty?(code) & lambda-code(head(code));
       let code-size = if (code-vec) size(code-vec) else 0 end;
       total-code-size := total-code-size + code-size;
-      unless (lambda-top-level?(literal) | ~*retract-dfm?*)
+      unless (lambda-top-level?(literal))
 	format-out?("\nRETRACTING %=\n", literal);
 	retract-method-dfm(literal);
 	retract-method-dfm(literal.function);
@@ -136,12 +136,10 @@ define method emit-code
   if (re-emit?)
     o.code := #();
     apply(emit-lambda, back-end, #f, o, flags);
-    if (*retract-dfm?*)
-      if (lambda-top-level?(o))
-        format-out?("\nRETRACTING %=\n", o);
-        retract-method-dfm(o);
-        retract-method-dfm(o.function);
-      end if;
+    if (lambda-top-level?(o))
+      format-out?("\nRETRACTING %=\n", o);
+      retract-method-dfm(o);
+      retract-method-dfm(o.function);
     end if;
   end if;
 end method emit-code;
@@ -260,11 +258,9 @@ define method emit-init-code-body
     emit-lambda-body(back-end, stream, o);
     ins--tag(back-end, back-end.cg-variables.exit-tag);
   end with-harp-variables;
-  if (*retract-dfm?*)
-    format-out?("\nRETRACTING %=\n", o);
-    retract-method-dfm(o);
-    retract-method-dfm(o.function);
-  end if;
+  format-out?("\nRETRACTING %=\n", o);
+  retract-method-dfm(o);
+  retract-method-dfm(o.function);
 end method;
 
 define method emit-system-init-code

--- a/sources/dfmc/llvm-back-end/llvm-emit-code.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-emit-code.dylan
@@ -181,11 +181,9 @@ define method emit-code
     end block;
 
     // Done with this DFM?
-    if (*retract-dfm?*)
-      if (lambda-top-level?(o))
-	retract-method-dfm(o);
-	retract-method-dfm(o.function);
-      end if;
+    if (lambda-top-level?(o))
+      retract-method-dfm(o);
+      retract-method-dfm(o.function);
     end if;
   end unless;
 end method;

--- a/sources/dfmc/llvm-back-end/llvm-emit.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-emit.dylan
@@ -76,9 +76,9 @@ end method;
 define method retract-local-methods-in-heap(heap :: <model-heap>) => ()
   for (literal in heap.heap-defined-object-sequence)
     if (instance?(literal, <&iep>))
-      unless (lambda-top-level?(literal) | ~*retract-dfm?*)
-	retract-method-dfm(literal);
-	retract-method-dfm(literal.function);
+      unless (lambda-top-level?(literal))
+        retract-method-dfm(literal);
+        retract-method-dfm(literal.function);
       end unless;
     end if;
   end for;


### PR DESCRIPTION
This is always true and there's nothing that flips it to #f.