### PR TITLE
[dfmc] Make <&objc-msgsend> subclass <&c-function>.

### DIFF
--- a/sources/dfmc/back-end/emit-object.dylan
+++ b/sources/dfmc/back-end/emit-object.dylan
@@ -348,7 +348,7 @@ end method;
 
 define method emit-name-internal
     (back-end :: <back-end>, stream, o :: <&objc-msgsend>) => (name)
-  "objc_msgSend"
+  o.binding-name
 end method;
 
 define method emit-name-internal

--- a/sources/dfmc/c-back-end/c-emit-c-computation.dylan
+++ b/sources/dfmc/c-back-end/c-emit-c-computation.dylan
@@ -68,7 +68,7 @@ define method emit-primitive-call
     end unless;
     format-emit(b, s, d, "^", type);
   end for;
-  format(s, "))objc_msgSend%s)", f.c-modifiers);
+  format(s, "))%s)", f.binding-name);
   emit-objc-msgsend-arguments(b, s, d, f, c.arguments);
   write(s, ";");
 end method;

--- a/sources/dfmc/c-linker/c-link-c-object.dylan
+++ b/sources/dfmc/c-linker/c-link-c-object.dylan
@@ -89,7 +89,7 @@ end method;
 
 define method emit-forward
     (back-end :: <c-back-end>, stream :: <stream>, o :: <&objc-msgsend>) => ();
-  format(stream, "extern void objc_msgSend%s(void);\n", o.c-modifiers);
+  format(stream, "extern void %s(void);\n", o.binding-name);
 end;
 
 

--- a/sources/dfmc/conversion/convert-c-ffi.dylan
+++ b/sources/dfmc/conversion/convert-c-ffi.dylan
@@ -164,11 +164,13 @@ define method convert-%objc-msgsend
      signature, arguments, modifiers)
   let sig-spec = parse-primitive-signature(name, signature);
   let (ffi-signature, signature) = make-ffi-signature(sig-spec);
+  let modifiers = as-string(modifiers);
   let function
     = make(<&objc-msgsend>,
+           binding-name: format-to-string("objc_msgSend", modifiers),
            c-signature: ffi-signature,
            signature: signature,
-           c-modifiers: as-string(modifiers));
+           c-modifiers: modifiers);
   convert-primitive-call(env, context, <primitive-call>, function, arguments);
 end method;
 

--- a/sources/dfmc/debug-back-end/print-object.dylan
+++ b/sources/dfmc/debug-back-end/print-object.dylan
@@ -189,7 +189,7 @@ define method primitive-name (o :: <&primitive>) => (name)
 end method;
 
 define method primitive-name (o :: <&objc-msgsend>) => (name)
-  "objc_msgSend"
+  o.binding-name
 end method;
 
 define compiler-sideways method print-object

--- a/sources/dfmc/modeling/c-function-models.dylan
+++ b/sources/dfmc/modeling/c-function-models.dylan
@@ -43,18 +43,5 @@ define class <&c-variable> (<named-object>, <emitted-object>)
   constant slot dll-import? = #f, init-keyword: import:;
 end class <&c-variable>;
 
-define class <&objc-msgsend> (<&primitive>)
-  constant slot c-modifiers :: <string> = "",
-    init-keyword: c-modifiers:;
-  constant slot c-signature :: <&signature>,
-    init-keyword: c-signature:;
+define class <&objc-msgsend> (<&c-function>)
 end class;
-
-define method initialize
-    (x :: <&objc-msgsend>, #rest all-keys, #key, #all-keys)
-  next-method();
-  // Unlike with the built-in primitives, we err on the side of caution...
-  primitive-side-effecting?(x) := #t;
-  primitive-stateless?(x)      := #f;
-  primitive-dynamic-extent?(x) := #f;
-end method;


### PR DESCRIPTION
``<&objc-msgsend>`` now inherits from ``<&c-function>`` and uses the
same slots rather than being a separate class of its own with
duplicated slot definitions.

We also can now construct the correct function name to use
during conversion rather than at each site where the function
name is emitted in the various back-ends.

This helps with upcoming LLVM back-end support for ``<&objc-msgsend>``.

* sources/dfmc/modeling/c-function-models.dylan
  (class <&objc-msgsend>): Change base class, remove slots that
   are now inherited.
  (initialize on <&objc-msgsend>): Remove. This is the same as the
   method defined on <&c-function>.

* sources/dfmc/conversion/convert-c-ffi.dylan
  (convert-%objc-msgsend): Construct the correct binding name and
   pass it to the <&objc-msgsend> constructor.

* sources/dfmc/back-end/emit-object.dylan
  (emit-name-internal on <&objc-msgsend>): Return the binding name
   rather than the string "objc_msgSend". This likely fixes a bug
   that would have happened if an alternate objc_msgSend function
   had been requested via c-modifiers:.

* sources/dfmc/debug-back-end/print-object
  (primitive-name on <&objc-msgsend>): As above for emit-name-internal.

* sources/dfmc/c-back-end/c-emit-c-computation.dylan
  (emit-primitive-call on <&objc-msgsend>): Use binding-name rather
   than constructing the function name here.

* sources/dfmc-c-linker/c-link-c-object.dylan
  (emit-forward on <&objc-msgsend>): Use binding-name rather than
   constructing the function name here.