### PR TITLE
[dfmc] Rename binding-name on <&c-function> and <&c-callable-function>.

### DIFF
--- a/sources/dfmc/back-end/emit-object.dylan
+++ b/sources/dfmc/back-end/emit-object.dylan
@@ -323,8 +323,8 @@ end method;
 
 define method emit-name-internal
     (back-end :: <back-end>, stream, o :: <&c-function>) => (name)
-  if (o.binding-name)
-    o.binding-name;
+  if (o.c-function-name)
+    o.c-function-name;
   else
     emit-anonymous-name(back-end, stream, o);
   end if;
@@ -333,8 +333,8 @@ end method;
 define method emit-name-internal
     (back-end :: <back-end>, stream, o :: <&c-callable-function>)
  => (name)
-  if (o.binding-name)
-    o.binding-name;
+  if (o.c-function-name)
+    o.c-function-name;
   else // use alternate-name
     concatenate("c_callable_", local-mangle(back-end, o.alternate-name));
   end;
@@ -348,7 +348,7 @@ end method;
 
 define method emit-name-internal
     (back-end :: <back-end>, stream, o :: <&objc-msgsend>) => (name)
-  o.binding-name
+  o.c-function-name
 end method;
 
 define method emit-name-internal

--- a/sources/dfmc/back-end/heaps.dylan
+++ b/sources/dfmc/back-end/heaps.dylan
@@ -2150,7 +2150,7 @@ end;
 
 define method maybe-claim-heap-element
     (heap :: <model-heap>, parent, element :: <&c-function>, ct-ref?)
-  unless (element.binding-name)
+  unless (element.c-function-name)
     mark-emitted-name(heap, element);
   end unless;
   do-record-external-heap-element-reference(heap, element, ct-ref?);

--- a/sources/dfmc/c-back-end/c-emit-c-computation.dylan
+++ b/sources/dfmc/c-back-end/c-emit-c-computation.dylan
@@ -21,7 +21,7 @@ end method;
 define method emit-primitive-call
     (b :: <c-back-end>, s :: <stream>, d :: <integer>,
      c :: <primitive-call>, f :: <&c-function>)
-  format-emit(b, s, d, "~", f.binding-name);
+  format-emit(b, s, d, "~", f.c-function-name);
   emit-c-function-arguments(b, s, d, f, c.arguments);
   write(s, ";");
 end method;
@@ -62,7 +62,7 @@ define method emit-primitive-call
     end unless;
     format-emit(b, s, d, "^", type);
   end for;
-  format(s, "))%s)", f.binding-name);
+  format(s, "))%s)", f.c-function-name);
   emit-c-function-arguments(b, s, d, f, c.arguments);
   write(s, ";");
 end method;

--- a/sources/dfmc/c-back-end/c-emit-c-object.dylan
+++ b/sources/dfmc/c-back-end/c-emit-c-object.dylan
@@ -6,7 +6,7 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define method external-lambda? (o :: <&c-callable-function>) => (well?)
-  o.binding-name
+  o.c-function-name
 end method;
 
 
@@ -64,7 +64,7 @@ define method emit-lambda-interface-using-function
     (back-end :: <c-back-end>, stream :: <stream>, o :: <&iep>,
      fun :: <&c-callable-function>)
  => ();
-  let global-name = fun.binding-name;
+  let global-name = fun.c-function-name;
   unless (global-name)
     write(stream, "static ");
   end;

--- a/sources/dfmc/c-linker/c-link-c-object.dylan
+++ b/sources/dfmc/c-linker/c-link-c-object.dylan
@@ -8,7 +8,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 define method emit-parameter-types
     (back-end :: <c-back-end>, stream :: <stream>, o :: <&c-function>) => ()
   format(stream, "(");
-  for (type in if (o.binding-name)
+  for (type in if (o.c-function-name)
                  o.c-signature.^signature-required
                else
                  // If there's no C name, it's an indirect function and the
@@ -32,18 +32,18 @@ define constant $generic-names-not-to-emit = #["pseudo_primitive_command_name",
 
 define method emit-forward
     (back-end :: <c-back-end>, stream :: <stream>, o :: <&c-function>) => ();
-  unless(member?(o.binding-name, $generic-names-not-to-emit, test: \=))
+  unless(member?(o.c-function-name, $generic-names-not-to-emit, test: \=))
     let sig-values = o.primitive-signature.^signature-values;
     let return-type = first(sig-values, default: dylan-value(#"<object>"));
     if (target-os-name() == #"win32")
       format-emit*(back-end, stream, "~ ^ ~ ^ ",
-                   if (o.binding-name) "extern" else "typedef" end,
+                   if (o.c-function-name) "extern" else "typedef" end,
                    return-type,
                    o.c-modifiers,
                    o);
     else
       format-emit*(back-end, stream, "~ ^ ^ ",
-                   if (o.binding-name) "extern" else "typedef" end,
+                   if (o.c-function-name) "extern" else "typedef" end,
                    return-type,
                    o);
     end if;
@@ -89,7 +89,7 @@ end method;
 
 define method emit-forward
     (back-end :: <c-back-end>, stream :: <stream>, o :: <&objc-msgsend>) => ();
-  format(stream, "extern void %s(void);\n", o.binding-name);
+  format(stream, "extern void %s(void);\n", o.c-function-name);
 end;
 
 

--- a/sources/dfmc/conversion/convert-c-ffi.dylan
+++ b/sources/dfmc/conversion/convert-c-ffi.dylan
@@ -81,7 +81,7 @@ define method convert-%c-call-function
   let (ffi-signature, signature) = make-ffi-signature(sig-spec);
   let function
     = make(<&c-function>,
-           binding-name: name & as-string(name),
+           c-function-name: name & as-string(name),
            c-signature: ffi-signature,
            signature: signature,
            c-modifiers: as-string(modifiers));
@@ -105,7 +105,7 @@ define method convert-%c-call-function-indirect
   let (ffi-signature, signature) = make-ffi-signature(sig-spec);
   let function
      = make(<&c-function>,
-            binding-name: #f,
+            c-function-name: #f,
             signature: signature,
             c-signature: ffi-signature,
             value: #f,
@@ -138,7 +138,7 @@ define method convert-%c-callable-function
   let model
     = compute-method-explicitly
         (<&c-callable-function>, #f, #f, signature-spec, body,
-         binding-name: ^top-level-eval(name),
+         c-function-name: ^top-level-eval(name),
          c-modifiers: ^top-level-eval(modifiers),
          alternate-name: as-string(other-name),
          export: export.fragment-value);
@@ -167,7 +167,7 @@ define method convert-%objc-msgsend
   let modifiers = as-string(modifiers);
   let function
     = make(<&objc-msgsend>,
-           binding-name: format-to-string("objc_msgSend", modifiers),
+           c-function-name: format-to-string("objc_msgSend", modifiers),
            c-signature: ffi-signature,
            signature: signature,
            c-modifiers: modifiers);

--- a/sources/dfmc/debug-back-end/c-debug.dylan
+++ b/sources/dfmc/debug-back-end/c-debug.dylan
@@ -5,11 +5,9 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
-// !@#$ might not be nec now that c-functions are primitives
-
 define compiler-sideways method print-object
     (o :: <&c-function>, stream :: <stream>) => ()
-  format(stream, "&[C-FUNCTION %s]", o.binding-name);
+  format(stream, "&[C-FUNCTION %s]", o.c-function-name);
 end method;
 
 // !@#$ perhaps this should be split into function-name-string

--- a/sources/dfmc/debug-back-end/print-object.dylan
+++ b/sources/dfmc/debug-back-end/print-object.dylan
@@ -188,8 +188,8 @@ define method primitive-name (o :: <&primitive>) => (name)
   end;
 end method;
 
-define method primitive-name (o :: <&objc-msgsend>) => (name)
-  o.binding-name
+define method primitive-name (o :: <&c-function>) => (name)
+  o.c-function-name
 end method;
 
 define compiler-sideways method print-object

--- a/sources/dfmc/harp-cg-linker/harp-link-object.dylan
+++ b/sources/dfmc/harp-cg-linker/harp-link-object.dylan
@@ -332,7 +332,7 @@ define method emit-extern/import
     (back-end :: <harp-back-end>, stream,
      o :: <&c-function>, import? :: <boolean>)
  => ()
-  if (o.binding-name)
+  if (o.c-function-name)
     let name = emit-name(back-end, stream, o);
     emit-extern(back-end, stream, name, unsupplied(), import?);
   end if;

--- a/sources/dfmc/harp-cg-linker/harp-linker.dylan
+++ b/sources/dfmc/harp-cg-linker/harp-linker.dylan
@@ -360,11 +360,11 @@ define method locally-defined-c-function?
   member?(object, c-functions,
           test: method (object, c-function)
                   let c-fun = c-function.function;
-                  if (object.binding-name = c-fun.binding-name)
+                  if (object.c-function-name = c-fun.c-function-name)
                     (object.c-modifiers = c-fun.c-modifiers)
                       | error("c-function %= has different calling convention "
                                 "from its c-callable-function",
-                              object.binding-name)
+                              object.c-function-name)
                     end if
                 end method)
 end method;

--- a/sources/dfmc/harp-cg/harp-emit.dylan
+++ b/sources/dfmc/harp-cg/harp-emit.dylan
@@ -554,14 +554,14 @@ end function;
 define sideways method emit-name-internal
     (back-end :: <harp-back-end>, stream, o :: <&c-callable-function>)
  => (c-name :: <string>);
-  let binding-name
-    = o.binding-name
+  let function-name
+    = o.c-function-name
     | concatenate("c_callable_", local-mangle(back-end, o.alternate-name));
   let c-emitted-name =
     select(o.c-modifiers by \=)
       "__stdcall" =>
-        stdcall-name(o.^function-signature, binding-name);
-      otherwise => c-name(back-end, binding-name);
+        stdcall-name(o.^function-signature, function-name);
+      otherwise => c-name(back-end, function-name);
     end select;
   c-emitted-name
 end method;
@@ -570,11 +570,11 @@ define sideways method emit-name-internal
     (back-end :: <harp-back-end>, stream, o :: <&c-function>)
  => (c-name :: <string>);
   let c-emitted-name =
-    if (o.binding-name)
+    if (o.c-function-name)
       select(o.c-modifiers by \=)
         "__stdcall" =>
-          stdcall-name(o.c-signature, o.binding-name);
-        otherwise => c-name(back-end, o.binding-name);
+          stdcall-name(o.c-signature, o.c-function-name);
+        otherwise => c-name(back-end, o.c-function-name);
       end select;
     else
       debug-assert(o.emitted-name, "Missing emitted-name for %s", o);

--- a/sources/dfmc/harp-cg/harp-main.dylan
+++ b/sources/dfmc/harp-cg/harp-main.dylan
@@ -23,7 +23,7 @@ define method emit-lambda(back-end :: <harp-back-end>, stream, o :: <&iep>,
     select(fun by instance?)
       <&c-callable-function> => 
 	let export? = if (fun.dll-export?) #"code-stub" else #f end;
-	values(~ fun.binding-name, export?);
+	values(~ fun.c-function-name, export?);
       <&lambda> =>
 	let public? = fun.model-has-definition?;
 	values(~ public?,

--- a/sources/dfmc/llvm-back-end/llvm-emit-computation.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-emit-computation.dylan
@@ -1064,7 +1064,7 @@ define method emit-primitive-call
     (back-end :: <llvm-back-end>, m :: <llvm-module>,
      c :: <primitive-call>, primitive :: <&c-function>)
  => ();
-  let name = primitive.binding-name;
+  let name = primitive.c-function-name;
   let calling-convention
     = llvm-c-function-calling-convention(back-end, primitive);
   let function-type = llvm-c-function-type(back-end, primitive);

--- a/sources/dfmc/llvm-linker/llvm-link-object.dylan
+++ b/sources/dfmc/llvm-linker/llvm-link-object.dylan
@@ -110,7 +110,7 @@ end method;
 define method emit-extern
     (back-end :: <llvm-back-end>, module :: <llvm-module>, o :: <&c-function>)
  => ();
-  let name = o.binding-name;
+  let name = o.c-function-name;
   if (name & ~llvm-builder-global-defined?(back-end, name))
     let calling-convention
       = llvm-c-function-calling-convention(back-end, o);
@@ -124,7 +124,7 @@ define method emit-extern
     let global
       = make(<llvm-function>,
              linkage: #"external",
-             name: primitive.binding-name,
+             name: name,
              type: llvm-pointer-to(back-end, function-type),
              arguments: args,
              calling-convention: calling-convention);

--- a/sources/dfmc/modeling/c-function-models.dylan
+++ b/sources/dfmc/modeling/c-function-models.dylan
@@ -6,10 +6,13 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
+define sealed generic c-function-name
+    (fun :: type-union(<&c-function>, <&c-callable-function>))
+ => (name :: false-or(<string>));
+
 define class <&c-function> (<&primitive>)
-  // !@#$ should be c-name
-  constant slot binding-name,
-    required-init-keyword: binding-name:;
+  constant slot c-function-name :: false-or(<string>),
+    required-init-keyword: c-function-name:;
   constant slot c-modifiers :: <string> = "",
     init-keyword: c-modifiers:;
   slot c-signature :: <&signature>,
@@ -26,10 +29,9 @@ define method initialize
 end method;
 
 define &class <c-callable-function> (<lambda>)
-  // !@#$ should be c-name
   // !@#$ should be somewhat virtual
-  constant slot binding-name,
-    required-init-keyword: binding-name:;
+  constant slot c-function-name :: false-or(<string>),
+    required-init-keyword: c-function-name:;
   constant slot c-modifiers :: <string> = "",
     init-keyword: c-modifiers:;
   slot c-signature :: <&signature>;

--- a/sources/dfmc/modeling/modeling-library.dylan
+++ b/sources/dfmc/modeling/modeling-library.dylan
@@ -734,6 +734,7 @@ define module-with-models dfmc-modeling
   export
     <&c-function>,
     <&c-callable-function>,
+      c-function-name,
       c-modifiers,
       c-signature,
       c-signature-setter,


### PR DESCRIPTION
This commit renames binding-name to c-function-name. This is a
new generic function and can be sealed to enable better error
reporting.

* sources/dfmc/modeling/c-function-models.dylan
  (generic c-function-name): New.
  (class <&c-function>): Rename binding-name slot to c-function-name
    and provide a type restriction on the slot.
  (class <&c-callable-function>: Same as for class <&c-function>.

* sources/dfmc/modeling/modeling-library.dylan:
  (module dfmc-modeling): Export c-function-name.

* sources/dfmc/back-end/emit-object.dylan
  (emit-name-internal on <&c-function>,
   emit-name-internal on <&c-callable-function>,
   emit-name-internal on <&objc-msgsend>): Change from binding-name
    to c-function-name.

* sources/dfmc/back-end/heaps.dylan
  (maybe-claim-heap-element on <&c-function>): Same.

* sources/dfmc/c-back-end/c-emit-c-computation.dylan
  (emit-primitive-call on <&c-function>,
   emit-primitive-call on <&objc-msgsend>): Same.

* sources/dfmc/c-back-end/c-emit-c-object.dylan
  (external-lambda?,
   emit-lambda-interface-using-function): Same.

* sources/dfmc/c-linker/c-link-c-object.dylan
  (emit-parameter-types on <&c-function>,
   emit-forward on <&c-function>,
   emit-forward on <&objc-msgsend>): Same.

* sources/dfmc/conversion/convert-c-ffi.dylan
  (convert-%c-call-function,
   convert-%c-call-function-indirect,
   convert-%c-callable-function,
   convert-%objc-msgsend): Same.

* sources/dfmc/debug-back-end/c-debug.dylan
  (print-object on <&c-function): Same. Also, remove comment that
    is no longer accurate now that we need a specialized function
    to get the right name.

* sources/debug-back-end/print-object.dylan
  (primitive-name on <&c-function>): New specialization replacing
    the previous specialization on <&objc-msgsend>, but now using
    c-function-name.

* sources/dfmc/harp-cg-linker/harp-link-object.dylan
  (emit-extern/import on <&c-function>): Change from binding-name
    to c-function-name.

* sources/dfmc/harp-cg-linker/harp-linker.dylan
  (locally-defined-c-function?): Same.

* sources/dfmc/harp-cg/harp-emit.dylan
  (emit-name-internal on <&c-callable-function>,
   emit-name-internal on <&c-function>): Same.

* sources/dfmc/harp-cg/harp-main.dylan
  (emit-lambda): Same.

* sources/dfmc/llvm-back-end/llvm-emit-computation.dylan
  (emit-primitive-call on <&c-function>): Same.

* sources/dfmc/llvm-linker/llvm-link-object.dylan
  (emit-extern on <&c-function>): Same. Also fix a bug where the
   binding-name was read from an incorrect object.