### PR TITLE
[dfmc-c-back-end] UWP needs volatile locals.

### DIFF
--- a/sources/dfmc/c-back-end/c-emit-c-object.dylan
+++ b/sources/dfmc/c-back-end/c-emit-c-object.dylan
@@ -36,15 +36,7 @@ define method emit-lambda-body-using-function
       end;
     end;
 
-    let volatile?
-      = block (result)
-          for-computations (c in o)
-            if (instance?(c, <block>) & ~c.entry-state.local-entry-state?)
-              result(#t);
-            end if;
-          end for-computations;
-          #f
-        end block;
+    let volatile? = need-volatile-locals?(o);
     for (tmp in o.environment.temporaries)
       if (used?(tmp))
         emit-local-definition(back-end, stream, tmp, volatile?);

--- a/sources/dfmc/c-back-end/c-emit-object.dylan
+++ b/sources/dfmc/c-back-end/c-emit-object.dylan
@@ -713,15 +713,7 @@ define method emit-lambda-body-using-function
      fun)
   dynamic-bind (*current-environment* = o.environment)
     write(stream, "{\n");
-    let volatile?
-      = block (result)
-          for-computations (c in o)
-            if (instance?(c, <block>) & ~c.entry-state.local-entry-state?)
-              result(#t);
-            end if;
-          end for-computations;
-          #f
-        end block;
+    let volatile? = need-volatile-locals?(o);
     for-temporary (tmp in o.environment)
       if (used?(tmp))
         emit-local-definition(back-end, stream, tmp, volatile?);


### PR DESCRIPTION
Previously, we only made locals volatile when the function
body contained a block with a non-local entry state. They
actually should be volatile if there is any ``<unwind-protect>``
involved as well.

* sources/dfmc/c-back-end/c-emit-object.dylan
  (emit-lambda-body-using-function): Factor out code and call
    ``need-volatile-locals?``.

* sources/dfmc/c-back-end/c-emit-c-object.dylan
  (emit-lambda-body-using-function): Factor out code and call
    ``need-volatile-locals?``.

* sources/dfmc/c-back-end/c-back-end.dylan
  (need-volatile-locals?): New function factored out from the
    above, but also checks for ``<unwind-protect>``.