### PR TITLE
[dfmc] Share emit-dfm caller code between back-ends.

### DIFF
--- a/sources/dfmc/back-end/back-end-library.dylan
+++ b/sources/dfmc/back-end/back-end-library.dylan
@@ -118,6 +118,7 @@ define module dfmc-back-end
     emit-reference,
     emit-indirect-reference,
     emit-all,
+    emit-all-dfm,
     emit-dfm,
 
     initialize-back-end, \with-back-end-initialization,

--- a/sources/dfmc/back-end/back-end.dylan
+++ b/sources/dfmc/back-end/back-end.dylan
@@ -10,6 +10,24 @@ define variable *retract-dfm?* = #t;
 define compiler-open generic emit-all
     (back-end :: <back-end>, record, #rest flags, #key, #all-keys);
 
+define function emit-all-dfm
+    (back-end :: <back-end>, cr :: <compilation-record>, flags :: <sequence>)
+ => ()
+  let heap = cr.compilation-record-model-heap;
+  with-build-area-output (stream = current-library-description(),
+                          name: concatenate(cr.compilation-record-name, ".dfm"))
+    for (literal in heap.heap-defined-object-sequence)
+      apply(emit-dfm, back-end, stream, literal, flags);
+    end for;
+    for (code in heap.heap-root-system-init-code)
+      apply(emit-dfm, back-end, stream, code.^iep, flags);
+    end for;
+    for (code in heap.heap-root-init-code)
+      apply(emit-dfm, back-end, stream, code.^iep, flags);
+    end for;
+  end with-build-area-output;
+end function emit-all-dfm;
+
 define compiler-open generic emit-dfm
   (back-end :: <back-end>, stream, object, #rest flags, #key, #all-keys) => ();
 

--- a/sources/dfmc/c-back-end/c-back-end.dylan
+++ b/sources/dfmc/c-back-end/c-back-end.dylan
@@ -180,18 +180,7 @@ define method emit-all (back-end :: <c-back-end>, cr :: <compilation-record>,
     let heap = cr.compilation-record-model-heap;
     let literals = heap.heap-defined-object-sequence;
     when (dfm-output?)
-      with-build-area-output (stream = current-library-description(),
-                              name: concatenate(cr.compilation-record-name, ".dfm"))
-        for (literal in literals)
-          apply(emit-dfm, back-end, stream, literal, flags);
-        end for;
-        for (code in heap.heap-root-system-init-code)
-          apply(emit-dfm, back-end, stream, code.^iep, flags);
-        end for;
-        for (code in heap.heap-root-init-code)
-          apply(emit-dfm, back-end, stream, code.^iep, flags);
-        end for;
-      end with-build-area-output;
+      emit-all-dfm(back-end, cr, flags);
     end when;
     for (literal in literals)
       emit-code(back-end, literal);

--- a/sources/dfmc/harp-cg/harp-emit.dylan
+++ b/sources/dfmc/harp-cg/harp-emit.dylan
@@ -55,12 +55,7 @@ define sideways method emit-all
 
           let literals = heap.heap-defined-object-sequence;
           when (dfm-output?)
-            with-build-area-output (stream = current-library-description(),
-                                    name: concatenate(cr.compilation-record-name, ".dfm"))
-              for (literal in literals)
-                apply(emit-dfm, back-end, stream, literal, flags);
-              end for;
-            end with-build-area-output;
+            emit-all-dfm(back-end, cr, flags);
           end when;
 
           for (literal in heap.heap-defined-object-sequence)

--- a/sources/dfmc/llvm-back-end/llvm-emit.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-emit.dylan
@@ -32,19 +32,7 @@ define method emit-all (back-end :: <llvm-back-end>,
       
       // Output DFM files
       if (dfm-output?)
-        with-build-area-output (stream = current-library-description(),
-                                base: compilation-record-name(cr),
-                                type: "dfm")
-          for (literal in literals)
-            apply(emit-dfm, back-end, stream, literal, flags);
-          end for;
-          for (code in heap.heap-root-system-init-code)
-            apply(emit-dfm, back-end, stream, code.^iep, flags);
-          end for;
-          for (code in heap.heap-root-init-code)
-            apply(emit-dfm, back-end, stream, code.^iep, flags);
-          end for;
-        end with-build-area-output;
+        emit-all-dfm(back-end, cr, flags);
       end if;
       
       // Emit code


### PR DESCRIPTION
back-end: Create emit-all-dfm which emits all DFM for a compilation
  record. This function is exported.

C, HARP, LLVM back-ends: Replace DFM printing code with a call to
  the new emit-all-dfm.