### PR TITLE
[llvm,run-time] Fix OS X x87 FPU exception handling.

### DIFF
--- a/sources/lib/run-time/llvm-exceptions.c
+++ b/sources/lib/run-time/llvm-exceptions.c
@@ -234,6 +234,7 @@ kern_return_t catch_mach_exception_raise_state_identity
     handler = (uintptr_t) &dylan_integer_overflow_error;
     break;
 
+  case EXC_I386_EXTERR:
   case EXC_I386_SSEEXTERR:
     // code[1] contains the floating point status word
     if (code[1] & FE_DIVBYZERO) {


### PR DESCRIPTION
* sources/lib/run-time/llvm-exceptions.c
  (catch_mach_exception_raise_state_identity): Handle EXC_I386_EXTERR
    the same as EXC_I386_SSEEXTERR. When compiling for the x87 FPU
    rather than SSE2 instructions, EXC_I386_EXTERR will happen when
    there is an FPU exception at run-time.