### PR TITLE
[dfmc-c-back-end] Make cells be dylan_value*.

### DIFF
--- a/sources/dfmc/c-back-end/c-emit-computation.dylan
+++ b/sources/dfmc/c-back-end/c-emit-computation.dylan
@@ -83,6 +83,7 @@ define method emit-local-tmp-definition
   if (tmp.cell?)
     if(closed-over?(tmp))
       emit-parameter-type(back-end, stream, dylan-value(#"<object>"));
+      format-emit*(back-end, stream, "*");
     else
       emit-parameter-type(back-end, stream, cell-representation-type(tmp));
     end;

--- a/sources/lib/run-time/c-run-time.c
+++ b/sources/lib/run-time/c-run-time.c
@@ -3567,17 +3567,17 @@ dylan_value primitive_engine_node_apply_spread (ENGINE* e, dylan_value parent, i
 
 /* temporary primitives for assignment */
 
-dylan_value MAKE_DYLAN_VALUE_CELL(dylan_value value) {
-  dylan_value cell = primitive_allocate(1);
-  *(dylan_value*)cell = value;
+dylan_value* MAKE_DYLAN_VALUE_CELL(dylan_value value) {
+  dylan_value* cell = primitive_allocate(1);
+  *cell = value;
   return cell;
 }
 
 #define define_make_cell(type) \
-  dylan_value MAKE_ ## type ## _CELL(type value) { \
+  dylan_value* MAKE_ ## type ## _CELL(type value) { \
     type* cell = (type*)allocate(sizeof(type)); \
     *cell = value; \
-    return cell; \
+    return (dylan_value*)cell; \
   }
 
 define_make_cell(DBCHR)

--- a/sources/lib/run-time/run-time.h
+++ b/sources/lib/run-time/run-time.h
@@ -1913,31 +1913,31 @@ extern void  primitive_exit_application (DSINT code) NORETURN_FUNCTION;
 
 /* TEMPORARY PRIMITIVES FOR ASSIGNMENT */
 
-extern dylan_value MAKE_DYLAN_VALUE_CELL(dylan_value);
+extern dylan_value* MAKE_DYLAN_VALUE_CELL(dylan_value);
 #define GET_DYLAN_VALUE_CELL_VAL(c)       (*(dylan_value*)c)
 #define SET_DYLAN_VALUE_CELL_VAL(c, v)    (*(dylan_value*)c = v)
 
-extern dylan_value MAKE_DBCHR_CELL(DBCHR);
+extern dylan_value* MAKE_DBCHR_CELL(DBCHR);
 #define GET_DBCHR_CELL_VAL(c)           (*(DBCHR*)c)
 #define SET_DBCHR_CELL_VAL(c, v)        (*(DBCHR*)c = v)
 
-extern dylan_value MAKE_DDBYTE_CELL(DDBYTE);
+extern dylan_value* MAKE_DDBYTE_CELL(DDBYTE);
 #define GET_DDBYTE_CELL_VAL(c)          (*(DDBYTE*)c)
 #define SET_DDBYTE_CELL_VAL(c, v)       (*(DDBYTE*)c = v)
 
-extern dylan_value MAKE_DWORD_CELL(DWORD);
+extern dylan_value* MAKE_DWORD_CELL(DWORD);
 #define GET_DWORD_CELL_VAL(c)           (*(DWORD*)c)
 #define SET_DWORD_CELL_VAL(c, v)        (*(DWORD*)c = v)
 
-extern dylan_value MAKE_DDWORD_CELL(DDWORD);
+extern dylan_value* MAKE_DDWORD_CELL(DDWORD);
 #define GET_DDWORD_CELL_VAL(c)          (*(DDWORD*)c)
 #define SET_DDWORD_CELL_VAL(c, v)       (*(DDWORD*)c = v)
 
-extern dylan_value MAKE_DSFLT_CELL(DSFLT);
+extern dylan_value* MAKE_DSFLT_CELL(DSFLT);
 #define GET_DSFLT_CELL_VAL(c)           (*(DSFLT*)c)
 #define SET_DSFLT_CELL_VAL(c, v)        (*(DSFLT*)c = v)
 
-extern dylan_value MAKE_DDFLT_CELL(DDFLT);
+extern dylan_value* MAKE_DDFLT_CELL(DDFLT);
 #define GET_DDFLT_CELL_VAL(c)           (*(DDFLT*)c)
 #define SET_DDFLT_CELL_VAL(c, v)        (*(DDFLT*)c = v)
 


### PR DESCRIPTION
This improves debugging a bit when using the C back-end as now
the debugger can understand that the cell is a pointer to a
value.

This leaves things as being dylan_value that aren't really
dylan_value as the C back-end isn't as advanced as we might
wish.

* sources/dfmc/c-back-end/c-emit-computation.dylan
  (emit-local-tmp-definition): Emit a pointer type.

* sources/lib/run-time/c-run-time.c
  (MAKE_DYLAN_VALUE_CELL): Update signature.
  (define_make_cell): Update generated signature.

* sources/lib/run-time/run-time.h
  (MAKE_DYLAN_VALUE_CELL,
   MAKE_DBCHR_CELL, MAKE_DDBYTE_CELL,
   MAKE_DWORD_CELL, MAKE_DDWORD_CELL,
   MAKE_DSFLT_CELL, MAKE_DDFLT_CELL): Update signature.