### PR TITLE
Reader tests

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -451,6 +451,7 @@ CHECK_COMPILER_STAGE = $(CHECK_STAGE)
 
 CHECK_APPS = \
 	libraries-test-suite-app \
+	dfmc-reader-test-suite-app \
 	strings-test-suite-app \
 	c-ffi-test-suite-app \
 	duim-test-suite-app \

--- a/sources/dfmc/reader/reader-library.dylan
+++ b/sources/dfmc/reader/reader-library.dylan
@@ -66,6 +66,9 @@ define module dfmc-reader
   export
     <reader-error>,
       <invalid-token>,
+        <integer-too-large>,
+        <character-code-too-large>,
+        <ratios-not-supported>,
       <invalid-end-of-input>,
       <parser-error>,
       <manual-parser-error>,

--- a/sources/dfmc/reader/reader-library.dylan
+++ b/sources/dfmc/reader/reader-library.dylan
@@ -162,6 +162,7 @@ define module dfmc-reader
             <symbol-fragment>,
               <symbol-syntax-symbol-fragment>,
               <keyword-syntax-symbol-fragment>,
+            <character-fragment>,
             <string-fragment>,
             <boolean-fragment>,
               <true-fragment>,

--- a/sources/dfmc/reader/tests/dfmc-reader-test-suite-app-library.dylan
+++ b/sources/dfmc/reader/tests/dfmc-reader-test-suite-app-library.dylan
@@ -1,0 +1,13 @@
+Module: dylan-user
+License: See License.txt in this distribution for details.
+
+
+define library dfmc-reader-test-suite-app
+  use testworks;
+  use dfmc-reader-test-suite;
+end;
+
+define module dfmc-reader-test-suite-app
+  use testworks;
+  use dfmc-reader-test-suite;
+end;

--- a/sources/dfmc/reader/tests/dfmc-reader-test-suite-app.dylan
+++ b/sources/dfmc/reader/tests/dfmc-reader-test-suite-app.dylan
@@ -1,0 +1,5 @@
+Module: dfmc-reader-test-suite-app
+License: See License.txt in this distribution for details.
+
+
+run-test-application(dfmc-reader-test-suite);

--- a/sources/dfmc/reader/tests/dfmc-reader-test-suite-app.lid
+++ b/sources/dfmc/reader/tests/dfmc-reader-test-suite-app.lid
@@ -1,0 +1,3 @@
+Library: dfmc-reader-test-suite-app
+Files: dfmc-reader-test-suite-app-library
+       dfmc-reader-test-suite-app

--- a/sources/dfmc/reader/tests/dfmc-reader-test-suite-library.dylan
+++ b/sources/dfmc/reader/tests/dfmc-reader-test-suite-library.dylan
@@ -1,0 +1,19 @@
+Module: dylan-user
+License: See License.txt in this distribution for details.
+
+
+define library dfmc-reader-test-suite
+  use common-dylan;
+  use dfmc-reader;
+  use testworks;
+
+  export dfmc-reader-test-suite;
+end library dfmc-reader-test-suite;
+
+define module dfmc-reader-test-suite
+  use common-dylan;
+  use dfmc-reader;
+  use testworks;
+
+  export dfmc-reader-test-suite;
+end module dfmc-reader-test-suite;

--- a/sources/dfmc/reader/tests/dfmc-reader-test-suite-library.dylan
+++ b/sources/dfmc/reader/tests/dfmc-reader-test-suite-library.dylan
@@ -5,6 +5,8 @@ License: See License.txt in this distribution for details.
 define library dfmc-reader-test-suite
   use common-dylan;
   use dfmc-reader;
+  use dfmc-common;
+  use source-records;
   use testworks;
 
   export dfmc-reader-test-suite;
@@ -13,6 +15,8 @@ end library dfmc-reader-test-suite;
 define module dfmc-reader-test-suite
   use common-dylan;
   use dfmc-reader;
+  use dfmc-common, import { <interactive-compilation-record> };
+  use source-records, import { <interactive-source-record> };
   use testworks;
 
   export dfmc-reader-test-suite;

--- a/sources/dfmc/reader/tests/dfmc-reader-test-suite-library.dylan
+++ b/sources/dfmc/reader/tests/dfmc-reader-test-suite-library.dylan
@@ -6,6 +6,7 @@ define library dfmc-reader-test-suite
   use common-dylan;
   use dfmc-reader;
   use dfmc-common;
+  use io;
   use source-records;
   use testworks;
 
@@ -17,6 +18,7 @@ define module dfmc-reader-test-suite
   use dfmc-reader;
   use dfmc-common, import { <interactive-compilation-record> };
   use source-records, import { <interactive-source-record> };
+  use streams;
   use testworks;
 
   export dfmc-reader-test-suite;

--- a/sources/dfmc/reader/tests/dfmc-reader-test-suite.dylan
+++ b/sources/dfmc/reader/tests/dfmc-reader-test-suite.dylan
@@ -1,0 +1,10 @@
+Module: dfmc-reader-test-suite
+License: See License.txt in this distribution for details.
+
+define test skeleton-reader-test ()
+  assert-true(#t);
+end test skeleton-reader-test;
+
+define suite dfmc-reader-test-suite ()
+  test skeleton-reader-test;
+end suite dfmc-reader-test-suite;

--- a/sources/dfmc/reader/tests/dfmc-reader-test-suite.dylan
+++ b/sources/dfmc/reader/tests/dfmc-reader-test-suite.dylan
@@ -1,10 +1,6 @@
 Module: dfmc-reader-test-suite
 License: See License.txt in this distribution for details.
 
-define test skeleton-reader-test ()
-  assert-true(#t);
-end test skeleton-reader-test;
-
 define suite dfmc-reader-test-suite ()
-  test skeleton-reader-test;
+  suite literal-test-suite;
 end suite dfmc-reader-test-suite;

--- a/sources/dfmc/reader/tests/dfmc-reader-test-suite.lid
+++ b/sources/dfmc/reader/tests/dfmc-reader-test-suite.lid
@@ -1,0 +1,3 @@
+Library: dfmc-reader-test-suite
+Files: dfmc-reader-test-suite-library
+       dfmc-reader-test-suite

--- a/sources/dfmc/reader/tests/dfmc-reader-test-suite.lid
+++ b/sources/dfmc/reader/tests/dfmc-reader-test-suite.lid
@@ -1,3 +1,5 @@
 Library: dfmc-reader-test-suite
 Files: dfmc-reader-test-suite-library
+       utilities
+       literal-test-suite
        dfmc-reader-test-suite

--- a/sources/dfmc/reader/tests/literal-test-suite.dylan
+++ b/sources/dfmc/reader/tests/literal-test-suite.dylan
@@ -35,6 +35,10 @@ define test integer-literal-test ()
   verify-literal(f, 123, <integer-fragment>);
 end test integer-literal-test;
 
+define test ratio-literal-test ()
+  assert-signals(<ratios-not-supported>, read-fragment("1/2"));
+end test ratio-literal-test;
+
 define test string-literal-test ()
   let f = read-fragment("\"abc\"");
   verify-literal(f, "abc", <string-fragment>);
@@ -52,6 +56,7 @@ define suite literal-test-suite ()
   test boolean-literal-test;
   test character-literal-test;
   test integer-literal-test;
+  test ratio-literal-test;
   test string-literal-test;
   test symbol-literal-test;
 end suite literal-test-suite;

--- a/sources/dfmc/reader/tests/literal-test-suite.dylan
+++ b/sources/dfmc/reader/tests/literal-test-suite.dylan
@@ -18,7 +18,7 @@ end test boolean-literal-test;
 
 define test character-literal-test ()
   let f = read-fragment("'n'");
-  verify-literal(f, 'n', <literal-fragment>);
+  verify-literal(f, 'n', <character-fragment>);
 
   let f = read-fragment("'\\\\'");
   assert-equal(f.fragment-value, '\\');

--- a/sources/dfmc/reader/tests/literal-test-suite.dylan
+++ b/sources/dfmc/reader/tests/literal-test-suite.dylan
@@ -46,6 +46,10 @@ define test character-literal-test ()
   let f = read-fragment("'\\<01>'");
   assert-equal(as(<integer>, f.fragment-value), 1);
   verify-presentation(f, "'\\<1>'");
+
+  let f = read-fragment("'\\<fF>'");
+  assert-equal(as(<integer>, f.fragment-value), 255);
+  verify-presentation(f, "'\\<FF>'");
 end test character-literal-test;
 
 define test integer-literal-test ()

--- a/sources/dfmc/reader/tests/literal-test-suite.dylan
+++ b/sources/dfmc/reader/tests/literal-test-suite.dylan
@@ -73,6 +73,9 @@ end test ratio-literal-test;
 define test string-literal-test ()
   let f = read-fragment("\"abc\"");
   verify-literal(f, "abc", <string-fragment>);
+
+  let f = read-fragment("\"a\\nc\"");
+  verify-literal(f, "a\nc", <string-fragment>);
 end test string-literal-test;
 
 define test symbol-literal-test ()

--- a/sources/dfmc/reader/tests/literal-test-suite.dylan
+++ b/sources/dfmc/reader/tests/literal-test-suite.dylan
@@ -56,6 +56,14 @@ define test integer-literal-test ()
   let f = read-fragment("123");
   verify-literal(f, 123, <integer-fragment>);
   verify-presentation(f, "123");
+
+  let f = read-fragment("-456");
+  verify-literal(f, -456, <integer-fragment>);
+  verify-presentation(f, "-456");
+
+  let f = read-fragment("+789");
+  verify-literal(f, 789, <integer-fragment>);
+  verify-presentation(f, "789");
 end test integer-literal-test;
 
 define test ratio-literal-test ()

--- a/sources/dfmc/reader/tests/literal-test-suite.dylan
+++ b/sources/dfmc/reader/tests/literal-test-suite.dylan
@@ -1,0 +1,57 @@
+Module: dfmc-reader-test-suite
+License: See License.txt in this distribution for details.
+
+define function verify-literal
+    (f :: <fragment>, value, required-class)
+ => ()
+  assert-equal(f.fragment-value, value);
+  assert-true(instance?(f, required-class));
+end function verify-literal;
+
+define test boolean-literal-test ()
+  let t = read-fragment("#t");
+  verify-literal(t, #t, <true-fragment>);
+
+  let f = read-fragment("#f");
+  verify-literal(f, #f, <false-fragment>);
+end test boolean-literal-test;
+
+define test character-literal-test ()
+  let f = read-fragment("'n'");
+  verify-literal(f, 'n', <literal-fragment>);
+
+  let f = read-fragment("'\\\\'");
+  assert-equal(f.fragment-value, '\\');
+
+  let f = read-fragment("'\\n'");
+  assert-equal(f.fragment-value, '\n');
+
+  let f = read-fragment("'\\<01>'");
+  assert-equal(as(<integer>, f.fragment-value), 1);
+end test character-literal-test;
+
+define test integer-literal-test ()
+  let f = read-fragment("123");
+  verify-literal(f, 123, <integer-fragment>);
+end test integer-literal-test;
+
+define test string-literal-test ()
+  let f = read-fragment("\"abc\"");
+  verify-literal(f, "abc", <string-fragment>);
+end test string-literal-test;
+
+define test symbol-literal-test ()
+  let kw = read-fragment("test:");
+  verify-literal(kw, #"test", <keyword-syntax-symbol-fragment>);
+
+  let sym = read-fragment("#\"hello world\"");
+  verify-literal(sym, #"hello world", <symbol-syntax-symbol-fragment>);
+end test symbol-literal-test;
+
+define suite literal-test-suite ()
+  test boolean-literal-test;
+  test character-literal-test;
+  test integer-literal-test;
+  test string-literal-test;
+  test symbol-literal-test;
+end suite literal-test-suite;

--- a/sources/dfmc/reader/tests/literal-test-suite.dylan
+++ b/sources/dfmc/reader/tests/literal-test-suite.dylan
@@ -8,31 +8,50 @@ define function verify-literal
   assert-true(instance?(f, required-class));
 end function verify-literal;
 
+define function verify-presentation
+    (f :: <fragment>, presentation :: <string>)
+ => ()
+  let stream = make(<string-stream>, direction: #"output");
+  present-fragments(list(f), stream);
+  assert-equal(stream.stream-contents, presentation);
+end function verify-presentation;
+
 define test boolean-literal-test ()
   let t = read-fragment("#t");
   verify-literal(t, #t, <true-fragment>);
+  verify-presentation(t, "#t");
 
   let f = read-fragment("#f");
   verify-literal(f, #f, <false-fragment>);
+  verify-presentation(f, "#f");
 end test boolean-literal-test;
 
 define test character-literal-test ()
   let f = read-fragment("'n'");
   verify-literal(f, 'n', <character-fragment>);
+  verify-presentation(f, "'n'");
+
+  let f = read-fragment("'N'");
+  assert-equal(f.fragment-value, 'N');
+  verify-presentation(f, "'N'");
 
   let f = read-fragment("'\\\\'");
   assert-equal(f.fragment-value, '\\');
+  verify-presentation(f, "'\\\\'");
 
   let f = read-fragment("'\\n'");
   assert-equal(f.fragment-value, '\n');
+  verify-presentation(f, "'\\n'");
 
   let f = read-fragment("'\\<01>'");
   assert-equal(as(<integer>, f.fragment-value), 1);
+  verify-presentation(f, "'\\<1>'");
 end test character-literal-test;
 
 define test integer-literal-test ()
   let f = read-fragment("123");
   verify-literal(f, 123, <integer-fragment>);
+  verify-presentation(f, "123");
 end test integer-literal-test;
 
 define test ratio-literal-test ()
@@ -47,9 +66,11 @@ end test string-literal-test;
 define test symbol-literal-test ()
   let kw = read-fragment("test:");
   verify-literal(kw, #"test", <keyword-syntax-symbol-fragment>);
+  verify-presentation(kw, "test:");
 
   let sym = read-fragment("#\"hello world\"");
   verify-literal(sym, #"hello world", <symbol-syntax-symbol-fragment>);
+  verify-presentation(sym, "#\"hello world\"");
 end test symbol-literal-test;
 
 define suite literal-test-suite ()

--- a/sources/dfmc/reader/tests/utilities.dylan
+++ b/sources/dfmc/reader/tests/utilities.dylan
@@ -1,0 +1,23 @@
+Module: dfmc-reader-test-suite
+License: See License.txt in this distribution for details.
+
+define function make-compilation-record
+    (source :: <byte-string>)
+ => (cr :: <compilation-record>)
+  let sr = make(<interactive-source-record>,
+                project: #f,
+                module: #"scratch",
+                source: as(<byte-vector>, source));
+  let cr = make(<interactive-compilation-record>,
+                library: #f,
+                source-record: sr);
+  cr
+end function make-compilation-record;
+
+define function read-fragment
+    (source :: <byte-string>)
+ => (fragment :: <fragment>)
+  let cr = make-compilation-record(source);
+  let (fragment, new-state) = read-top-level-fragment(cr, #f);
+  fragment
+end function read-fragment;

--- a/sources/registry/generic/dfmc-reader-test-suite
+++ b/sources/registry/generic/dfmc-reader-test-suite
@@ -1,0 +1,1 @@
+abstract://dylan/dfmc/reader/tests/dfmc-reader-test-suite.lid

--- a/sources/registry/generic/dfmc-reader-test-suite-app
+++ b/sources/registry/generic/dfmc-reader-test-suite-app
@@ -1,0 +1,1 @@
+abstract://dylan/dfmc/reader/tests/dfmc-reader-test-suite-app.lid


### PR DESCRIPTION
A long time ago, @cgay had done a quick skeleton for adding ``dfmc-reader`` tests. This takes that and then adds some initial tests that start to test reading the fragments for literals.
