### PR TITLE
[dfmc-reader] <definition-tail-fragment> will never be abstract.

### DIFF
--- a/sources/dfmc/reader/fragments.dylan
+++ b/sources/dfmc/reader/fragments.dylan
@@ -1201,7 +1201,7 @@ define abstract class <definition-fragment> (<macro-call-fragment>)
     required-init-keyword: define-word:;
 end class;
 
-define /* abstract */ class <definition-tail-fragment> (<compound-fragment>)
+define class <definition-tail-fragment> (<compound-fragment>)
   constant slot fragment-end,
     required-init-keyword: end:;
   constant slot fragment-tail-name-1 = #f,


### PR DESCRIPTION
* sources/dfmc/reader/fragments.dylan
  (``<definition-tail-fragment>``): Remove commented out "abstract" adjective
   as there is no need or plan for this to be an abstract class.