### PR TITLE
[common-dylan] Add float classification.

### DIFF
--- a/documentation/release-notes/source/2015.1.rst
+++ b/documentation/release-notes/source/2015.1.rst
@@ -98,6 +98,9 @@ Common Dylan
   * ``asin``, ``acos``, ``atan``
   * ``sinh``, ``cosh``, ``tanh``
   * ``asinh``, ``acosh``, ``atanh``
+* The ``common-dylan`` library now provides a ``classify-float``
+  method which will return if the given float is ``#"normal"``,
+  ``#"zero"``, ``#"infinite"``, ``#"nan"``, or ``#"subnormal"``.
 
 Compiler
 ========

--- a/sources/common-dylan/format.dylan
+++ b/sources/common-dylan/format.dylan
@@ -338,21 +338,13 @@ define function string-to-integer
   end
 end function string-to-integer;
 
-//---*** NOTE: The following function is a kludge that's needed until
-//---*** the necessary primitives are added and the Dylan library provides
-//---*** an interface.  Unfortunately, this kludge relies on a code generation
-//---*** bug which causes all NaNs to compare equal to any other value.
-//---*** When that bug is fixed, we'll need a new way to check for NaNs.
 define inline-only function nan? (float :: <float>) => (nan? :: <boolean>)
-  float = 0.0 & float = 1.0
+  classify-float(float) == #"nan"
 end function nan?;
 
-//---*** NOTE: The following function is a kludge that's needed until
-//---*** the necessary primitives are added and the Dylan library provides
-//---*** an interface.
-define inline-only function infinity? (float :: <float>) => (infinity? :: <boolean>)
-  ~zero?(float) & (float / 2.0) = float
-end function infinity?;
+define inline-only function infinite? (float :: <float>) => (infinite? :: <boolean>)
+  classify-float(float) == #"infinite"
+end function infinite?;
 
 define function float-to-string
     (float :: <float>,
@@ -379,7 +371,7 @@ define function float-to-string
         else
           format-to-string("{NaN}%c0", marker)
         end;
-      infinity?(float) =>
+      infinite?(float) =>
         let sign :: <byte-character> = if (negative?(float)) '-' else '+' end;
         if (class == <single-float>)
           format-to-string("%c{infinity}", sign)

--- a/sources/common-dylan/library.dylan
+++ b/sources/common-dylan/library.dylan
@@ -95,6 +95,8 @@ define module common-extensions
          byte-storage-address,
          byte-storage-offset-address,
          integer-length,
+         <float-classification>,
+         classify-float,
          decode-float,
          scale-float,
          float-radix,

--- a/sources/common-dylan/tests/functions.dylan
+++ b/sources/common-dylan/tests/functions.dylan
@@ -959,3 +959,37 @@ define common-extensions function-test scale-float ()
               as(<double-float>, -float-radix(1.0d0)),
               scale-float(-1.0d0, 1));
 end function-test scale-float;
+
+define inline function classify-single-float (bits)
+ => (classification :: <float-classification>)
+  classify-float(encode-single-float(as(<machine-word>, bits)))
+end function classify-single-float;
+
+define inline function classify-double-float (low-bits, high-bits)
+ => (classification :: <float-classification>)
+  classify-float(encode-double-float(as(<machine-word>, low-bits),
+                                     as(<machine-word>, high-bits)))
+end function classify-double-float;
+
+// These values came from http://www.astro.umass.edu/~weinberg/a732/notes07_01.pdf
+define common-extensions function-test classify-float ()
+  assert-equal(classify-single-float(#x00000000), #"zero");
+  assert-equal(classify-single-float(#x80000000), #"zero");
+  assert-equal(classify-single-float(#x7f800000), #"infinite");
+  assert-equal(classify-single-float(#xff800000), #"infinite");
+  assert-equal(classify-single-float(#x00000001), #"subnormal");
+  assert-equal(classify-single-float(#x007fffff), #"subnormal");
+  assert-equal(classify-single-float(#x00800000), #"normal");
+  assert-equal(classify-single-float(#x7f7fffff), #"normal");
+  assert-equal(classify-single-float(#x7fc00000), #"nan");
+
+  assert-equal(classify-double-float(#x00000000, #x00000000), #"zero");
+  assert-equal(classify-double-float(#x00000000, #x80000000), #"zero");
+  assert-equal(classify-double-float(#x00000000, #x7ff00000), #"infinite");
+  assert-equal(classify-double-float(#x00000000, #xfff00000), #"infinite");
+  assert-equal(classify-double-float(#x00000001, #x00000000), #"subnormal");
+  assert-equal(classify-double-float(#xffffffff, #x000fffff), #"subnormal");
+  assert-equal(classify-double-float(#x00000000, #x00100000), #"normal");
+  assert-equal(classify-double-float(#xffffffff, #x7fefffff), #"normal");
+  assert-equal(classify-double-float(#x00000000, #x7ff80000), #"nan");
+end function-test classify-float;

--- a/sources/common-dylan/tests/library.dylan
+++ b/sources/common-dylan/tests/library.dylan
@@ -7,6 +7,7 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define library common-dylan-test-suite
+  use dylan;
   use common-dylan;
   use testworks;
   use testworks-specs;
@@ -17,6 +18,8 @@ end library common-dylan-test-suite;
 
 define module common-dylan-test-suite
   use dylan;
+  use dylan-extensions,
+    import: { encode-single-float, encode-double-float };
   use common-extensions;
   use streams-protocol;
   use locators-protocol;

--- a/sources/common-dylan/tests/specification.dylan
+++ b/sources/common-dylan/tests/specification.dylan
@@ -12,6 +12,7 @@ define module-spec common-extensions ()
 
   function decode-float (<float>) => (<float>, <integer>, <float>);
   function scale-float (<float>, <integer>) => (<float>);
+  function classify-float (<float>) => (<float-classification>);
   function float-radix (<float>) => (<integer>);
   function float-digits (<float>) => (<integer>);
   function float-precision (<float>) => (<integer>);


### PR DESCRIPTION
Add a `classify-float` that returns whether the float is a NaN, infinite,
zero, subnormal or normal value.

* sources/common-dylan/library.dylan
  (module `common-extensions`): Export `classify-float`, `<float-classification>`.

* sources/common-dylan/numerics.dylan
  (``<float-classification>``): New.
  (`classify-float`): New.

* documentation/release-notes/source/2015.1.rst: Update.