### PR TITLE
Add support for building C++ files from a LID.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -104,6 +104,7 @@ bootstrap_target=3-stage-bootstrap
 AC_SUBST(bootstrap_target)
 
 AC_PROG_CC([clang-3.5 clang gcc cc])
+AC_PROG_CXX([clang++-3.5 clang++ g++ c++])
 
 if test -n "$SUPPORT_LLVM"; then
     AC_MSG_CHECKING([whether Clang is new enough])

--- a/documentation/hacker-guide/source/build-system.rst
+++ b/documentation/hacker-guide/source/build-system.rst
@@ -229,6 +229,9 @@ component is the base name of the executable or shared library (from the
     normally used to ensure that files of various sorts (not just C header
     files) are copied into the build directory.
 
+``DylanLibraryC++Sources *image* : *sources* ;``
+    Link C++ source files into the shared library.
+
 ``DylanLibraryRCFiles *image* : *rcfiles* ;``
     Link Win32 resource files into the shared library and executable.
 

--- a/documentation/release-notes/source/2015.1.rst
+++ b/documentation/release-notes/source/2015.1.rst
@@ -37,6 +37,9 @@ Build System
   back-ends. These shouldn't be changed unless you're sure you know
   what you're doing.
 
+* A new option for building C++ code, ``c++-source-files``,  has been
+  added to LID files.  This matches the ``c-source-files:`` keyword.
+
 C-FFI
 =====
 

--- a/sources/environment/project-wizard/project-description.dylan
+++ b/sources/environment/project-wizard/project-description.dylan
@@ -547,7 +547,8 @@ define constant $project-file-header-order :: <vector>
         #"Library", #"Module",
         #"Synopsis", #"Author", #"Copyright", #"Version",
         #"Major-Version", #"Minor-Version",
-        #"Files", #"C-Header-Files", #"C-Source-Files", #"RC-Files",
+        #"Files", #"C-Header-Files", #"C-Source-Files",
+        #"C++-Source-Files", #"RC-Files",
         #"C-Libraries",        #"C-Object-Files",
         #"Linker-Options", #"Base-Address", #"Executable",
         #"Debug-Command", #"Debug-Arguments"];

--- a/sources/jamfiles/config.jam.in
+++ b/sources/jamfiles/config.jam.in
@@ -5,6 +5,8 @@
 
 CC                ?= @CC@ ;
 CCFLAGS           ?= @DISABLE_WARNINGS_CFLAGS@ @CFLAGS@ ;
+C++               ?= @CXX@ ;
+C++FLAGS          ?= $(CCFLAGS) ;
 
 MPS_CFLAGS        ?= @MPS_CFLAGS@ -DGC_USE_MPS ;
 MPS_LIBS          ?= @MPS_LIBS@ ;

--- a/sources/jamfiles/mini-jambase.jam
+++ b/sources/jamfiles/mini-jambase.jam
@@ -58,6 +58,21 @@ rule Cc
 	CCDEFS on $(<) = [ on $(<) FDefines $(DEFINES) ] ;
 }
 
+rule C++
+{
+	Depends $(<) : $(>) ;
+
+	if $(RELOCATE)
+	{
+	    CcMv $(<) : $(>) ;
+	}
+
+	C++FLAGS on $(<) += $(C++FLAGS) $(SUBDIRC++FLAGS) $(OPTIM) ;
+
+	CCHDRS on $(<) = [ on $(<) FIncludes $(HDRS) ] ;
+	CCDEFS on $(<) = [ on $(<) FDefines $(DEFINES) ] ;
+}
+
 rule Chmod
 {
 	if $(CHMOD) { Chmod1 $(<) ; }
@@ -241,6 +256,11 @@ rule FIncludes { return -I$(<) ; }
 actions Cc
 {
 	$(CC) -c -o "$(<)" $(CCFLAGS) $(CCDEFS) $(CCHDRS) "$(>)"
+}
+
+actions C++
+{
+	$(C++) -c -o "$(<)" $(C++FLAGS) $(CCDEFS) $(CCHDRS) "$(>)"
 }
 
 actions Chmod1

--- a/sources/jamfiles/posix-build.jam
+++ b/sources/jamfiles/posix-build.jam
@@ -322,6 +322,28 @@ rule DylanLibraryCSources image : sources {
   }
 }
 
+rule DylanLibraryC++Sources image : sources {
+  # DylanLibraryC++Sources image : sources ;
+  #Echo DylanLibraryC++Sources $(image) ":" $(sources) ;
+
+  # Link C++ source files into the shared library.
+  if ! $(SYSTEM) {
+    local _dll = [ FDLLName $(image) ] ;
+    local _exe = [ FEXEName $(image) ] ;
+
+    local _i ;
+    for _i in [ FGristFiles $(sources) ] {
+      SEARCH on $(_i) = $(SEARCH_SOURCE) ;
+      local _obj = [ FGristFiles $(_i:S=$(SUFOBJ)) ] ;
+      MakeLocate $(_obj) : $(LOCATE_TARGET) ;
+
+      C++ $(_obj) : $(_i) ;
+
+      LinkDLL $(_dll) : $(_obj) ;
+    }
+  }
+}
+
 rule DylanLibraryCHeaders image : headers {
   # DylanLibraryCHeaders image : headers ;
   #Echo DylanLibraryCHeaders $(image) ":" $(headers) ;

--- a/sources/jamfiles/x86-win32-pellesc-build.jam
+++ b/sources/jamfiles/x86-win32-pellesc-build.jam
@@ -6,6 +6,8 @@ CC      ?= pocc ;
 CCFLAGS ?= -DWIN32 -D_WIN32 -D_MT -D_DLL -MD -Ze
            -DOPEN_DYLAN_PLATFORM_WINDOWS
            -DOPEN_DYLAN_ARCH_X86 ;
+C++     ?= pellesc-has-no-c++compiler ;
+C++FLAGS ?= $(CCFLAGS);
 RC      ?= porc ;
 LINK    ?= polink ;
 

--- a/sources/jamfiles/x86-win32-vc6-build.jam
+++ b/sources/jamfiles/x86-win32-vc6-build.jam
@@ -6,6 +6,8 @@ CC      ?= cl /nologo ;
 CCFLAGS ?= -DWIN32 -D_WIN32 -D_MT -D_DLL -MD -Z7 -Od
            -DOPEN_DYLAN_PLATFORM_WINDOWS
            -DOPEN_DYLAN_ARCH_X86 ;
+C++     ?= $(CC) ;
+C++FLAGS ?= $(CCFLAGS) ;
 CP      ?= copy /y ;
 RC      ?= rc ;
 RM      ?= del/f/q ;
@@ -270,6 +272,30 @@ rule DylanLibraryCHeaders image : headers {
 
   # Mark the shared library as depending on the given header files.
   # TODO: The original build-system didn't do anything with this either.
+}
+
+rule DylanLibraryC++Sources image : sources {
+  # DylanLibraryC++Sources image : sources ;
+  #Echo DylanLibraryC++Sources $(image) ":" $(sources) ;
+
+  # Link C source files into the shared library.
+  if ! $(SYSTEM) {
+    local _dll = [ FDLLName $(image) ] ;
+    local _lib = [ FLIBName $(image) ] ;
+    local _exe = [ FEXEName $(image) ] ;
+
+    local _i ;
+    for _i in [ FGristFiles $(sources) ] {
+      SEARCH on $(_i) = $(SEARCH_SOURCE) ;
+      local _obj = [ FGristFiles $(_i:S=$(SUFOBJ)) ] ;
+      MakeLocate $(_obj) : $(LOCATE_TARGET) ;
+
+      C++ $(_obj) : $(_i) ;
+
+      LinkDLL $(_dll) $(_lib) : $(_obj) ;
+      LinkEXE $(_exe) : $(_obj) ;
+    }
+  }
 }
 
 rule DylanLibraryRCFiles image : rcfiles {

--- a/sources/jamfiles/x86-win32-vc8-build.jam
+++ b/sources/jamfiles/x86-win32-vc8-build.jam
@@ -6,6 +6,8 @@ CC      ?= cl /nologo ;
 CCFLAGS ?= -DWIN32 -D_WIN32 -D_MT -D_DLL -MD -Z7 -Od
            -DOPEN_DYLAN_PLATFORM_WINDOWS
            -DOPEN_DYLAN_ARCH_X86 ;
+C++     ?= $(CC) ;
+C++FLAGS ?= $(CCFLAGS) ;
 CP      ?= copy /y ;
 RC      ?= rc ;
 RM      ?= del/f/q ;
@@ -290,6 +292,33 @@ rule DylanLibraryCHeaders image : headers {
 
   # Mark the shared library as depending on the given header files.
   # TODO: The original build-system didn't do anything with this either.
+}
+
+rule DylanLibraryC++Sources image : sources {
+  # DylanLibraryC++Sources image : sources ;
+  #Echo DylanLibraryC++Sources $(image) ":" $(sources) ;
+
+  # Link C source files into the shared library.
+  if ! $(SYSTEM) {
+    local _dll = [ FDLLName $(image) ] ;
+    local _lib = [ FLIBName $(image) ] ;
+    local _exe = [ FEXEName $(image) ] ;
+
+    local _dlm = $(_dll).manifest ;
+    local _exm = $(_exe).manifest ;
+
+    local _i ;
+    for _i in [ FGristFiles $(sources) ] {
+      SEARCH on $(_i) = $(SEARCH_SOURCE) ;
+      local _obj = [ FGristFiles $(_i:S=$(SUFOBJ)) ] ;
+      MakeLocate $(_obj) : $(LOCATE_TARGET) ;
+
+      C++ $(_obj) : $(_i) ;
+
+      LinkDLL $(_dll) $(_dlm) $(_lib) : $(_obj) ;
+      LinkEXE $(_exe) $(_exm) : $(_obj) ;
+    }
+  }
 }
 
 rule DylanLibraryRCFiles image : rcfiles {

--- a/sources/lib/build-system/jam-build.dylan
+++ b/sources/lib/build-system/jam-build.dylan
@@ -24,6 +24,7 @@ define method jam-read-mkf
   // DylanLibraryCObjects image : objects ;
   // DylanLibraryCSources image : sources ;
   // DylanLibraryCHeaders image : headers ;
+  // DylanLibraryC++Sources image ; sources ;
   // DylanLibraryRCFiles image : rcfiles ;
   // DylanLibraryJamIncludes image : includes ;
   let rule-specs
@@ -35,6 +36,7 @@ define method jam-read-mkf
         #["DylanLibraryCObjects", #"c-object-files", #f],
         #["DylanLibraryCSources", #"c-source-files", #f],
         #["DylanLibraryCHeaders", #"c-header-files", #f],
+        #["DylanLibraryC++Sources", #"c++-source-files", #f],
         #["DylanLibraryRCFiles", #"rc-files", #f]];
   for (spec in rule-specs)
     let value = element(variables, spec[1], default: #());

--- a/sources/project-manager/projects/lid-projects.dylan
+++ b/sources/project-manager/projects/lid-projects.dylan
@@ -23,6 +23,7 @@ define constant $standard-lid-keyword = #[#"comment",
                                           #"c-header-files",
                                           #"c-object-files",
                                           #"c-libraries",
+                                          #"c++-source-files",
                                           #"rc-files",
                                           #"major-version",
                                           #"minor-version",
@@ -46,6 +47,7 @@ define constant $list-build-keyword = #[#"linker-options",
                                         #"c-header-files",
                                         #"c-object-files",
                                         #"c-libraries",
+                                        #"c++-source-files",
                                         #"rc-files",
                                         #"other-files",
                                         #"broken-files",
@@ -504,6 +506,8 @@ define function lid-build-settings (source-loc, properties)
   if (o-names) add-setting(c-object-files: map(source-dir, o-names)) end;
   let c-libs = element(properties, #"c-libraries", default: #f);
   if (c-libs) add-setting(c-libraries: c-libs) end;
+  let c++-names = element(properties, #"c++-source-files", default: #f);
+  if (c++-names) add-setting(c++-source-files: map(source-dir, c++-names)) end;
   let rc-names = element(properties, #"rc-files", default: #f);
   if (rc-names) add-setting(rc-files: map(source-dir, rc-names)) end;
   let jam-names = element(properties, #"jam-includes", default: #f);
@@ -616,6 +620,7 @@ define method copy-extra-records (project :: <lid-project>,
                           c-source-files = #(),
                           c-header-files = #(),
                           c-object-files = #(),
+                          c++-source-files = #(),
                           rc-files = #(),
                           jam-includes = #(),
                           c-libraries = #())
@@ -637,13 +642,14 @@ define method copy-extra-records (project :: <lid-project>,
                   end for
                 end method do-one-set;
           if (~empty?(c-source-files) | ~empty?(c-header-files) | ~empty?(c-object-files)
-                | ~empty?(rc-files) | ~empty?(jam-includes))
+                | ~empty?(c++-source-files) | ~empty?(rc-files) | ~empty?(jam-includes))
             debug-out(#"project-manager",
                       "Copying extra files for: %s",
                       project);
             do-one-set(c-source-files);
             do-one-set(c-header-files);
             do-one-set(c-object-files);
+            do-one-set(c++-source-files);
             do-one-set(rc-files);
             do-one-set(jam-includes);
           end

--- a/sources/project-manager/user-projects/add-file.dylan
+++ b/sources/project-manager/user-projects/add-file.dylan
@@ -25,7 +25,8 @@ define method project-other-sources (project :: <lid-project>)
           add-sources(filenames)
         end method add-project-filenames;
   for (key in #[#"c-source-files", #"c-header-files", #"jam-includes", #"c-object-files",
-                  #"c-libraries", #"rc-files", #"other-files", #"broken-files"])
+                  #"c-libraries", #"c++-source-files", #"rc-files", #"other-files",
+                  #"broken-files"])
     add-project-filenames(key)
   end;
   sources
@@ -100,6 +101,12 @@ define method project-add-file-of-type
     (type == $C-libraries-file-type, p :: <user-project>,
      file-locator :: <file-locator>)
   project-add-list-property(p, #"c-libraries", as(<string>, shorten-pathname(file-locator)))
+end;
+
+define method project-add-file-of-type
+    (type :: $c++-source-file-types, p :: <user-project>,
+     file-locator :: <file-locator>)
+  project-add-list-property(p, #"c++-source-files", as(<string>, file-locator))
 end;
 
 define method project-add-file-of-type
@@ -224,6 +231,13 @@ define method project-remove-file-of-type
     (type == $C-libraries-file-type, p :: <user-project>,
      file-locator :: <file-locator>)
   project-remove-list-property(p, #"c-libraries", as(<string>, file-locator))
+end;
+
+define method project-remove-file-of-type
+    (type :: $c++-source-file-types, p :: <user-project>,
+     file-locator :: <file-locator>)
+  project-remove-list-property(p, #"c++-source-files",
+                               project-relative-file(p, file-locator))
 end;
 
 define method project-remove-file-of-type

--- a/sources/project-manager/user-projects/save-project.dylan
+++ b/sources/project-manager/user-projects/save-project.dylan
@@ -21,6 +21,7 @@ define function lid-project-build-settings
      c-header-files :: <sequence>,
      c-object-files :: <sequence>,
      c-libraries :: <sequence>,
+     c++-source-files :: <sequence>,
      rc-files :: <sequence>,
      jam-includes :: <sequence>)
 
@@ -39,6 +40,7 @@ define function lid-project-build-settings
          project-build-property(p, #"c-header-files") | #[],
          project-build-property(p, #"c-object-files") | #[],
          project-build-property(p, #"c-libraries") | #[],
+         project-build-property(p, #"c++-source-files") | #[],
          project-build-property(p, #"rc-files") | #[],
          project-build-property(p, #"jam-includes") | #[])
 end function lid-project-build-settings;
@@ -140,7 +142,8 @@ define function save-lid-info
   let (executable, base-address-string,
        debug-command, debug-arguments-string, debug-machine, debug-directory,
        start-function, linker-options, c-source-files,
-       c-header-files, c-object-files, c-libraries, rc-files, jam-includes)
+       c-header-files, c-object-files, c-libraries,
+       c++-source-files, rc-files, jam-includes)
     = lid-project-build-settings(p);
   let relative = if (flatten-extras?)
                    curry(map, convert-path-to-filename)
@@ -161,6 +164,7 @@ define function save-lid-info
   save-list-value(stream, #"c-header-files", relative(c-header-files));
   save-list-value(stream, #"c-object-files", relative(c-object-files));
   save-list-value(stream, #"c-libraries", c-libraries);
+  save-list-value(stream, #"c++-source-files", relative(c++-source-files));
   save-list-value(stream, #"rc-files", relative(rc-files));
   save-list-value(stream, #"jam-includes", relative(jam-includes));
   save-single-value(stream, #"major-version", p.project-major-version);

--- a/sources/project-manager/user-projects/user-projects.dylan
+++ b/sources/project-manager/user-projects/user-projects.dylan
@@ -16,6 +16,7 @@ define constant $C-source-file-type    = #"C";
 define constant $C-header-file-type    = #"h";
 define constant $C-object-file-type    = #"obj";
 define constant $C-libraries-file-type = #"lib";
+define constant $c++-source-file-types = one-of(#"cpp", #"cxx", #"cc", #"c++");
 define constant $rc-file-type          = #"rc";
 define constant $ico-file-type         = #"ico";
 define constant $bmp-file-type         = #"bmp";


### PR DESCRIPTION
Fixes #900.

* documentation/hacker-guide/source/build-system.rst: Update to
    mention DylanLibraryCxxSources.

* documentation/release-notes/source/2015.1.rst: Mention new support.

* sources/environment/project-wizard/project-description.dylan
  ($project-file-header-order): Add #"cxx-source-files".

* sources/jamfiles/config.jam.in
  (CXX, CXXFLAGS): New variables.

* sources/jamfiles/mini-jambase.jam
  (rule Cxx, actions Cxx): New.

* sources/jamfiles/posix-build.jam:
  (rule DylanLibraryCxxSources): New.

* sources/jamfiles/x86-win32-pellesc-build.jam
  (CXX, CXXFLAGS): New variables.

* sources/jamfiles/x86-win32-vc6-build.jam
  (CXX, CXXFLAGS): New variables.
  (rule DylanLibraryCxxSources): New.

* sources/jamfiles/x86-win32-vc8-build.jam
  (CXX, CXXFLAGS): New variables.
  (rule DylanLibraryCxxSources): New.

* sources/lib/build-system/jam-build.dylan
  (jam-read-mkf): Add #"cxx-source-files" handling.

* sources/project-manager/projects/lid-projects.dylan
  ($standard-lid-keyword, $list-build-keyword): Add #"cxx-source-files".
  (copy-extra-records): Copy C++ source files.

* sources/project-manager/user-projects/add-file.dylan
  (project-other-sources): Include C++ sources.
  (project-add-file-of-type): Support C++ extensions.
  (project-remove-file-of-type): Support C++ extensions.

* sources/project-manager/user-projects/save-project.dylan
  (lid-project-build-settings): Return C++ source files.
  (save-lid-file-info): Save C++ source files.

* sources/project-manager/user-projects/user-projects.dylan
  ($cxx-source-file-types): New constant for C++ file extensions.

*