### PR TITLE
[dfmc-conditions] Make <program-error> a <program-note>.

### DIFF
--- a/documentation/hacker-guide/source/compiler/notes-warnings-errors.rst
+++ b/documentation/hacker-guide/source/compiler/notes-warnings-errors.rst
@@ -390,18 +390,13 @@ Program Conditions
    :open:
    :abstract:
 
-   :superclasses: :class:`<serious-program-warning>`
+   :superclasses: :class:`<program-note>`
 
    :description:
 
      A ``<program-error>`` is a language error.  Examples would be (most)
      syntax errors, inconsistent direct superclasses, or a reference to
      an undefined name.
-
-     .. note:: This is currently a :class:`<serious-program-warning>`
-        rather than a separate subclass of :class:`<program-note>`.
-        This is noted in the source as a short term hack since
-        April 6, 1998.
 
 .. class:: <program-restart>
    :open:

--- a/sources/dfmc/conditions/hierarchy.dylan
+++ b/sources/dfmc/conditions/hierarchy.dylan
@@ -251,14 +251,12 @@ define program-condition-definer serious-program-warning;
 // A <program-error> is a language error.  Examples would be (most)
 // syntax errors, inconsistent direct superclasses, or a reference to
 // an undefined name.
-// gts,98apr06 -- short term hack -- instead of having <program-error> be
-//   interesting in its own right, just stick it under serious-program-warning
-//   for now.
 
-// define open abstract program-note <program-error>
-define open abstract serious-program-warning <program-error>
+define open abstract program-note <program-error>
+  filter $signal-program-note;
+  // This doesn't show anything yet and needs further work.
   // filter $signal-program-error;
-end serious-program-warning <program-error>;
+end program-note <program-error>;
 
 define program-condition-definer program-error;
 

--- a/sources/dfmc/conditions/presentation.dylan
+++ b/sources/dfmc/conditions/presentation.dylan
@@ -59,7 +59,7 @@ define macro with-program-conditions
 end macro with-program-conditions;
 
 define function do-with-program-conditions (body)
-  let handler <program-warning>
+  let handler <program-note>
     = method (condition, next-handler)
         present-program-note(condition)
       end;

--- a/sources/dfmc/debug-back-end/print-condition.dylan
+++ b/sources/dfmc/debug-back-end/print-condition.dylan
@@ -63,8 +63,7 @@ define method condition-classification (o :: <program-note>)
 end method;
 
 define method condition-classification (o :: <program-error>)
-  // gts,98apr06: temporary fix: ppml-string("Error");
-  next-method();
+  ppml-string("Error");
 end method;
 
 define method condition-classification (o :: <program-warning>)


### PR DESCRIPTION
There has been a long-standing TODO item in the codebase (since
April of 1998) to make <program-error> inherit from ``<program-note>``
instead of ``<serious-program-warning>``.

* sources/dfmc/conditions/hierarchy.dylan: Change superclass for
   ``<program-error>`` to ``<program-note>``.

* sources/dfmc/conditions/presentation.dylan
  (do-with-program-conditions): Update the condition handler to
   handle all ``<program-note>`` instances rather than only
   ``<program-warning>`` instances. This allows it to handle
   ``<program-error>`` instances as well as (in the future) other
   sorts of ``<program-note>``.

* sources/dfmc/debug-back-end/print-condition
  (condition-classification): Return the correct text for
   ``<program-error>`` instances.

* documentation/hacker-guide/source/compiler/notes-warnings-errors.rst:
   Update superclass for ``<program-error>`` and remove note about the
   TODO item.