### PR TITLE
[environment] Remove application-debug?

### DIFF
--- a/sources/environment/dfmc/application/app-server.dylan
+++ b/sources/environment/dfmc/application/app-server.dylan
@@ -263,18 +263,6 @@ define method invoke-application-callback
   callback & apply(callback, application.application-client, args)
 end method invoke-application-callback;
 
-
-///// APPLICATION-DEBUG? (Environment Protocol Method)
-//    Indicates whether the application is running for debugging purposes.
-//    TODO: Remove in favour of APPLICATION-STARTUP-OPTION.
-//          This method has been retained purely for backwards
-//          compatibility.
-
-define method application-debug?
-    (application :: <dfmc-application>) => (debug? :: <boolean>)
-  application.application-tether-status ~== #"start"
-end method;
-
 define method application-just-stepped?
     (application :: <dfmc-application>, thread :: <thread-object>)
  => (just-stepped? :: <boolean>)

--- a/sources/environment/protocols/applications.dylan
+++ b/sources/environment/protocols/applications.dylan
@@ -87,10 +87,6 @@ define open generic application-proxy-id
     (application :: <application>, proxy)
  => (id :: false-or(<id>));
 
-define open generic application-debug?
-    (server :: <server>)
- => (debug? :: <boolean>);
-
 define open generic application-pause-before-termination?
     (server :: <server>)
  => (well? :: <boolean>);
@@ -237,13 +233,6 @@ define method environment-object-home-server?
   let proxy = application-object-proxy(object);
   proxy & lookup-environment-object-by-proxy(application, proxy) & #t
 end method environment-object-home-server?;
-
-
-define method application-debug?
-    (project :: <project-object>) => (debug? :: <boolean>)
-  let application = project.project-application;
-  application & application-debug?(application);
-end method;
 
 define method application-pause-before-termination?
     (project :: <project-object>) => (pause? :: <boolean>)

--- a/sources/environment/protocols/module.dylan
+++ b/sources/environment/protocols/module.dylan
@@ -373,7 +373,6 @@ define module environment-protocols
          application-stopped?,
          application-closed?,
          application-tethered?,
-         application-debug?,
          application-pause-before-termination?,
          application-just-hit-breakpoint?,
          application-just-hit-dylan-error?,


### PR DESCRIPTION
This was flagged as a TODO item long ago for removal but was being
kept around for backwards compatibility. Nothing uses it, so it is
safe to remove now.

* sources/environment/dfmc/application/app-server.dylan
  (application-debug?): Remove method.

* sources/environment/protocols/applications.dylan
  (application-debug?): Remove generic and method.

* sources/environment/protocols/module.dylan
  (module environment-protocols): Remove export of application-debug?.