### PR TITLE
[dfmc-optimization] Mark some warnings as abstract.

### DIFF
--- a/sources/dfmc/optimization/dispatch.dylan
+++ b/sources/dfmc/optimization/dispatch.dylan
@@ -1573,7 +1573,7 @@ define method check-maybe-mv-call-compatibility
   check-call-compatibility(f, call, arg-te*);
 end method;
 
-define serious-program-warning <incompatible-call>
+define abstract serious-program-warning <incompatible-call>
   slot condition-function,
     required-init-keyword: function:;
 end serious-program-warning;
@@ -1601,7 +1601,7 @@ define program-warning <unknown-keyword-in-call> (<incompatible-call>)
     function, supplied-keyword, known-keywords;
 end program-warning;
 
-define program-warning <argument-count-mismatch-in-call> (<incompatible-call>)
+define abstract program-warning <argument-count-mismatch-in-call> (<incompatible-call>)
   slot condition-supplied-count,
     required-init-keyword: supplied-count:;
   slot condition-required-count,


### PR DESCRIPTION
* ``sources/dfmc/optimization/dispatch.dylan``
  (``<incompatible-call>``): Mark as abstract, both because it should
    be and because marking ``<argument-count-mismatch-in-call>`` as
    abstract requires that this be abstract.
  (``<argument-count-mismatch-in-call>``): Mark as abstract as it
    shouldn't be instantiated directly. It has subclasses for
    the various scenarios which provide the error message.