### PR TITLE
[dfmc-execution] Fix calls with rest and keyword args.

### DIFF
--- a/sources/dfmc/execution/runtime-execution.dylan
+++ b/sources/dfmc/execution/runtime-execution.dylan
@@ -623,8 +623,16 @@ end macro;
 
 define method bind-call-arguments
     (state :: <machine-state>, c :: <call>) => (args :: <simple-object-vector>)
-  let args     = make(<vector>, size: size(c.arguments) + 1);
-  args[size(args) - 1] := #[];
+  let function = fetch(state, c.function);
+  let (_required, rest?, key?) = function-arguments(function);
+  let args =
+    if (rest? | key?)
+      make(<vector>, size: size(c.arguments));
+    else
+      let args = make(<vector>, size: size(c.arguments) + 1);
+      args[size(args) - 1] := #[];
+      args
+    end if;
   map-into(args, curry(fetch, state), c.arguments);
   args
 end method;

--- a/sources/dfmc/testing/execution-tests.dylan
+++ b/sources/dfmc/testing/execution-tests.dylan
@@ -135,6 +135,22 @@ define execution-test string-size
   => 3
 end;
 
+define execution-test string-index
+  "define not-inline method f (x :: <byte-string>)\n"
+  "  x[0]\n"
+  "end;\n"
+  "f(\"abc\")"
+  => 'a'
+end;
+
+define execution-test string-concatenate
+  "define not-inline method f (fun :: <function>, x :: <byte-string>, y :: <byte-string>)\n"
+  "  apply(fun, vector(x, y))\n"
+  "end;\n"
+  "f(concatenate, \"abc\", \"def\")"
+  => "abcdef"
+end;
+
 define execution-test for-loop
   "define not-inline method f (args)\n"
   "  let sum = 0;\n"
@@ -196,6 +212,8 @@ define suite dfmc-execution-suite ()
   test execution-single-float-subtraction;
   test execution-double-float-multiplication;
   test execution-string-size;
+  test execution-string-index;
+  test execution-string-concatenate;
   test execution-for-loop;
   test execution-block-exit-1;
   test execution-block-exit-2;


### PR DESCRIPTION
* sources/dfmc/execution/runtime-execution.dylan
  (bind-call-arguments): Check for whether or not the call has
    rest or keyword arguments. If so, then the call site already
    has the rest vector prepared and we can just use it rather
    than putting our own #[] into the arguments.

* sources/dfmc/testing/execution-tests.dylan
  (execution-test string-test,
   execution-test string-concatenate): Test using rest and keyword
    arguments. The concatenate test jumps through a hoop to do an
    apply() so that code path is tested as well.
  (suite dfmc-execution-suite): Run string-test and string-concatenate
    tests.