### PR TITLE
[debugging] New dylan-lldb wrapper script.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -361,6 +361,7 @@ install-stage:
 	@cp -Rf $(abs_builddir)/Bootstrap.3/share/opendylan $(prefix)/share
 	@cp -R $(abs_srcdir)/tools/lldb $(prefix)/share/opendylan
 	@cp -R $(abs_srcdir)/tools/bash_completion $(prefix)/share/opendylan
+	@cp $(abs_srcdir)/tools/scripts/dylan-lldb $(prefix)/bin
 	@cp $(abs_srcdir)/License.txt $(prefix)
 	@cp $(abs_srcdir)/packages/unix/README $(prefix)
 	@echo Done!

--- a/documentation/release-notes/source/2015.1.rst
+++ b/documentation/release-notes/source/2015.1.rst
@@ -101,6 +101,18 @@ Compiler
 * The C back-end no longer generates invalid C when outputting a
   float with a value of infinity or NaN.
 
+Debugging
+=========
+
+* There is a new ``dylan-lldb`` wrapper script which can be used to
+  launch ``lldb`` and pre-load the Open Dylan LLDB integration scripts.
+  ``lldb`` is the debugger that is part of the LLVM project. It is the
+  default debugger on Mac OS X.
+
+  If you need it to launch a custom build of LLDB, you can set the
+  ``OPEN_DYLAN_LLDB`` environment variable to point to an alternative
+  ``lldb`` executable.
+
 Documentation
 =============
 

--- a/tools/scripts/dylan-lldb
+++ b/tools/scripts/dylan-lldb
@@ -1,0 +1,35 @@
+#! /bin/sh
+
+# Find some pathnames
+compiler=`which dylan-compiler`
+lldb=$OPEN_DYLAN_LLDB
+if test ! -x "$lldb"; then
+  lldb=`which lldb`
+fi
+
+# Exit if there's an error
+# We do this after finding the path names as the script
+# would exit if `which ...` failed to find something.
+set -e
+
+# Validate pathnames
+if test ! -x "$compiler"; then
+  echo "Could not find 'dylan-compiler' on the PATH."
+  exit 1
+fi
+
+if test ! -x "$lldb"; then
+  echo "Could not find 'lldb' on the PATH."
+  exit 1
+fi
+
+compilerDir="`dirname "$compiler"`"
+# Normalize the path name. Can't use realpath or readlink due to portability.
+dylanDir="`cd "${compilerDir}"/..;pwd`"
+helper=$dylanDir/share/opendylan/lldb/dylan
+if test ! -d "$helper"; then
+  echo "Could not find $helper."
+  exit 1
+fi
+
+$lldb -O "command script import $helper" "$@"


### PR DESCRIPTION
This script will start lldb with the Dylan LLDB scripts pre-loaded.
Customization of which lldb is launched can be done via the
OPEN_DYLAN_LLDB environment variable.

* Makefile.in: Install dylan-lldb.

* documentation/release-notes/source/2015.1.rst: Add release note.

* tools/scripts/dylan-lldb: New file.