### PR TITLE
jamfiles: Update POSIX API version

### DIFF
--- a/sources/jamfiles/shared-darwin-build.jam
+++ b/sources/jamfiles/shared-darwin-build.jam
@@ -3,7 +3,7 @@
 #
 SUFDLL  ?= .dylib ;             # shared library suffix
 
-CCFLAGS  += -fno-strict-aliasing -D_POSIX_C_SOURCE
+CCFLAGS  += -fno-strict-aliasing -D_POSIX_C_SOURCE=200112L
             -DOPEN_DYLAN_PLATFORM_UNIX -DOPEN_DYLAN_PLATFORM_DARWIN ;
 
 DSYMUTIL ?= /usr/bin/dsymutil ;


### PR DESCRIPTION
As noted in Darwin's /usr/include/sys/cdefs.h, in STRICT compilation mode "A correct, portable definition for _POSIX_C_SOURCE is 200112L."
