### PR TITLE
Type display for limited integers and type unions

### DIFF
--- a/sources/common-dylan/format.dylan
+++ b/sources/common-dylan/format.dylan
@@ -764,6 +764,21 @@ define method print-specializer
 end method print-specializer;
 
 define method print-specializer
+    (buffer :: <string-buffer>, type :: <limited-collection-type>) => ()
+  print-format(buffer, "limited(%s, of: %s",
+               type.limited-collection-class,
+               type.limited-collection-element-type);
+  if (type.limited-collection-size)
+    print-format(buffer, ", size: %d", type.limited-collection-size);
+  elseif (type.limited-collection-dimensions)
+    print-string(buffer, ", dimensions: #[");
+    print-elements(buffer, type.limited-collection-dimensions);
+    print-string(buffer, "]");
+  end if;
+  print-string(buffer, ")");
+end method print-specializer;
+
+define method print-specializer
     (buffer :: <string-buffer>, type :: <limited-integer>) => ()
   print-string(buffer, "limited(<integer>");
   if (type.limited-integer-min)

--- a/sources/common-dylan/format.dylan
+++ b/sources/common-dylan/format.dylan
@@ -764,6 +764,18 @@ define method print-specializer
 end method print-specializer;
 
 define method print-specializer
+    (buffer :: <string-buffer>, type :: <limited-integer>) => ()
+  print-string(buffer, "limited(<integer>");
+  if (type.limited-integer-min)
+    print-format(buffer, ", min: %d", type.limited-integer-min);
+  end if;
+  if (type.limited-integer-max)
+    print-format(buffer, ", max: %d", type.limited-integer-max);
+  end if;
+  print-string(buffer, ")");
+end method print-specializer;
+
+define method print-specializer
     (buffer :: <string-buffer>, type :: <singleton>) => ()
   print-string(buffer, "singleton(");
   print-unique-name(buffer, singleton-object(type));

--- a/sources/common-dylan/tests/functions.dylan
+++ b/sources/common-dylan/tests/functions.dylan
@@ -640,6 +640,10 @@ define generic test-print-10 (a :: one-of(#"a", #"b")) => ();
 define generic test-print-11
     (a :: limited(<integer>, min: 0), b :: limited(<integer>, max: 64))
  => (c :: limited(<integer>, min: 0, max: 64));
+define generic test-print-12
+    (a :: limited(<vector>, of: <float>),
+     b :: limited(<vector>, of: <double-float>, size: 4))
+ => (c :: false-or(limited(<array>, of: <float>, dimensions: #[2, 2])));
 
 define method test-print-1 () => ()
 end method test-print-1;
@@ -680,6 +684,13 @@ define method test-print-11
   0
 end method test-print-11;
 
+define method test-print-12
+    (a :: limited(<vector>, of: <float>),
+     b :: limited(<vector>, of: <double-float>, size: 4))
+ => (c :: false-or(limited(<array>, of: <float>, dimensions: #[2, 2])))
+  #f
+end method test-print-12;
+
 define constant $format-function-mappings
   = vector(vector(test-print-1,
                   "{<sealed-generic-function>: test-print-1}",
@@ -713,7 +724,10 @@ define constant $format-function-mappings
                   "{<simple-method>: ??? (one-of(#\"a\", #\"b\")) => ()}"),
            vector(test-print-11,
                   "{<sealed-generic-function>: test-print-11}",
-                  "{<simple-method>: ??? (limited(<integer>, min: 0), limited(<integer>, max: 64)) => (limited(<integer>, min: 0, max: 64))}"));
+                  "{<simple-method>: ??? (limited(<integer>, min: 0), limited(<integer>, max: 64)) => (limited(<integer>, min: 0, max: 64))}"),
+           vector(test-print-12,
+                  "{<sealed-generic-function>: test-print-12}",
+                  "{<simple-method>: ??? (limited(<simple-vector>, of: <float>), limited(<simple-vector>, of: <double-float>, size: 4)) => (false-or(limited(<array>, of: <float>, dimensions: #[2, 2])))}"));
 
 define function format-function-tests
     () => ()

--- a/sources/common-dylan/tests/functions.dylan
+++ b/sources/common-dylan/tests/functions.dylan
@@ -563,7 +563,8 @@ define simple-format function-test format-to-string ()
   check-equal("format-to-string(\"%%\")",
               format-to-string("%%"),
               "%");
-  format-object-tests()
+  format-object-tests();
+  format-function-tests();
 end function-test format-to-string;
 
 define constant $format-object-mappings
@@ -625,6 +626,98 @@ define function format-object-tests
                        class-name, class-name);
   test-print-name(type, expected-name, expected-name)
 end function format-object-tests;
+
+define generic test-print-1 () => ();
+define generic test-print-2 ();
+define generic test-print-3 (a :: <integer>) => num;
+define generic test-print-4 (a :: <number>, #rest args) => (num :: <integer>);
+define generic test-print-5 (a :: <string>, #key test) => (num :: <integer>, #rest vals);
+define generic test-print-6 (a :: <string>, #key #all-keys) => (#rest vals :: <string>);
+define generic test-print-7 (a :: subclass(<string>)) => ();
+define generic test-print-8 (a :: false-or(<string>)) => ();
+define generic test-print-9 (a :: type-union(<integer>, <float>)) => ();
+define generic test-print-10 (a :: one-of(#"a", #"b")) => ();
+
+define method test-print-1 () => ()
+end method test-print-1;
+
+define method test-print-2 ()
+end method test-print-2;
+
+define method test-print-3 (a :: <integer>) => (num)
+  #f
+end method test-print-3;
+
+define method test-print-4 (a :: <number>, #rest args) => (num :: <integer>)
+  0
+end method test-print-4;
+
+define method test-print-5 (a :: <string>, #key test) => (num :: <integer>, #rest vals)
+  0
+end method test-print-5;
+
+define method test-print-6 (a :: <string>, #key #all-keys) => (#rest vals :: <string>)
+end method test-print-6;
+
+define method test-print-7 (a :: subclass(<string>)) => ()
+end method test-print-7;
+
+define method test-print-8 (a :: false-or(<string>)) => ()
+end method test-print-8;
+
+define method test-print-9 (a :: type-union(<integer>, <float>)) => ()
+end method test-print-9;
+
+define method test-print-10 (a :: one-of(#"a", #"b")) => ()
+end method test-print-10;
+
+define constant $format-function-mappings
+  = vector(vector(test-print-1,
+                  "{<sealed-generic-function>: test-print-1}",
+                  "{<simple-method>: ??? () => ()}"),
+           vector(test-print-2,
+                  "{<sealed-generic-function>: test-print-2}",
+                  "{<simple-method>: ??? () => (#rest)}"),
+           vector(test-print-3,
+                  "{<sealed-generic-function>: test-print-3}",
+                  "{<simple-method>: ??? (<integer>) => (<object>)}"),
+           vector(test-print-4,
+                  "{<sealed-generic-function>: test-print-4}",
+                  "{<simple-method>: ??? (<number>, #rest) => (<integer>)}"),
+           vector(test-print-5,
+                  "{<sealed-generic-function>: test-print-5}",
+                  "{<keyword-method>: ??? (<string>, #key test:) => (<integer>, #rest)}"),
+           vector(test-print-6,
+                  "{<sealed-generic-function>: test-print-6}",
+                  "{<keyword-method>: ??? (<string>, #key #all-keys) => (#rest <string>)}"),
+           vector(test-print-7,
+                  "{<sealed-generic-function>: test-print-7}",
+                  "{<simple-method>: ??? (subclass(<string>)) => ()}"),
+           vector(test-print-8,
+                  "{<sealed-generic-function>: test-print-8}",
+                  "{<simple-method>: ??? (false-or(<string>)) => ()}"),
+           vector(test-print-9,
+                  "{<sealed-generic-function>: test-print-9}",
+                  "{<simple-method>: ??? (type-union(<integer>, <float>)) => ()}"),
+           vector(test-print-10,
+                  "{<sealed-generic-function>: test-print-10}",
+                  "{<simple-method>: ??? (one-of(#\"a\", #\"b\")) => ()}"));
+
+define function format-function-tests
+    () => ()
+  for (mapping in $format-function-mappings)
+    let gf = mapping[0];
+    let gf-expected-text = mapping[1];
+    check-equal(format-to-string("format-to-string(\"%%=\", %s)", gf-expected-text),
+                format-to-string("%=", gf),
+                gf-expected-text);
+    let meth = generic-function-methods(gf).first;
+    let meth-expected-text = mapping[2];
+    check-equal(format-to-string("format-to-string(\"%%=\", %s)", meth-expected-text),
+                format-to-string("%=", meth),
+                meth-expected-text);
+  end for;
+end function format-function-tests;
 
 
 /// simple-random tests

--- a/sources/common-dylan/tests/functions.dylan
+++ b/sources/common-dylan/tests/functions.dylan
@@ -637,6 +637,9 @@ define generic test-print-7 (a :: subclass(<string>)) => ();
 define generic test-print-8 (a :: false-or(<string>)) => ();
 define generic test-print-9 (a :: type-union(<integer>, <float>)) => ();
 define generic test-print-10 (a :: one-of(#"a", #"b")) => ();
+define generic test-print-11
+    (a :: limited(<integer>, min: 0), b :: limited(<integer>, max: 64))
+ => (c :: limited(<integer>, min: 0, max: 64));
 
 define method test-print-1 () => ()
 end method test-print-1;
@@ -671,6 +674,12 @@ end method test-print-9;
 define method test-print-10 (a :: one-of(#"a", #"b")) => ()
 end method test-print-10;
 
+define method test-print-11
+    (a :: limited(<integer>, min: 0), b :: limited(<integer>, max: 64))
+ => (c :: limited(<integer>, min: 0, max: 64))
+  0
+end method test-print-11;
+
 define constant $format-function-mappings
   = vector(vector(test-print-1,
                   "{<sealed-generic-function>: test-print-1}",
@@ -701,7 +710,10 @@ define constant $format-function-mappings
                   "{<simple-method>: ??? (type-union(<integer>, <float>)) => ()}"),
            vector(test-print-10,
                   "{<sealed-generic-function>: test-print-10}",
-                  "{<simple-method>: ??? (one-of(#\"a\", #\"b\")) => ()}"));
+                  "{<simple-method>: ??? (one-of(#\"a\", #\"b\")) => ()}"),
+           vector(test-print-11,
+                  "{<sealed-generic-function>: test-print-11}",
+                  "{<simple-method>: ??? (limited(<integer>, min: 0), limited(<integer>, max: 64)) => (limited(<integer>, min: 0, max: 64))}"));
 
 define function format-function-tests
     () => ()

--- a/sources/dfmc/modeling/namespaces.dylan
+++ b/sources/dfmc/modeling/namespaces.dylan
@@ -844,6 +844,9 @@ define &module dylan-extensions
     <union>, union-type1, union-type2,
     <limited-integer>, limited-integer-min, limited-integer-max;
 
+  create type-union-members;
+         <type-union-classification>, classify-type-union;
+
   /// TEMPORARILY FOR METHOD DISPATCH
 
   create

--- a/sources/io/print.dylan
+++ b/sources/io/print.dylan
@@ -899,8 +899,15 @@ end method print-specializer;
 // deal with.
 //
 
+define constant <types-with-specializer-printing>
+ = type-union(<class>,
+              <limited-integer>,
+              <singleton>,
+              <subclass>,
+              <union>);
+
 define sealed method print-object
-    (object :: type-union(<singleton>, <limited-integer>, <union>), stream :: <stream>) => ()
+    (object :: <types-with-specializer-printing>, stream :: <stream>) => ()
   pprint-logical-block
     (stream,
      prefix: "{Type ",

--- a/sources/io/tests/print.dylan
+++ b/sources/io/tests/print.dylan
@@ -170,7 +170,9 @@ define constant $type-printing-tests
      vector("limited-integer max", limited(<integer>, max: 64),
             "{Type limited(<integer>, max: 64)}"),
      vector("limited-integer min-max", limited(<integer>, min: 0, max: 32),
-            "{Type limited(<integer>, min: 0, max: 32)}")
+            "{Type limited(<integer>, min: 0, max: 32)}"),
+     vector("subclass", subclass(<string>),
+            "{Type subclass(<string>)}")
    );
 
 define function test-print-types ()

--- a/sources/io/tests/print.dylan
+++ b/sources/io/tests/print.dylan
@@ -41,6 +41,7 @@ define print function-test print-to-string ()
   test-print-booleans();
   test-print-numbers();
   test-print-functions();
+  test-print-types();
   test-print-miscellaneous();
   extend-print-object();
   test-print-variables();
@@ -144,8 +145,42 @@ define function test-print-functions ()
   check-equal("method: test-print-1", print-to-string(m), "{method () => ()}");
 end function test-print-functions;
 
+define constant $type-printing-tests
+ = vector(
+     vector("<object>", <object>, "{class <object>}"),
+     vector("singleton(3)", singleton(3), "{Type singleton(3)}"),
+     vector("false-or(<integer>)", false-or(<integer>),
+            "{Type false-or(<integer>)}"),
+     vector("false-or, manual", type-union(singleton(#f), <integer>),
+            "{Type false-or(<integer>)}"),
+     vector("false-or, manual 2", type-union(<integer>, singleton(#f)),
+            "{Type false-or(<integer>)}"),
+     vector("false-or(<integer>, <float>)", false-or(<integer>, <float>),
+            "{Type false-or(<integer>, <float>)}"),
+     vector("type-union", type-union(<integer>, <string>),
+            "{Type type-union(<integer>, <string>)}"),
+     vector("type-union nested", type-union(<integer>, <string>, <float>),
+            "{Type type-union(<integer>, <string>, <float>)}"),
+     vector("one-of", one-of(1, 2, "hello"),
+            "{Type one-of(1, 2, \"hello\")}"),
+     vector("one-of symbols", one-of(#"a", #"b"),
+            "{Type one-of(#\"a\", #\"b\")}"),
+     vector("limited-integer min", limited(<integer>, min: 0),
+            "{Type limited(<integer>, min: 0)}"),
+     vector("limited-integer max", limited(<integer>, max: 64),
+            "{Type limited(<integer>, max: 64)}"),
+     vector("limited-integer min-max", limited(<integer>, min: 0, max: 32),
+            "{Type limited(<integer>, min: 0, max: 32)}")
+   );
+
+define function test-print-types ()
+  for (type-test in $type-printing-tests)
+    check-print(type-test[0], type-test[1]);
+    check-equal(type-test[0], print-to-string(type-test[1]), type-test[2]);
+  end for;
+end function test-print-types;
+
 define function test-print-miscellaneous ()
-  check-print("<object>", <object>);
   check-print("class", <test-class>);
   check-print("make(class)", make(<test-class>));
   check-print("list", #(1, 2, 3));
@@ -153,12 +188,6 @@ define function test-print-miscellaneous ()
   check-print("function", add);
   check-print("range", range(from: 10, by: 2, to: 20));
   check-print("symbol", #"symbol");
-
-  // common types/specializers
-  check-print("singleton(3)", singleton(3));
-  check-print("false-or(<integer>)", false-or(<integer>));
-  check-print("limited <integer>", limited(<integer>, min: 0, max: 255));
-  check-print("type-union", type-union(<integer>, <string>));
 end function test-print-miscellaneous;
 
 // extend-print-object


### PR DESCRIPTION
This is another step along the way to having the IO module's printing code handle Dylan constructs better / more readably.