### PR TITLE
[system,settings] Bootstrapping cleanup.

### DIFF
--- a/sources/system/library.dylan
+++ b/sources/system/library.dylan
@@ -332,11 +332,6 @@ define module settings-internals
          register-key, unregister-key,
          get-value, set-value,
          do-remove-value!;
-
-  //---*** BOOTSTRAPPING: Remove these exports and declare
-  //---*** the generics dynamic after 2.1a1 is released...
-  export invalidate-settings-caches,
-         %settings-key-name-setter;
 end module settings-internals;
 
 define module system-internals

--- a/sources/system/settings/settings.dylan
+++ b/sources/system/settings/settings.dylan
@@ -20,7 +20,6 @@ end class <settings>;
 define generic initialize-settings
     (settings :: <settings>, for-writing? :: <boolean>) => ();
 
-///---*** BOOTSTRAP: Change to dynamic and remove export after 2.1a1 is released...
 define open generic invalidate-settings-caches
     (settings :: <settings>) => ();
 
@@ -43,7 +42,6 @@ define open generic settings-key-name
     (settings :: <settings>) => (key-name :: <byte-string>);
 define open generic settings-key-name-setter
     (key-name :: <byte-string>, settings :: <settings>) => (key-name :: <byte-string>);
-///---*** BOOTSTRAP: Change to dynamic and remove export after 2.1a1 is released...
 define open generic %settings-key-name-setter
     (key-name :: <byte-string>, settings :: <settings>) => (key-name :: <byte-string>);
 


### PR DESCRIPTION
On July 30, 2001, Gary Palter added a comment for some maintenance work
that should happen once Functional Developer 2.1a1 had shipped.  It
shipped a while ago, so we can do this cleanup now.

* sources/system/library.dylan
  (module settings-internals): No longer export invalidate-settings-caches
    or %settings-key-name-setter.

* sources/system/settings/settings.dylan
  (generic invalidate-settings-caches): Mark as dynamic and not open.
  (generic %settings-key-name-setter): Mark as dynamci and not open.