### PR TITLE
Move format-to-string: part two

### DIFF
--- a/sources/app/create-id/library.dylan
+++ b/sources/app/create-id/library.dylan
@@ -16,6 +16,6 @@ end library;
 define module create-id
   use common-dylan;
   use operating-system;
-  use simple-io;
+  use simple-format;
   use COM;
 end module;

--- a/sources/app/djam/library.dylan
+++ b/sources/app/djam/library.dylan
@@ -14,7 +14,7 @@ define library djam
 end library;
 
 define module djam
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use format-out;
   use format;
   use streams;

--- a/sources/app/dll-wrap/module.dylan
+++ b/sources/app/dll-wrap/module.dylan
@@ -11,7 +11,7 @@ define module dll-wrap
   use format-out;
   use format;
   use finalization;
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use simple-random;
   use operating-system;
 end module dll-wrap;

--- a/sources/app/duim-resource-example/library.dylan
+++ b/sources/app/duim-resource-example/library.dylan
@@ -17,7 +17,7 @@ define library duim-resource-example
 end library duim-examples;
 
 define module duim-resource-example
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use format;
   use format-out;
   use operating-system;

--- a/sources/app/dylan-playground/gui-module.dylan
+++ b/sources/app/dylan-playground/gui-module.dylan
@@ -7,9 +7,7 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module gui-dylan-playground
-  use common-dylan,
-    //---*** This shouldn't be necessary!
-    exclude: { format-to-string };
+  use common-dylan;
   use simple-random;
   use threads;
   use finalization;

--- a/sources/app/dylan-playground/module.dylan
+++ b/sources/app/dylan-playground/module.dylan
@@ -7,9 +7,7 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module dylan-playground
-  use common-dylan,
-    //---*** This shouldn't be necessary!
-    exclude: { format-to-string };
+  use common-dylan;
   use simple-random;
   use threads;
   use finalization;

--- a/sources/app/factorial/factorial-library-big.dylan
+++ b/sources/app/factorial/factorial-library-big.dylan
@@ -16,6 +16,6 @@ end;
 define module factorial
   // Single top-level module, so it exports nothing.
   use generic-arithmetic-common-dylan;
-  use simple-io;
+  use simple-format;
   use simple-profiling;
 end;

--- a/sources/app/factorial/factorial-library-small.dylan
+++ b/sources/app/factorial/factorial-library-small.dylan
@@ -14,6 +14,6 @@ end;
 define module factorial
   // Single top-level module, so it exports nothing.
   use common-dylan;
-  use simple-io;
+  use simple-format;
   use simple-profiling;
 end;

--- a/sources/app/gctest/module.dylan
+++ b/sources/app/gctest/module.dylan
@@ -7,7 +7,7 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module gctest
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use threads;
   use format;
   use format-out;

--- a/sources/app/hello-world/hello-world-library.dylan
+++ b/sources/app/hello-world/hello-world-library.dylan
@@ -13,5 +13,5 @@ end library;
 
 define module hello-world
   use common-dylan;
-  use simple-io;
+  use simple-format;
 end module;

--- a/sources/app/llvm-runtime-generator/llvm-runtime-generator-library.dylan
+++ b/sources/app/llvm-runtime-generator/llvm-runtime-generator-library.dylan
@@ -19,7 +19,7 @@ define library llvm-runtime-generator
 end library;
 
 define module llvm-runtime-generator
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use operating-system;
   use format;
   use standard-io;

--- a/sources/app/llvm-tablegen/library.dylan
+++ b/sources/app/llvm-tablegen/library.dylan
@@ -13,7 +13,7 @@ define library llvm-tablegen
 end library llvm-tablegen;
 
 define module llvm-tablegen
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use streams;
   use print;
   use format;

--- a/sources/app/parser-compiler/library.dylan
+++ b/sources/app/parser-compiler/library.dylan
@@ -12,7 +12,7 @@ define library parser-compiler
 end;
 
 define module parser-compiler
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use streams;
   use format-out;
   use format;

--- a/sources/app/quicksort/library.dylan
+++ b/sources/app/quicksort/library.dylan
@@ -12,7 +12,7 @@ end library quicksort;
 
 define module quicksort
   use common-dylan;
-  use simple-io;
+  use simple-format;
   use simple-random;
   use simple-profiling;
 end module quicksort;

--- a/sources/app/tool-invoke/module.dylan
+++ b/sources/app/tool-invoke/module.dylan
@@ -8,7 +8,7 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module tool-invoke
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use operating-system;
   use streams;
   use standard-io;

--- a/sources/benchmarks/customer/cn2/library.dylan
+++ b/sources/benchmarks/customer/cn2/library.dylan
@@ -14,7 +14,7 @@ define library cn2
 end library cn2;
 
 define module cn2
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use dylan-extensions, import: { without-bounds-checks };
   use streams;
   use format;

--- a/sources/benchmarks/customer/fft-test/module.dylan
+++ b/sources/benchmarks/customer/fft-test/module.dylan
@@ -10,7 +10,7 @@ define module fft-test
   use finalization;
   use common-dylan;
   use dylan-extensions, import: { \without-bounds-checks };
-  use simple-io;
+  use simple-format;
   use simple-random;
   use simple-profiling;
   use transcendentals;

--- a/sources/benchmarks/deltablue/deltablue-library.dylan
+++ b/sources/benchmarks/deltablue/deltablue-library.dylan
@@ -14,7 +14,7 @@ define module deltablue
   use common-dylan;
   use dylan-extensions;
   use dispatch-engine;
-  use simple-io;
+  use simple-format;
   use operating-system;
   use dispatch-profiler;
 end module;

--- a/sources/benchmarks/gabriel/library.dylan
+++ b/sources/benchmarks/gabriel/library.dylan
@@ -17,7 +17,7 @@ define module gabriel-benchmarks
     import: { sin, cos, $single-pi, $double-pi };
   use threads,
     import: { dynamic-bind };
-  use simple-io;
+  use simple-format;
   use simple-random;
   use simple-profiling;
 end module gabriel-benchmarks;

--- a/sources/benchmarks/richards/richards-library.dylan
+++ b/sources/benchmarks/richards/richards-library.dylan
@@ -10,5 +10,5 @@ end;
 
 define module richards
   use common-dylan;
-  use simple-io;
+  use simple-format;
 end;

--- a/sources/collections/tests/library.dylan
+++ b/sources/collections/tests/library.dylan
@@ -16,7 +16,7 @@ end library collections-test-suite;
 
 define module collections-test-suite
   use common-dylan;
-  use simple-io;
+  use simple-format;
   use testworks;
 
   use byte-vector;

--- a/sources/common-dylan/library.dylan
+++ b/sources/common-dylan/library.dylan
@@ -298,5 +298,5 @@ define module common-dylan-internals
   use simple-random;
   use simple-profiling;
   use simple-timers;
-  use simple-io;
+  use simple-format;
 end module common-dylan-internals;

--- a/sources/common-dylan/tests/library.dylan
+++ b/sources/common-dylan/tests/library.dylan
@@ -21,7 +21,7 @@ define module common-dylan-test-suite
   use streams-protocol;
   use locators-protocol;
   use finalization;
-  use simple-io;
+  use simple-format;
   use simple-random;
   use simple-profiling;
   use transcendentals;

--- a/sources/corba/demos/bank/bank-server/module.dylan
+++ b/sources/corba/demos/bank/bank-server/module.dylan
@@ -7,7 +7,7 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module bank-server
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use dylan-orb;
   use bank-skeletons;
   use naming-client;

--- a/sources/corba/demos/chat/client/module.dylan
+++ b/sources/corba/demos/chat/client/module.dylan
@@ -58,7 +58,7 @@ define module chat-client-implementation
 end module;
 
 define module chat-client-gui
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use duim;
   use threads;
   use operating-system;

--- a/sources/corba/demos/chat/server/module.dylan
+++ b/sources/corba/demos/chat/server/module.dylan
@@ -47,7 +47,7 @@ define module corba-server-implementation
 end module;
 
 define module chat-server-implementation
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use dylan-orb;
   use format;
   use chat-stubs;
@@ -56,7 +56,7 @@ define module chat-server-implementation
 end module;
 
 define module chat-server-gui
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use format;
   use duim;
   use threads;

--- a/sources/corba/demos/corba-hello-world/client/module.dylan
+++ b/sources/corba/demos/corba-hello-world/client/module.dylan
@@ -9,7 +9,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 define module corba-hello-world-client
   use byte-vector;
   use finalization;
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use machine-words;
   use simple-random;
   use transcendentals;

--- a/sources/corba/demos/corba-hello-world/server/module.dylan
+++ b/sources/corba/demos/corba-hello-world/server/module.dylan
@@ -9,7 +9,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 define module corba-hello-world-server
   use byte-vector;
   use finalization;
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use machine-words;
   use simple-random;
   use transcendentals;

--- a/sources/corba/orb/dylan/corba-dylan-library.dylan
+++ b/sources/corba/orb/dylan/corba-dylan-library.dylan
@@ -17,7 +17,6 @@ end library;
 
 define module corba-dylan
   use generic-arithmetic-common-dylan,
-    exclude: { format-to-string },
     export: all;
   use dylan-arithmetic,
     export: all,

--- a/sources/corba/scepter/abstract-syntax-tree/scepter-ast-module.dylan
+++ b/sources/corba/scepter/abstract-syntax-tree/scepter-ast-module.dylan
@@ -6,7 +6,7 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module scepter-ast
-  use generic-arithmetic-common-dylan, exclude: { union, format-to-string };
+  use generic-arithmetic-common-dylan, exclude: { union };
   use streams;
   use format;
   use table-extensions, exclude: { table };

--- a/sources/corba/scepter/back-end/dump/module.dylan
+++ b/sources/corba/scepter/back-end/dump/module.dylan
@@ -7,8 +7,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module scepter-dump-back-end
   use date;
-  use generic-arithmetic-common-dylan,
-    exclude: { format-to-string };
+  use generic-arithmetic-common-dylan;
   use format;
   use streams;
   use file-system;

--- a/sources/corba/scepter/back-end/dylan/scepter-dylan-back-end-module.dylan
+++ b/sources/corba/scepter/back-end/dylan/scepter-dylan-back-end-module.dylan
@@ -9,8 +9,7 @@ define module scepter-dylan-back-end
   use date;
   use file-system;
   use format;
-  use generic-arithmetic-common-dylan,
-    exclude: { format-to-string };
+  use generic-arithmetic-common-dylan;
   use locators;
   use streams;
   use threads;

--- a/sources/corba/scepter/back-end/ir/scepter-ir-back-end-module.dylan
+++ b/sources/corba/scepter/back-end/ir/scepter-ir-back-end-module.dylan
@@ -6,7 +6,7 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module scepter-ir-back-end-internal
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use dylan-orb;
   use format;
   use streams;

--- a/sources/corba/scepter/console/console-scepter-library.dylan
+++ b/sources/corba/scepter/console/console-scepter-library.dylan
@@ -15,7 +15,7 @@ define library console-scepter
 end library;
 
 define module console-scepter
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use simple-debugging;
   use file-system;
   use format;

--- a/sources/corba/scepter/console/minimal-console-scepter-library.dylan
+++ b/sources/corba/scepter/console/minimal-console-scepter-library.dylan
@@ -15,7 +15,7 @@ define library minimal-console-scepter
 end library;
 
 define module console-scepter
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use simple-debugging;
   use file-system;
   use format;

--- a/sources/corba/scepter/core/scepter-core-module.dylan
+++ b/sources/corba/scepter/core/scepter-core-module.dylan
@@ -148,7 +148,7 @@ define module scepter-error
 end module;
 
 define module scepter-driver-implementation
-  use generic-arithmetic-common-dylan, exclude: { format-to-string };
+  use generic-arithmetic-common-dylan;
   use simple-debugging;
   use file-system;
   use format;
@@ -168,7 +168,7 @@ end module;
 define module scepter-back-end-implementation
   use date;
   use format;
-  use generic-arithmetic-common-dylan, exclude: { format-to-string };
+  use generic-arithmetic-common-dylan;
   use streams;
   use scepter-back-end;
   use scepter-front-end;
@@ -177,7 +177,7 @@ end module;
 
 define module scepter-front-end-implementation
   use date;
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use format;
   use streams;
   use locators;
@@ -186,7 +186,7 @@ define module scepter-front-end-implementation
 end module;
 
 define module scepter-error-implementation
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use format;
   use scepter-error;
   use scepter-driver;

--- a/sources/corba/scepter/front-end/file/scepter-file-front-end-module.dylan
+++ b/sources/corba/scepter/front-end/file/scepter-file-front-end-module.dylan
@@ -7,8 +7,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module scepter-file-front-end
   use date;
-  use generic-arithmetic-common-dylan,
-    exclude: { format-to-string };
+  use generic-arithmetic-common-dylan;
   use file-system;
   use format;
   use streams;

--- a/sources/corba/scepter/tests/library.dylan
+++ b/sources/corba/scepter/tests/library.dylan
@@ -22,7 +22,7 @@ define module scepter-tests
   use standard-io;
   use print;
   use format;
-  use common-extensions, exclude: {format-to-string, <union>};
+  use common-extensions, exclude: {<union>};
   use parser-run-time;
   use c-lexer,
     rename: { constant-value => lexer-value, $eoi-token => $lexer-eoi-token };

--- a/sources/corba/scepter/tool/tool-scepter-module.dylan
+++ b/sources/corba/scepter/tool/tool-scepter-module.dylan
@@ -6,7 +6,7 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module tool-scepter
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use format;
   use streams;
   use table-extensions;

--- a/sources/corba/scepter/utilities/scepter-utilities-module.dylan
+++ b/sources/corba/scepter/utilities/scepter-utilities-module.dylan
@@ -6,7 +6,7 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module scepter-utilities
-  use generic-arithmetic-common-dylan, exclude: { <union>, format-to-string };
+  use generic-arithmetic-common-dylan, exclude: { <union> };
   use standard-io;
   use format;
   use streams;

--- a/sources/corba/services/naming/module.dylan
+++ b/sources/corba/services/naming/module.dylan
@@ -7,7 +7,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module naming-service
   use common-dylan;
-  use simple-io;
+  use simple-format;
   use table-extensions;
   use dylan-orb;
   use naming-skeletons;

--- a/sources/corba/tools/ir-browser/module.dylan
+++ b/sources/corba/tools/ir-browser/module.dylan
@@ -6,7 +6,7 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module ir-browser
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use dylan-orb;
   use duim;
   use format;

--- a/sources/databases/sql-odbc-test/library.dylan
+++ b/sources/databases/sql-odbc-test/library.dylan
@@ -60,7 +60,7 @@ end module;
 
 define module sql-odbc-test
   use dylan;
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use memory-manager;
   use threads;
   use sql-odbc;

--- a/sources/databases/sql-odbc/library.dylan
+++ b/sources/databases/sql-odbc/library.dylan
@@ -233,7 +233,7 @@ end module;
 
 define module sql-odbc-implementation
   use dylan;
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use generic-arithmetic, prefix: "big/";
   use dylan-extensions;
   use machine-words;

--- a/sources/databases/sql/library.dylan
+++ b/sources/databases/sql/library.dylan
@@ -677,7 +677,7 @@ end module;
 
 define module sql-implementation
   use dylan;
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use threads;
   use finalization;
   use sql;

--- a/sources/databases/tests/stress-tool/module.dylan
+++ b/sources/databases/tests/stress-tool/module.dylan
@@ -8,7 +8,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module database-stress-tool
   use common-dylan;
-  use simple-io;
+  use simple-format;
   use simple-profiling;
   use sql-odbc;
 

--- a/sources/deuce/duim/module.dylan
+++ b/sources/deuce/duim/module.dylan
@@ -39,7 +39,7 @@ end module duim-deuce;
 
 define module duim-deuce-internals
   use common-dylan,
-    exclude: { position, position-if, format-to-string };
+    exclude: { position, position-if };
   use threads;
   use plists;
 

--- a/sources/deuce/module.dylan
+++ b/sources/deuce/module.dylan
@@ -333,7 +333,7 @@ end module deuce;
 // Implementation and extension module
 define module deuce-internals
   use common-dylan,
-    exclude: { position, position-if, count, format-to-string };
+    exclude: { position, position-if, count };
   use dylan-extensions,
     import: { \without-bounds-checks,
               element-no-bounds-check,

--- a/sources/deuce/standalone/library.dylan
+++ b/sources/deuce/standalone/library.dylan
@@ -33,7 +33,7 @@ end module standalone-deuce;
 
 define module standalone-deuce-internals
   use common-dylan,
-    exclude: { position, position-if, format-to-string };
+    exclude: { position, position-if };
   use threads;
   use plists;
   use streams-internals,

--- a/sources/deuce/standalone/win32-library.dylan
+++ b/sources/deuce/standalone/win32-library.dylan
@@ -34,7 +34,7 @@ end module standalone-deuce;
 
 define module standalone-deuce-internals
   use common-dylan,
-    exclude: { position, position-if, format-to-string };
+    exclude: { position, position-if };
   use threads;
   use plists;
   use streams-internals,

--- a/sources/deuce/tests/library.dylan
+++ b/sources/deuce/tests/library.dylan
@@ -18,7 +18,7 @@ end library deuce-test-suite;
 
 define module deuce-test-suite
   use common-dylan,
-    exclude: { position, position-if, format-to-string };
+    exclude: { position, position-if };
   use format;
   use threads;
   use deuce-internals;

--- a/sources/dfmc/c-back-end/c-back-end-library.dylan
+++ b/sources/dfmc/c-back-end/c-back-end-library.dylan
@@ -19,7 +19,7 @@ end library;
 
 define module dfmc-c-back-end
   use big-integers, prefix: "generic-";
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use format;
   use streams-internals;
   use dfmc-core;

--- a/sources/dfmc/c-linker/c-linker-library.dylan
+++ b/sources/dfmc/c-linker/c-linker-library.dylan
@@ -19,7 +19,7 @@ define library dfmc-c-linker
 end library;
 
 define module dfmc-c-linker
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use dfmc-core;
   use dfmc-imports;
   use dfmc-conversion;

--- a/sources/dfmc/common/common-library.dylan
+++ b/sources/dfmc/common/common-library.dylan
@@ -42,7 +42,7 @@ define module dfmc-imports
              <ordered-object-table>,
              <ordered-object-set> },
     export: all;
-  use common-extensions, exclude: { format-to-string }, export: all;
+  use common-extensions, export: all;
   use threads, export: all;
   use collectors, export: all;
   use set, export: all;

--- a/sources/dfmc/harp-browser-support/harp-browser-support-library.dylan
+++ b/sources/dfmc/harp-browser-support/harp-browser-support-library.dylan
@@ -33,7 +33,7 @@ end module;
 
 
 define module dfmc-harp-browser-support
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use dylan-extensions, import: {case-insensitive-equal};
   use dfmc-imports, 
     exclude: { source-record-start-line, source-record-end-line };

--- a/sources/dfmc/harp-cg-linker/harp-linker-library.dylan
+++ b/sources/dfmc/harp-cg-linker/harp-linker-library.dylan
@@ -16,7 +16,7 @@ define library dfmc-harp-cg-linker
 end library;
 
 define module dfmc-harp-cg-linker
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use machine-word-lowlevel,
     import: { machine-word-unsigned-shift-left,
               machine-word-unsigned-shift-right };

--- a/sources/dfmc/harp-cg/harp-cg-library.dylan
+++ b/sources/dfmc/harp-cg/harp-cg-library.dylan
@@ -26,7 +26,7 @@ define library dfmc-harp-cg
 end library;
 
 define module dfmc-harp-cg
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use dylan-extensions,
     import: {decode-single-float, decode-double-float,
 	     <machine-word>, <double-integer>, $minimum-unsigned-machine-word},

--- a/sources/dfmc/harp-native-cg/library.dylan
+++ b/sources/dfmc/harp-native-cg/library.dylan
@@ -23,7 +23,7 @@ end library dfmc-harp-native-cg;
 
 define module dfmc-harp-native-cg
 
- use common-dylan, exclude: { format-to-string };
+ use common-dylan;
  use streams-internals;
 
  use harp-native,

--- a/sources/dfmc/harp-x86-cg/harp-x86-cg-library.dylan
+++ b/sources/dfmc/harp-x86-cg/harp-x86-cg-library.dylan
@@ -24,7 +24,7 @@ end library dfmc-harp-x86-cg;
 
 define module dfmc-harp-x86-cg
 
- use common-dylan, exclude: { format-to-string };
+ use common-dylan;
  use streams-internals;
 
  use harp-x86,

--- a/sources/dfmc/llvm-back-end/llvm-back-end-library.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-back-end-library.dylan
@@ -19,7 +19,7 @@ define library dfmc-llvm-back-end
 end library;
 
 define module dfmc-llvm-back-end
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use generic-arithmetic,
     prefix: "generic/";
   use dfmc-core;

--- a/sources/dfmc/llvm-linker/llvm-linker-library.dylan
+++ b/sources/dfmc/llvm-linker/llvm-linker-library.dylan
@@ -21,7 +21,7 @@ define library dfmc-llvm-linker
 end library;
 
 define module dfmc-llvm-linker
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use dfmc-core;
   use dfmc-imports;
   use dfmc-conversion;

--- a/sources/duim/examples/cookbook/module.dylan
+++ b/sources/duim/examples/cookbook/module.dylan
@@ -8,7 +8,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 // Implementation module
 define module duim-examples
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use format;
   use format-out;
   use operating-system;

--- a/sources/duim/examples/helpmate/library.dylan
+++ b/sources/duim/examples/helpmate/library.dylan
@@ -14,7 +14,7 @@ define library helpmate
 end library;
 
 define module helpmate
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use duim;
   use format;
 end module;

--- a/sources/duim/examples/interface-builder/module.dylan
+++ b/sources/duim/examples/interface-builder/module.dylan
@@ -7,7 +7,7 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module interface-builder
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use threads;
   use streams;
   use file-system;

--- a/sources/duim/examples/resources/library.dylan
+++ b/sources/duim/examples/resources/library.dylan
@@ -17,7 +17,7 @@ define library duim-resource-example
 end library duim-resource-example;
 
 define module duim-resource-example
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use format;
   use format-out;
   use operating-system;

--- a/sources/duim/examples/reversi/module.dylan
+++ b/sources/duim/examples/reversi/module.dylan
@@ -8,7 +8,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module reversi
   use common-dylan;
-  use simple-io;		// exported from common-dylan
+  use simple-format;		// exported from common-dylan
   use simple-random;		// exported from common-dylan
   use operating-system;		// exported from system
   use file-system;		// exported from system

--- a/sources/duim/examples/tetris/module.dylan
+++ b/sources/duim/examples/tetris/module.dylan
@@ -17,6 +17,6 @@ define module tetris
   use table-extensions;
   use machine-words;
   use finalization;
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use simple-random;
 end module tetris;

--- a/sources/duim/examples/web-browser/module.dylan
+++ b/sources/duim/examples/web-browser/module.dylan
@@ -8,7 +8,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 // Implementation module
 define module web-browser
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use file-system;
   use streams;
   use format;

--- a/sources/duim/examples/windows-viewer/hook-module.dylan
+++ b/sources/duim/examples/windows-viewer/hook-module.dylan
@@ -8,7 +8,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module windows-hook
   use common-dylan;
-  use simple-io;
+  use simple-format;
 
   use c-ffi;
   use win32-common;

--- a/sources/duim/examples/windows-viewer/module.dylan
+++ b/sources/duim/examples/windows-viewer/module.dylan
@@ -7,7 +7,7 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module windows-viewer
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use threads;
   use streams;
   use format;

--- a/sources/duim/tests/core/module.dylan
+++ b/sources/duim/tests/core/module.dylan
@@ -10,7 +10,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 define module duim-test-suite
   use common-dylan,
     exclude: { position };
-  use simple-io;
+  use simple-format;
   use threads;
 
   use testworks;

--- a/sources/duim/user/module.dylan
+++ b/sources/duim/user/module.dylan
@@ -8,7 +8,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 // Useful module for hacking around in listeners...
 define module duim-user
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use streams;
   use standard-io;
   use print;
@@ -21,8 +21,7 @@ end module duim-user;
 define module duim-internals-user
   use common-dylan,
     exclude: { position,
-	       \without-bounds-checks,
-               format-to-string };
+	       \without-bounds-checks };
   use streams;
   use standard-io;
   use print;

--- a/sources/duim/utilities/module.dylan
+++ b/sources/duim/utilities/module.dylan
@@ -20,7 +20,7 @@ define module duim-imports
 	      element-range-error },
     export: all;
   use simple-debugging, export: all;
-  use simple-io, export: all;
+  use simple-format, export: all;
   use threads, export: all;
   use transcendentals, export: all;
   use table-extensions, exclude: { table }, export: all;

--- a/sources/environment/commands/module.dylan
+++ b/sources/environment/commands/module.dylan
@@ -8,7 +8,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module command-lines
   use dylan;
-  use common-extensions, exclude: { format-to-string };
+  use common-extensions;
   use dylan-extensions,
     import: { <keyboard-interrupt>,
               keyboard-interrupt?, keyboard-interrupt?-setter,

--- a/sources/environment/debugger/tests/checkmate/module.dylan
+++ b/sources/environment/debugger/tests/checkmate/module.dylan
@@ -7,7 +7,7 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module checkmate
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use big-integers, prefix: "generic-";
   use streams;
   use standard-io;

--- a/sources/environment/dfmc/reports/module.dylan
+++ b/sources/environment/dfmc/reports/module.dylan
@@ -7,7 +7,7 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module dfmc-environment-reports
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use streams;
   use format;
 

--- a/sources/environment/dswank/library.dylan
+++ b/sources/environment/dswank/library.dylan
@@ -25,7 +25,7 @@ define library dswank
 end library;
 
 define module dswank
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use lisp-reader;
   use format-out;
   use format;

--- a/sources/environment/project-wizard/module.dylan
+++ b/sources/environment/project-wizard/module.dylan
@@ -51,7 +51,7 @@ define module utilities
 end module;
 
 define module repository
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use duim-internals,         // for string-capitalize
     exclude: { position };
   use release-info;
@@ -101,7 +101,7 @@ define module repository
 end module;
 
 define module environment-project-wizard
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use duim;
   use win32-duim;
   use duim-internals,         // for port-default-frame-manager, string-capitalize

--- a/sources/environment/server/parsers/library.dylan
+++ b/sources/environment/server/parsers/library.dylan
@@ -40,7 +40,7 @@ end module parser-interface;
 // They should rely on the definition of parser-user for an interface.
 
 define module string-parser
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use threads;
   use format;
 

--- a/sources/environment/source-control/module.dylan
+++ b/sources/environment/source-control/module.dylan
@@ -64,7 +64,7 @@ end module source-control-manager;
 
 define module source-control-manager-internals
   use dylan;
-  use common-extensions, exclude: { format-to-string };
+  use common-extensions;
   use threads;
   use locators;
   use settings;

--- a/sources/environment/tests/dfmc/module.dylan
+++ b/sources/environment/tests/dfmc/module.dylan
@@ -8,7 +8,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module dfmc-environment-test-suite
   use common-dylan;
-  use simple-io;
+  use simple-format;
   use locators;
 
   use source-records;

--- a/sources/examples/c-ffi/taskbar-icons/status-buttons/module.dylan
+++ b/sources/examples/c-ffi/taskbar-icons/status-buttons/module.dylan
@@ -17,7 +17,7 @@ define module status-buttons
   use table-extensions;
   use machine-words;
   use finalization;
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use simple-random;
   use status-icons;
 

--- a/sources/examples/console/towers-of-hanoi/library.dylan
+++ b/sources/examples/console/towers-of-hanoi/library.dylan
@@ -13,5 +13,5 @@ end library hanoi;
 
 define module hanoi
   use common-dylan;
-  use simple-io;
+  use simple-format;
 end module hanoi;

--- a/sources/examples/documentation/reversi/module.dylan
+++ b/sources/examples/documentation/reversi/module.dylan
@@ -8,7 +8,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module reversi
   use common-dylan;
-  use simple-io;		// exported from common-dylan
+  use simple-format;		// exported from common-dylan
   use simple-random;		// exported from common-dylan
   use operating-system;		// exported from system
   use file-system;		// exported from system

--- a/sources/examples/documentation/task-list-1/module.dylan
+++ b/sources/examples/documentation/task-list-1/module.dylan
@@ -7,7 +7,7 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module task-list
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use operating-system;
   use streams;
   use standard-io;

--- a/sources/examples/documentation/task-list-2/module.dylan
+++ b/sources/examples/documentation/task-list-2/module.dylan
@@ -7,7 +7,7 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module task-list
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use operating-system;
   use streams;
   use standard-io;

--- a/sources/examples/odbc/database-viewer/module.dylan
+++ b/sources/examples/odbc/database-viewer/module.dylan
@@ -9,7 +9,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 define module database-viewer
   use common-dylan;
   use threads;
-  use simple-io;
+  use simple-format;
   use sql-odbc,
     exclude: { command-function };
   use duim;

--- a/sources/examples/odbc/employee-explorer/module.dylan
+++ b/sources/examples/odbc/employee-explorer/module.dylan
@@ -18,7 +18,7 @@ define module employee-explorer
   use table-extensions;
   use machine-words;
   use finalization;
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use simple-random;
   use sql-odbc, exclude: { command-function };
 end module employee-explorer;

--- a/sources/examples/odbc/select-viewer/module.dylan
+++ b/sources/examples/odbc/select-viewer/module.dylan
@@ -18,6 +18,6 @@ define module select-viewer
   use table-extensions;
   use machine-words;
   use finalization;
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use simple-random;
 end module select-viewer;

--- a/sources/gtk/cairo-dylan/library.dylan
+++ b/sources/gtk/cairo-dylan/library.dylan
@@ -13,7 +13,7 @@ define library cairo
 end library;
 
 define module cairo
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use c-ffi;
   use dylan-direct-c-ffi;
   use gobject-glue; // For g-value-to-dylan-helper

--- a/sources/gtk/gobject-dylan/library.dylan
+++ b/sources/gtk/gobject-dylan/library.dylan
@@ -759,7 +759,7 @@ define module gobject
 end module;
 
 define module gobject-glue
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use c-ffi;
   use format;
   use standard-io;

--- a/sources/harp/binary-manager/library.dylan
+++ b/sources/harp/binary-manager/library.dylan
@@ -20,8 +20,7 @@ end library;
 
 
 define module binary-manager
-  use common-dylan,
-    exclude: { format-to-string };
+  use common-dylan;
   use byte-vector;
   use table-extensions, import: {<string-table>};
   use format;

--- a/sources/harp/binary-outputter/library.dylan
+++ b/sources/harp/binary-outputter/library.dylan
@@ -24,7 +24,7 @@ end library;
 
 
 define module binary-outputter
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use dylan-extensions;
   use byte-vector;
   use table-extensions, import: {<string-table>};

--- a/sources/harp/core-harp/module.dylan
+++ b/sources/harp/core-harp/module.dylan
@@ -9,7 +9,6 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module common-harp-imports
   use common-extensions,
-    exclude: { format-to-string },
     rename: { <stretchy-object-vector> => <stretchy-vector> },
     export: all;
   use dylan-extensions, 

--- a/sources/harp/gnu-as-outputter/library.dylan
+++ b/sources/harp/gnu-as-outputter/library.dylan
@@ -23,7 +23,7 @@ define library gnu-as-outputter
 end library;
 
 define module gnu-as-outputter
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use dylan-extensions;
   use byte-vector;
   use format;

--- a/sources/harp/mnemonic-assembler/library.dylan
+++ b/sources/harp/mnemonic-assembler/library.dylan
@@ -21,7 +21,7 @@ end library;
 
 define module mnemonic-assembler
   use generic-arithmetic-dylan;
-  use common-extensions, exclude: { format-to-string };
+  use common-extensions;
   use byte-vector;
   use format;
   use format-out;

--- a/sources/harp/native-rtg/module.dylan
+++ b/sources/harp/native-rtg/module.dylan
@@ -9,7 +9,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 
 define module harp-native-rtg
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use streams;
   use format;
   use print;

--- a/sources/harp/unix-rtg/module.dylan
+++ b/sources/harp/unix-rtg/module.dylan
@@ -9,7 +9,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 
 define module harp-unix-rtg
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use streams;
   use format;
   use print;

--- a/sources/harp/x86-rtg/module.dylan
+++ b/sources/harp/x86-rtg/module.dylan
@@ -9,7 +9,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 
 define module harp-x86-rtg
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use streams;
   use format;
   use print;

--- a/sources/harp/x86-windows-rtg/module.dylan
+++ b/sources/harp/x86-windows-rtg/module.dylan
@@ -9,7 +9,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 
 define module harp-x86-windows-rtg
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use streams;
   use format;
   use print;

--- a/sources/harp/x86/module.dylan
+++ b/sources/harp/x86/module.dylan
@@ -9,7 +9,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 
 define module harp-x86
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use dylan-extensions,  import: {<abstract-integer>, <simple-integer-vector>};
   use big-integers, prefix: "generic-";
   use streams;

--- a/sources/io/library.dylan
+++ b/sources/io/library.dylan
@@ -336,8 +336,7 @@ define module format-out
 end module format-out;
 
 define module io-internals
-  use common-dylan,
-    exclude: { format-to-string };
+  use common-dylan;
   use dylan-direct-c-ffi;
   use threads;
   use streams-internals;

--- a/sources/io/tests/library.dylan
+++ b/sources/io/tests/library.dylan
@@ -20,8 +20,7 @@ define library io-test-suite
 end library io-test-suite;
 
 define module io-test-suite
-  use common-dylan,
-    exclude: { format-to-string };
+  use common-dylan;
   use simple-random;
   use threads;
   use date;

--- a/sources/lib/build-system/library.dylan
+++ b/sources/lib/build-system/library.dylan
@@ -21,7 +21,7 @@ define library build-system
 end library build-system;
 
 define module build-system
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use dylan-primitives;
   use threads;
   use operating-system;

--- a/sources/lib/c-ffi/test/c-ffi-test-library.dylan
+++ b/sources/lib/c-ffi/test/c-ffi-test-library.dylan
@@ -21,7 +21,7 @@ define module c-ffi-test
   use machine-words;
   use c-ffi;
 //    exclude: { test-function };
-  use simple-io;
+  use simple-format;
 
   export c-ffi-suite
 end;

--- a/sources/lib/c-lexer/cpp/cpp-tester-library.dylan
+++ b/sources/lib/c-lexer/cpp/cpp-tester-library.dylan
@@ -14,7 +14,7 @@ end library;
 
 
 define module cpp-tester
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use standard-io;
   use streams;
   use c-lexer;

--- a/sources/lib/c-lexer/library.dylan
+++ b/sources/lib/c-lexer/library.dylan
@@ -36,7 +36,7 @@ define module c-lexer-utilities
 end module;
 
 define module c-lexer-utilities-internal
-  use common-dylan, exclude: { <union>, clex-digit?, format-to-string };
+  use common-dylan, exclude: { <union>, clex-digit? };
   use streams;
   use standard-io;
   use print;
@@ -121,7 +121,7 @@ define module C-lexer
 end module;
 
 define module C-lexer-internal
-  use common-dylan, exclude: { format-to-string }; //  exclude: {<union>, close, clex-digit?}
+  use common-dylan;
   use streams, export: {read-element, unread-element};
   use standard-io;
   use print;
@@ -150,7 +150,7 @@ define module cpp
 end module cpp;
 
 define module cpp-internal
-  use common-dylan, exclude: { <union>, format-to-string };
+  use common-dylan, exclude: { <union> };
   use table-extensions, exclude: { table };
   use streams, export: {read-element, unread-element};
   use standard-io;

--- a/sources/lib/cl/module.dylan
+++ b/sources/lib/cl/module.dylan
@@ -47,7 +47,7 @@ define module CL-strings
 end module CL-strings;
 
 define module CL-internals
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use format;
 
   use CL-macros, export: all;

--- a/sources/lib/commands/library.dylan
+++ b/sources/lib/commands/library.dylan
@@ -8,7 +8,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define library commands
   use dylan;
-  use common-dylan, import: { common-extensions, simple-io };
+  use common-dylan, import: { common-extensions, simple-format };
 
   export commands,
 	 commands-internals;

--- a/sources/lib/commands/module.dylan
+++ b/sources/lib/commands/module.dylan
@@ -48,7 +48,7 @@ end module commands;
 define module commands-internals
   use dylan;
   use common-extensions;
-  use simple-io;
+  use simple-format;
   use commands, export: all;
 
   export command-pattern-string,

--- a/sources/lib/disasm/disasm-test/library.dylan
+++ b/sources/lib/disasm/disasm-test/library.dylan
@@ -16,7 +16,7 @@ define library disasm-test
 end library;
 
 define module disasm-test
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use byte-vector;
   use format;
   use format-out;

--- a/sources/lib/disasm/library.dylan
+++ b/sources/lib/disasm/library.dylan
@@ -20,7 +20,7 @@ end library;
 
 define module disasm
   use generic-arithmetic-dylan;
-  use common-extensions, exclude: { format-to-string };
+  use common-extensions;
   use dylan-extensions, import: { <byte-character> };
   use byte-vector;
   use format;

--- a/sources/lib/dood/dood-library.dylan
+++ b/sources/lib/dood/dood-library.dylan
@@ -18,7 +18,7 @@ define library dood
 end library;
 
 define module dood
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use dylan-extensions;
   use dylan-primitives;
   use dylan-incremental;

--- a/sources/lib/dood/tests/dood-test-suite-library.dylan
+++ b/sources/lib/dood/tests/dood-test-suite-library.dylan
@@ -15,7 +15,7 @@ define library dood-test-suite
 end library;
 
 define module dood-test-suite
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use streams;
   use standard-io;
   use format;

--- a/sources/lib/lisp-reader/library.dylan
+++ b/sources/lib/lisp-reader/library.dylan
@@ -12,7 +12,7 @@ define library lisp-reader
 end library;
 
 define module lisp-reader
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use streams;
   use format;
   use standard-io;

--- a/sources/lib/llvm/llvm-asm-parser-library.dylan
+++ b/sources/lib/llvm/llvm-asm-parser-library.dylan
@@ -29,7 +29,7 @@ define module llvm-asm-parser-internals
     import: { <double-integer>, %double-integer-low, %double-integer-high,
               decode-single-float, decode-double-float,
               encode-single-float, encode-double-float };
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use streams;
   use machine-words;
   use parser-run-time;

--- a/sources/lib/llvm/llvm-library.dylan
+++ b/sources/lib/llvm/llvm-library.dylan
@@ -500,7 +500,7 @@ define module llvm-internals
               encode-single-float, encode-double-float,
               debug-name, address-of };
   use machine-word-lowlevel;
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use streams;
   use format;
   use print;

--- a/sources/lib/llvm/tests/library.dylan
+++ b/sources/lib/llvm/tests/library.dylan
@@ -19,7 +19,7 @@ define library llvm-test-suite
 end library;
 
 define module llvm-test-suite
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use testworks;
   use testworks-specs;
   use %testworks, import: { <test>, make-suite };

--- a/sources/lib/motley/library.dylan
+++ b/sources/lib/motley/library.dylan
@@ -23,7 +23,7 @@ define library motley
 end library motley;
 
 define module motley
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use com;
   use ole-automation;
   use win32-kernel;

--- a/sources/lib/parser-generator/module.dylan
+++ b/sources/lib/parser-generator/module.dylan
@@ -8,7 +8,7 @@ define module parser-generator
   use dylan;
   use dylan-extensions;
   use simple-debugging, import: { debug-out };
-  use common-extensions, exclude: { format-to-string };
+  use common-extensions;
   use streams;
   use format;
   use standard-io;

--- a/sources/lib/parser-generator/tool/module.dylan
+++ b/sources/lib/parser-generator/tool/module.dylan
@@ -6,7 +6,7 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module tool-parser-generator
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use simple-debugging, import: { debug-out };
   use date;
   use file-system;

--- a/sources/lib/parser-run-time/library.dylan
+++ b/sources/lib/parser-run-time/library.dylan
@@ -15,7 +15,7 @@ define module parser-run-time
   use common-dylan;
   use dylan-extensions,
     import: { vector-element, vector-element-setter, pointer-id? };
-  use simple-io;
+  use simple-format;
   export
     <parser>, run-parser;
 end module;

--- a/sources/lib/ppml/ppml-library.dylan
+++ b/sources/lib/ppml/ppml-library.dylan
@@ -11,7 +11,7 @@ define library ppml
 end library;
 
 define module ppml
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use streams;
   use format;
   use print;

--- a/sources/lib/release-info/module.dylan
+++ b/sources/lib/release-info/module.dylan
@@ -12,7 +12,7 @@ define module release-info
   use operating-system;
   use locators;
   use settings;
-  use simple-io;
+  use simple-format;
   use simple-xml;
   use file-source-records, import: {read-file-header};
   use file-system; // import: {file-exists?, do-directory};

--- a/sources/lib/source-records/file-source-records-library.dylan
+++ b/sources/lib/source-records/file-source-records-library.dylan
@@ -30,7 +30,7 @@ define module file-source-records
 end module;
 
 define module file-source-records-implementation
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use threads;
   use locators;
   // Probably don't need all this, sort it out later

--- a/sources/lib/source-records/source-records-library.dylan
+++ b/sources/lib/source-records/source-records-library.dylan
@@ -79,7 +79,7 @@ define module source-records
 end module;
 
 define module source-records-implementation
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use threads;
   // Probably don't need all this, sort it out later
   // use collectors;

--- a/sources/lib/ssl/examples/ssl-echo-client/library.dylan
+++ b/sources/lib/ssl/examples/ssl-echo-client/library.dylan
@@ -17,6 +17,6 @@ define module ssl-echo-client
   use dylan;
   use streams;
   use standard-io;
-  use simple-io;
+  use simple-format;
   use sockets;
 end module;

--- a/sources/lib/ssl/examples/ssl-echo-server/library.dylan
+++ b/sources/lib/ssl/examples/ssl-echo-server/library.dylan
@@ -16,7 +16,7 @@ end library;
 define module ssl-echo-server
   use dylan;
   use streams;
-  use simple-io;
+  use simple-format;
   use threads;
   use sockets;
 end module;

--- a/sources/lib/ssl/examples/ssl-smtp-server/library.dylan
+++ b/sources/lib/ssl/examples/ssl-smtp-server/library.dylan
@@ -16,7 +16,7 @@ end library;
 define module ssl-smtp-server
   use dylan;
   use streams;
-  use simple-io;
+  use simple-format;
   use threads;
   use sockets;
   use ssl-sockets;

--- a/sources/lib/t-lists/library.dylan
+++ b/sources/lib/t-lists/library.dylan
@@ -24,7 +24,7 @@ end module;
 
 // Main implementation module
 define module t-lists-internal
-  use common-dylan, exclude: {close, format-to-string};
+  use common-dylan;
   use streams;
   use print;
   use format;

--- a/sources/network/examples/daytime-client/library.dylan
+++ b/sources/network/examples/daytime-client/library.dylan
@@ -14,7 +14,7 @@ define library daytime-client
 end library;
 
 define module daytime-client
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use streams;
   use standard-io;
   use format;

--- a/sources/network/examples/daytime-server/library.dylan
+++ b/sources/network/examples/daytime-server/library.dylan
@@ -14,7 +14,7 @@ define library daytime-server
 end library;
 
 define module daytime-server
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use streams;
   use standard-io;
   use format;

--- a/sources/network/examples/echo-client/library.dylan
+++ b/sources/network/examples/echo-client/library.dylan
@@ -16,6 +16,6 @@ define module echo-client
   use dylan;
   use streams;
   use standard-io;
-  use simple-io;
+  use simple-format;
   use sockets;
 end module;

--- a/sources/network/examples/echo-server/library.dylan
+++ b/sources/network/examples/echo-server/library.dylan
@@ -15,7 +15,7 @@ end library;
 define module echo-server
   use dylan;
   use streams;
-  use simple-io;
+  use simple-format;
   use threads;
   use sockets;
 end module;

--- a/sources/network/examples/simple-daytime-client/library.dylan
+++ b/sources/network/examples/simple-daytime-client/library.dylan
@@ -14,7 +14,7 @@ define library daytime-client
 end library;
 
 define module daytime-client
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use streams;
   use standard-io;
   use format;

--- a/sources/network/examples/simple-daytime-server/library.dylan
+++ b/sources/network/examples/simple-daytime-server/library.dylan
@@ -14,7 +14,7 @@ define library daytime-server
 end library;
 
 define module daytime-server
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use streams;
   use standard-io;
   use format;

--- a/sources/network/linux-network-library.dylan
+++ b/sources/network/linux-network-library.dylan
@@ -16,7 +16,7 @@ end;
 
 define module unix-sockets
   use common-dylan,
-    exclude: { close, format-to-string };
+    exclude: { close };
   use C-FFI;
 
   // Misc
@@ -259,7 +259,7 @@ end module sockets;
 
 define module sockets-internals
   use dylan;
-  use common-extensions, exclude: { format-to-string };
+  use common-extensions;
   use dylan-extensions;
   use machine-words;
   use C-FFI;

--- a/sources/network/nntp-client/module.dylan
+++ b/sources/network/nntp-client/module.dylan
@@ -7,7 +7,7 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module nntp-client
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use streams;
   use format-out;
   use format;

--- a/sources/network/pop-client/module.dylan
+++ b/sources/network/pop-client/module.dylan
@@ -7,7 +7,7 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module pop-client
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use streams;
   use format-out;
   use format;

--- a/sources/network/tests/server/module.dylan
+++ b/sources/network/tests/server/module.dylan
@@ -8,7 +8,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module sockets-tests-server
   use common-dylan;
-  use simple-io;
+  use simple-format;
   use threads;
   use sockets;
   use date;

--- a/sources/network/unix-network-library.dylan
+++ b/sources/network/unix-network-library.dylan
@@ -16,7 +16,7 @@ end;
 
 define module unix-sockets
   use common-dylan,
-    exclude: { close, format-to-string };
+    exclude: { close };
   use C-FFI;
 
   // Misc
@@ -248,7 +248,7 @@ end module sockets;
 
 define module sockets-internals
   use dylan;
-  use common-extensions, exclude: { format-to-string };
+  use common-extensions;
   use dylan-extensions;
   use machine-words;
   use C-FFI;

--- a/sources/network/win32-network-library.dylan
+++ b/sources/network/win32-network-library.dylan
@@ -520,7 +520,7 @@ define module sockets
 end module sockets;
 
 define module sockets-internals
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use dylan-extensions;
   use machine-words;
   use C-FFI;

--- a/sources/ole/examples/asp-view/module.dylan
+++ b/sources/ole/examples/asp-view/module.dylan
@@ -7,7 +7,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module asp-view
   use dylan;
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use format;
   use streams;
   use date;

--- a/sources/ole/ole-automation/tests/parameter-type-tests/library-server.dylan
+++ b/sources/ole/ole-automation/tests/parameter-type-tests/library-server.dylan
@@ -23,7 +23,7 @@ end library parameter-type-tests-server;
 define module parameter-type-tests
   use machine-words;
   use simple-random;
-  use simple-io;
+  use simple-format;
   use big-integers;
   use generic-arithmetic-common-dylan;
   use c-ffi;

--- a/sources/ole/ole-automation/tests/parameter-type-tests/library.dylan
+++ b/sources/ole/ole-automation/tests/parameter-type-tests/library.dylan
@@ -22,7 +22,7 @@ end library parameter-type-tests;
 
 define module parameter-type-tests
   use machine-words;
-  use simple-io;
+  use simple-format;
   use simple-random;
   use big-integers;
   use generic-arithmetic-common-dylan;

--- a/sources/project-manager/projects/projects-library.dylan
+++ b/sources/project-manager/projects/projects-library.dylan
@@ -141,7 +141,7 @@ end module;
 
 define module projects-implementation
   use dylan;
-  use common-extensions, exclude: { format-to-string };
+  use common-extensions;
   use threads;
   use memory-manager;
   use build-system;
@@ -232,7 +232,7 @@ end module;
 
 define module lid-projects
   use dylan;
-  use common-extensions, exclude: { format-to-string };
+  use common-extensions;
   use simple-debugging, import: { debug-out };
   // Probably don't need all this, sort it out later...
   use locators;

--- a/sources/project-manager/tools-interface/library.dylan
+++ b/sources/project-manager/tools-interface/library.dylan
@@ -19,7 +19,7 @@ end library tools-interface;
 
 define module tools-interface
   use dylan;
-  use common-extensions, exclude: { format-to-string };
+  use common-extensions;
   use machine-words;
   use format;
   use format-out;

--- a/sources/project-manager/user-projects/library.dylan
+++ b/sources/project-manager/user-projects/library.dylan
@@ -26,7 +26,7 @@ end library;
 
 define module user-projects
   use dylan;
-  use common-extensions, exclude: { format-to-string };
+  use common-extensions;
   use threads;
   use machine-word-lowlevel,
     import: { machine-word-unsigned-shift-left, machine-word-unsigned-shift-right };

--- a/sources/qa/apps/disk-usage/library.dylan
+++ b/sources/qa/apps/disk-usage/library.dylan
@@ -17,7 +17,7 @@ end library disk-usage;
 
 define module disk-usage
   use generic-arithmetic-common-dylan;
-  use simple-io;
+  use simple-format;
   use operating-system;
   use file-system;
   use locators;

--- a/sources/runtime-manager/access-path/module.dylan
+++ b/sources/runtime-manager/access-path/module.dylan
@@ -528,7 +528,7 @@ define module access-path-nub
 end module;
 
 define module access-path-implementation
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use dylan-extensions,
      import: {<machine-word>, 
               <double-integer>, 

--- a/sources/runtime-manager/debugger-nub/debugger-server/module.dylan
+++ b/sources/runtime-manager/debugger-nub/debugger-server/module.dylan
@@ -12,7 +12,7 @@ define module debugger-server
   use threads;
   use byte-vector;
   use finalization;
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use machine-words;
   use simple-random;
   use transcendentals;

--- a/sources/runtime-manager/debugger-nub/server/module.dylan
+++ b/sources/runtime-manager/debugger-nub/server/module.dylan
@@ -12,7 +12,7 @@ define module remote-nub
   use threads;
   use byte-vector;
   use finalization;
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use machine-words;
   use simple-random;
   use transcendentals;

--- a/sources/runtime-manager/devel-dbg-ui/batch-library.dylan
+++ b/sources/runtime-manager/devel-dbg-ui/batch-library.dylan
@@ -36,7 +36,6 @@ end library;
 
 define module devel-dbg-ui
   use common-dylan,
-    exclude: { format-to-string },
     rename: { application-filename => os-application-filename };
   use dylan-extensions,
     import: { keyboard-interrupt-polling-thread?-setter };

--- a/sources/runtime-manager/devel-dbg-ui/library.dylan
+++ b/sources/runtime-manager/devel-dbg-ui/library.dylan
@@ -36,7 +36,6 @@ end library;
 
 define module devel-dbg-ui
   use common-dylan,
-    exclude: { format-to-string },
     rename: { application-filename => os-application-filename };
   use dylan-extensions,
     import: { *class-profiling-enabled?*,

--- a/sources/runtime-manager/devel-dbg-ui/mm-debugger-library.dylan
+++ b/sources/runtime-manager/devel-dbg-ui/mm-debugger-library.dylan
@@ -33,7 +33,7 @@ define library mm-debugger
 end library;
 
 define module devel-dbg-ui
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use collectors;
   use c-ffi;
   use operating-system, 

--- a/sources/runtime-manager/interactive-downloader/library-no-dfmc.dylan
+++ b/sources/runtime-manager/interactive-downloader/library-no-dfmc.dylan
@@ -21,7 +21,7 @@ define library simple-downloader
 end library;
 
 define module interactive-downloader
-  use common-dylan, exclude: { format-to-string }, rename: {table => hqnex-table};
+  use common-dylan, rename: {table => hqnex-table};
   use format;
   use format-out;
   use access-path;
@@ -37,7 +37,7 @@ define module interactive-downloader
 end module;
 
 define module interactive-downloader-internals
-  use common-dylan, exclude: { format-to-string }, rename: {table => hqnex-table};
+  use common-dylan, rename: {table => hqnex-table};
   use format;
   use format-out;
   use access-path;

--- a/sources/runtime-manager/interactive-downloader/library.dylan
+++ b/sources/runtime-manager/interactive-downloader/library.dylan
@@ -22,7 +22,7 @@ define library interactive-downloader
 end library;
 
 define module interactive-downloader
-  use common-dylan, exclude: { format-to-string }, rename: {table => hqnex-table};
+  use common-dylan, rename: {table => hqnex-table};
   use format;
   use format-out;
   use access-path;
@@ -38,7 +38,7 @@ define module interactive-downloader
 end module;
 
 define module interactive-downloader-internals
-  use common-dylan, exclude: { format-to-string }, rename: {table => hqnex-table};
+  use common-dylan, rename: {table => hqnex-table};
   use format;
   use format-out;
   use access-path;

--- a/sources/runtime-manager/interactive-symbol-table/library.dylan
+++ b/sources/runtime-manager/interactive-symbol-table/library.dylan
@@ -97,7 +97,7 @@ define module interactive-symbol-table
 end module;
 
 define module ist-implementation
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use table-extensions, import: {<string-table>};
   use format;
   use format-out;

--- a/sources/runtime-manager/remote-access-path/module.dylan
+++ b/sources/runtime-manager/remote-access-path/module.dylan
@@ -8,7 +8,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 
 define module remote-access-path
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use dylan-extensions,
      import: {<machine-word>, 
               <double-integer>, 

--- a/sources/runtime-manager/tether-downloader/library.dylan
+++ b/sources/runtime-manager/tether-downloader/library.dylan
@@ -16,7 +16,7 @@ define library tether-downloader
 end library;
 
 define module tether-downloader
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use byte-vector;
   use format;
   use access-path;
@@ -71,7 +71,7 @@ define module tether-downloader
 end module;
 
 define module tether-downloader-internals
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use byte-vector;
   use format;
   use format-out;

--- a/sources/system/library.dylan
+++ b/sources/system/library.dylan
@@ -340,7 +340,7 @@ define module settings-internals
 end module settings-internals;
 
 define module system-internals
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan;
   use dylan-extensions;
   use dylan-direct-c-ffi;
   use threads;

--- a/sources/tools/make-dylan-app/library.dylan
+++ b/sources/tools/make-dylan-app/library.dylan
@@ -8,8 +8,7 @@ define library make-dylan-app
 end library make-dylan-app;
 
 define module make-dylan-app
-  use common-dylan,
-    exclude: { format-to-string };
+  use common-dylan;
   use format-out,
     import: { format-err };
   use format,

--- a/sources/tools/map-statistics/module.dylan
+++ b/sources/tools/map-statistics/module.dylan
@@ -8,7 +8,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module map-statistics
   use common-dylan;
-  use simple-io;
+  use simple-format;
   use operating-system;
   use file-system;
   use streams;

--- a/sources/win32/win32-resources/module.dylan
+++ b/sources/win32/win32-resources/module.dylan
@@ -61,7 +61,7 @@ define module win32-resources-internal
   use win32-kernel,
     exclude: { sleep };
 
-  use simple-io;
+  use simple-format;
 
   use win32-resources;
 end module win32-resources-internal;


### PR DESCRIPTION
This is a continuation of some changes that are in the middle of being made to clean up some of the ``format-to-string`` mess in ``common-dylan``.

@housel: It would be ideal if this were tested on Win32 prior to landing.
