### PR TITLE
[console] Remove -save command line option.

### DIFF
--- a/sources/environment/console/command-line.dylan
+++ b/sources/environment/console/command-line.dylan
@@ -55,8 +55,6 @@ define abstract class <basic-main-command> (<basic-command>)
     init-keyword: verbose?:;
   constant slot %unify? :: <boolean> = #f,
     init-keyword: unify?:;
-  constant slot %save? :: <boolean> = #t,
-    init-keyword: save?:;
   constant slot %harp?          :: <boolean> = #f,
     init-keyword: harp?:;
   constant slot %assemble?                   = #f,
@@ -96,7 +94,6 @@ define method execute-main-command
   if (build? | command.%compile?)
     run(<build-project-command>,
         clean?:      command.%clean?,
-        save?:       command.%save?,
         link?:       #f,
         release?:    command.%release?,
         verbose?:    command.%verbose?,

--- a/sources/environment/console/compiler-command-line.dylan
+++ b/sources/environment/console/compiler-command-line.dylan
@@ -46,7 +46,4 @@ define command-line main => <main-command>
   flag harp             = "generate HARP output";
   flag assemble         = "generate assembly-language output";
   flag dfm              = "generate Dylan Flow Machine output";
-
-  // Backwards-compatibility options for pentium-dw users
-  flag save             = "save compiler databases";
 end command-line main;

--- a/sources/environment/console/environment-command-line.dylan
+++ b/sources/environment/console/environment-command-line.dylan
@@ -128,7 +128,4 @@ define command-line main => <main-command>
   flag harp             = "generate HARP output";
   flag assemble         = "generate assembly-language output";
   flag dfm              = "generate Dylan Flow Machine output";
-
-  // Backwards-compatibility options for pentium-dw users
-  flag save             = "save compiler databases";
 end command-line main;


### PR DESCRIPTION
This was here for compat with pentium-dw and hasn't been needed
for years.

* sources/environment/console/command-line.dylan
  (class ``<basic-main-command>``): Remove ``%save?`` slot.
  (execute-main-command): Don't pass ``save?`` as this defaults
    to ``#t`` and we no longer allow modifying that at this point.

* sources/environment/console/compiler-command-line.dylan
  (command-line main): Remove ``save`` flag.

* sources/environment/console/environment-command-line.dylan
  (command-line main): Remove ``save`` flag.