### PR TITLE
[dfmc] Simplify <&objc-msgsend>.

### DIFF
--- a/sources/dfmc/back-end/heaps.dylan
+++ b/sources/dfmc/back-end/heaps.dylan
@@ -2163,15 +2163,6 @@ define method maybe-claim-heap-element
   maybe-claim-c-signature-elements(heap, element.c-signature);
 end method;
 
-define method maybe-claim-heap-element
-    (heap :: <model-heap>, parent, element :: <&objc-msgsend>, ct-ref?)
-  unless (element.binding-name)
-    mark-emitted-name(heap, element);
-  end unless;
-  do-record-external-heap-element-reference(heap, element, ct-ref?);
-  maybe-claim-c-signature-elements(heap, element.c-signature);
-end method;
-
 define method maybe-claim-c-signature-elements
     (heap :: <model-heap>, sig :: <&signature>)
   for (type in ^signature-required(sig),

--- a/sources/dfmc/c-back-end/c-emit-c-computation.dylan
+++ b/sources/dfmc/c-back-end/c-emit-c-computation.dylan
@@ -13,12 +13,6 @@ end method;
 
 define method emit-call
     (b :: <c-back-end>, s :: <stream>, d :: <integer>,
-     c :: <primitive-call>, f :: <&objc-msgsend>)
-  emit-primitive-call(b, s, d, c, f);
-end method;
-
-define method emit-call
-    (b :: <c-back-end>, s :: <stream>, d :: <integer>,
      c :: <c-variable-pointer-call>, f)
   format-emit(b, s, d, "&~;", c.c-variable.name);
 end method;
@@ -69,23 +63,9 @@ define method emit-primitive-call
     format-emit(b, s, d, "^", type);
   end for;
   format(s, "))%s)", f.binding-name);
-  emit-objc-msgsend-arguments(b, s, d, f, c.arguments);
+  emit-c-function-arguments(b, s, d, f, c.arguments);
   write(s, ";");
 end method;
-
-define method emit-objc-msgsend-arguments
-    (back-end :: <c-back-end>, s :: <stream>, d :: <integer>,
-     c :: <&objc-msgsend>, arguments)
- => ()
-  write(s, "(");
-  for (arg in arguments,
-       parm in c.c-signature.^signature-required,
-       first? = #t then #f)
-    unless (first?) write(s, ", "); end;
-    emit-c-function-argument-out(back-end, s, d, arg, parm);
-  end;
-  write(s, ")");
-end;
 
 // general method
 define method emit-c-function-argument-out

--- a/sources/dfmc/flow-graph/dfm-copier.dylan
+++ b/sources/dfmc/flow-graph/dfm-copier.dylan
@@ -256,11 +256,6 @@ define method deep-copy
 end method;
 
 define method deep-copy
-    (copier :: <dfm-copier>, object :: <&objc-msgsend>) => (value)
-  maybe-do-deep-copy(copier, object)
-end method;
-
-define method deep-copy
     (copier :: <dfm-copier>, object :: <&raw-object>) => (value)
   maybe-do-deep-copy(copier, object)
 end method;


### PR DESCRIPTION
Now that ``<&objc-msgsend>`` is a subclass of ``<&c-function>``, we can
simplify some of the implementation to use existing code from
the handling of ``<&c-function>``.

* sources/dfmc/back-end/heaps.dylan
  (maybe-claim-heap-element on <&objc-msgsend>): Remove specialization.

* sources/dfmc/c-back-end/c-emit-c-computation.dylan
  (emit-call on <&objc-msgsend>): Remove specialization.
  (emit-primitive-call on <&objc-msgsend>): Update to use
    emit-c-function-arguments instead of emit-objc-msgsend-arguments.
  (emit-objc-msgsend-arguments): Remove as this was a duplicate of
    emit-c-function-arguments.

* sources/dfmc/flow-graph/dfm-copier.dylan
  (deep-copy on <&objc-msgsend>): Remove specialization.