### PR TITLE
[fdmake] Support C++-Source-Files keyword in LIDs.

### DIFF
--- a/admin/builds/fdmake.pl
+++ b/admin/builds/fdmake.pl
@@ -669,7 +669,7 @@ sub parse_header {
             # Continuation line -- part of a multi-line value
             $contents{$last_keyword} .= ' ' . $1;
         } else {
-            if(!/^([-A-Za-z0-9_!&*<>|^\$\%\@\?]+):\s*(.*)\s*$/) {
+            if(!/^([-+A-Za-z0-9_!&*<>|^\$\%\@\?]+):\s*(.*)\s*$/) {
                 print STDERR "$file:$lidfile_line: Warning: ",
                              "bad keyword line\n";
                 next;


### PR DESCRIPTION
* admin/builds/fdmake.pl
  (parse_header): '+' is a valid character in a LID header and is
    used for C++-Source-Files.