### PR TITLE
[dylan] Optimize symbol comparison when using \=.

### DIFF
--- a/documentation/release-notes/source/2015.1.rst
+++ b/documentation/release-notes/source/2015.1.rst
@@ -12,6 +12,12 @@ XXX XX, 2015.
 * `Report bugs <https://github.com/dylan-lang/opendylan/issues>`_
 * `Source code <https://github.com/dylan-lang/opendylan/tree/v2015.1>`_
 
+Dylan Standard Library
+======================
+
+* Symbol comparisons when using ``\=`` are now the same as using ``\==``
+  rather than being significantly more expensive. See `issue #899`_.
+
 Build System
 ============
 
@@ -124,3 +130,5 @@ system
   from strings for the ``<file-system-directory-locator>`` and
   ``<file-system-file-locator>`` classes. These aren't typically used but
   their omission led to possible confusion for users.
+
+.. _issue #899: https://github.com/dylan-lang/opendylan/issues/899

--- a/sources/dylan/symbol.dylan
+++ b/sources/dylan/symbol.dylan
@@ -24,7 +24,8 @@ end method as;
 
 define sealed inline method \=
     (symbol-1 :: <symbol>, symbol-2 :: <symbol>) => (well? :: <boolean>)
-  as(<string>, symbol-1) = as(<string>, symbol-2)
+  /* This is safe to do as symbols are interned. */
+  symbol-1 == symbol-2
 end method \=;
 
 define sealed inline method \<


### PR DESCRIPTION
This makes ``\=`` on ``<symbol>`` instances be the same as calling ``\==``
instead of going through costly conversions to strings, type
checks and more.

Fixes #899.

* sources/dylan/symbol.dylan
  (``\=`` on ``<symbol>``): Implement using ``\==`` rather than a conversion
    to strings and comparing the strings.

* documentation/release-notes/source/2015.1.rst: Discuss this change.