### PR TITLE
[dylan] Remove <optional-name> type alias.

### DIFF
--- a/documentation/hacker-guide/source/runtime/primitives.rst
+++ b/documentation/hacker-guide/source/runtime/primitives.rst
@@ -16,7 +16,7 @@ primitive-make-thread
 
 Signature
 
-(thread :: <thread>, name :: <optional-name>, priority :: <integer>, function :: <function>) => ()
+(thread :: <thread>, name :: false-or(<byte-string>), priority :: <integer>, function :: <function>) => ()
 
 Arguments
 
@@ -159,7 +159,7 @@ primitive-make-simple-lock
 
 Signature
 
-(lock :: <portable-container>, name :: <optional-name>) => ()
+(lock :: <portable-container>, name :: false-or(<byte-string>)) => ()
 
 Arguments
 
@@ -286,7 +286,7 @@ primitive-make-recursive-lock
 
 Signature
 
-(lock :: <portable-container>, name :: <optional-name>) => ()
+(lock :: <portable-container>, name :: false-or(<byte-string>)) => ()
 
 Arguments
 
@@ -418,7 +418,7 @@ primitive-make-semaphore
 
 Signature
 
-(lock :: <portable-container>, name :: <optional-name>,
+(lock :: <portable-container>, name :: false-or(<byte-string>),
  initial :: <integer>, max :: <integer>) => ()
 
 Arguments
@@ -530,7 +530,7 @@ primitive-make-notification
 
 Signature
 
-(notification :: <portable-container>, name :: <optional-name>) => ()
+(notification :: <portable-container>, name :: false-or(<byte-string>)) => ()
 
 Arguments
 

--- a/documentation/hacker-guide/source/runtime/threads.rst
+++ b/documentation/hacker-guide/source/runtime/threads.rst
@@ -89,13 +89,10 @@ Dylan Types for Threads Portability
 -----------------------------------
 
 Three Dylan types merit discussion for their use with portability
-primitives: ``<thread>``, ``<portable-container>``, and ``<optional-name>``.
-Objects that are instances of the ``<thread>`` and
-``<portable-container>`` classes have slots which contain lower-level
-objects that are specific to the Dylan runtime or operating system. The
-``<optional-name>`` type allows an object, such as a lock, to have a name
-represented as a string or, if no name is supplied, as the Boolean false
-value ``#f``.
+primitives: ``<thread>``, ``<portable-container>``.  Objects that are
+instances of the ``<thread>`` and ``<portable-container>`` classes have
+slots which contain lower-level objects that are specific to the Dylan
+runtime or operating system.
 
 <thread>
 
@@ -116,15 +113,6 @@ superclass for all the concrete synchronization classes (``<simple-lock>``,
 ``<portable-container>`` object contains an OS handle, which is available
 to the runtime for storing any OS-specific data. Subclasses may provide
 additional slots.
-
-<optional-name>
-
-[Type]
-------
-
-This is a union type which is used to represent names of synchronization
-objects. Values of the type are either strings (of class :drm:`<byte-string>`)
-or false (``#f``).
 
 Various classes of Dylan objects are passed through the portability
 interface, and hence require description in terms of lower level
@@ -168,7 +156,7 @@ Correspondence Between Dylan Types and C Types
 |                               |               | *char data[ ];*                      |
 |                               |               | *} B\_STRING;*                       |
 +-------------------------------+---------------+--------------------------------------+
-| ``<optional-name>``           | *D\_NAME*     | *typedef void\* D\_NAME;*            |
+| ``false-or(<byte-string>)``   | *D\_NAME*     | *typedef void\* D\_NAME;*            |
 +-------------------------------+---------------+--------------------------------------+
 | ``<portable-container>``      | *CONTAINER\** | *typedef struct \_ctr {              |
 |                               |               | * *D class;                          |

--- a/sources/dfmc/modeling/namespaces.dylan
+++ b/sources/dfmc/modeling/namespaces.dylan
@@ -1905,7 +1905,6 @@ define &module threads-primitives
     *dylan-library-initialized?*;
 
   export
-    <optional-name>,
     <portable-container>, handle1, handle1-setter,
     <portable-double-container>, handle2, handle2-setter,
     $success,

--- a/sources/dylan/portable-container.dylan
+++ b/sources/dylan/portable-container.dylan
@@ -40,9 +40,3 @@ define abstract primary class <portable-double-container> (<portable-container>)
   slot handle2 :: <object>;
 
 end class;
-
-
-
-/// <optional-name> is not exactly related, but gets defined here anyway
-
-define constant <optional-name> = type-union(<byte-string>, singleton(#f));

--- a/sources/dylan/synchronization.dylan
+++ b/sources/dylan/synchronization.dylan
@@ -10,14 +10,14 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define open abstract class <synchronization> (<object>)
 
-  constant slot synchronization-name :: <optional-name>,
+  constant slot synchronization-name :: false-or(<byte-string>),
     init-value: #f, init-keyword: name:;
 
 end class;
 
 
 define open generic synchronization-name
-   (object :: <synchronization>) => (name :: <optional-name>);
+   (object :: <synchronization>) => (name :: false-or(<byte-string>));
 
 define open generic wait-for
    (object :: <synchronization>, #key timeout = #f) => (success?);

--- a/sources/dylan/thread.dylan
+++ b/sources/dylan/thread.dylan
@@ -20,7 +20,7 @@ define sealed class <thread> (<portable-double-container>)
   constant slot priority :: <integer>,
     init-value: $normal-priority, init-keyword: priority:;
 
-  constant slot thread-name :: <optional-name>,
+  constant slot thread-name :: false-or(<byte-string>),
     init-value: #f, init-keyword: name:;
 
   constant slot function :: <function>,


### PR DESCRIPTION
The <optional-name> type alias for false-or(<byte-string>) didn't
provide any value and just required that you go and look it up
to make sure it wasn't something else tricky.