### PR TITLE
Alter how the debugger-nub is linked in on Windows.

### DIFF
--- a/sources/registry/x86-win32/access-path
+++ b/sources/registry/x86-win32/access-path
@@ -1,1 +1,0 @@
-abstract://dylan/runtime-manager/access-path/win32-access-path.lid

--- a/sources/registry/x86-win32/debugger-nub
+++ b/sources/registry/x86-win32/debugger-nub
@@ -1,0 +1,1 @@
+abstract://dylan/runtime-manager/debugger-nub/x86-win32/x86-win32-debugger-nub.lid

--- a/sources/runtime-manager/access-path/library.dylan
+++ b/sources/runtime-manager/access-path/library.dylan
@@ -15,6 +15,7 @@ define library access-path
   use io;
   use system;
   use c-ffi;
+  use debugger-nub;
 
   export
     access-path, access-path-nub;

--- a/sources/runtime-manager/access-path/win32-access-path.lid
+++ b/sources/runtime-manager/access-path/win32-access-path.lid
@@ -1,9 +1,0 @@
-library:     access-path
-LID:         access-path.lid
-C-libraries: devnub.lib
-             minvcrt.lib
-             dbghelp.LIB
-Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
-              All rights reserved.
-License:      See License.txt in this distribution for details.
-Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND

--- a/sources/runtime-manager/debugger-nub/x86-win32/library.dylan
+++ b/sources/runtime-manager/debugger-nub/x86-win32/library.dylan
@@ -1,0 +1,17 @@
+Module:       dylan-user
+Synopsis:     A debugger-nub implementation using LLDB.
+Author:       Bruce Mitchener, Jr.
+Copyright:    Original Code is Copyright (c) 2015, Dylan Hackers.
+              All rights reserved.
+License:      See License.txt in this distribution for details.
+Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
+
+define library debugger-nub
+  use dylan;
+
+  export debugger-nub;
+end library debugger-nub;
+
+define module debugger-nub
+  use dylan;
+end module debugger-nub;

--- a/sources/runtime-manager/debugger-nub/x86-win32/x86-win32-debugger-nub.lid
+++ b/sources/runtime-manager/debugger-nub/x86-win32/x86-win32-debugger-nub.lid
@@ -1,0 +1,10 @@
+library:    debugger-nub
+Files:       library
+C-libraries: devnub.lib
+             minvcrt.lib
+             dbghelp.LIB
+Copyright:  Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
+            All rights reserved.
+License:    See License.txt in this distribution for details.
+Warranty:   Distributed WITHOUT WARRANTY OF ANY KIND
+


### PR DESCRIPTION
Previously, we just linked against a library on Windows and had
a custom access-path LID file to pull that library in. Instead,
we can have a debugger-nub Dylan library that knows to link
against devnub.lib and will pull that in.

* sources/registry/x86-win32/access-path: Remove as there is no
    Windows specific access-path LID file any longer.

* sources/registry/x86-win32/debugger-nub: New registry entry for
    the new debugger-nub Dylan library.

* sources/runtime-manager/access-path/library.dylan
  (library access-path): Use the new debugger-nub library to pull it in.

* sources/runtime-manager/access-path/win32-access-path.lid: Remove
    as it is no longer needed since the C libraries are pulled in
    via the debugger-nub Dylan library.

* sources/runtime-manager/debugger-nub/x86-win32/library.dylan: New.

* sources/runtime-manager/debugger-nub/x86-win32/x86-win32-debugger-nub.lid: New.