### PR TITLE
[coloring-stream] Handle colorize-stream on coloring stream.

### DIFF
--- a/documentation/library-reference/source/coloring-stream/index.rst
+++ b/documentation/library-reference/source/coloring-stream/index.rst
@@ -104,6 +104,12 @@ The COLORING-STREAM module
      text to :var:`*standard-output*` or when writing a network server
      where the user may have an ANSI-capable client.
 
+     When called on a :class:`<coloring-stream>`, if *force-ansi?* is
+     set and the stream is not an ANSI coloring stream, then the stream
+     will be unwrapped and a new ANSI coloring stream wrapper will
+     be created. Otherwise, calling ``colorize-stream`` on a
+     :class:`<coloring-stream>` will return the same stream.
+
    :example:
 
      .. code-block:: dylan

--- a/sources/lib/coloring-stream/coloring-stream.dylan
+++ b/sources/lib/coloring-stream/coloring-stream.dylan
@@ -39,6 +39,11 @@ define method coloring-stream-class-for-stream
   end if
 end method coloring-stream-class-for-stream;
 
+define generic colorize-stream
+    (stream :: <stream>,
+     #key force-ansi?)
+ => (coloring-stream :: <coloring-stream>);
+
 define method colorize-stream
     (stream :: <stream>,
      #key force-ansi? = #f)
@@ -48,6 +53,30 @@ define method colorize-stream
   else
     make(<coloring-stream>, inner-stream: stream)
   end if
+end;
+
+define method colorize-stream
+    (stream :: <coloring-stream>,
+     #key force-ansi? = #f)
+ => (coloring-stream :: <coloring-stream>)
+  if (force-ansi?)
+    // This isn't an <ansi-coloring-stream>, so unwrap and rewrap.
+    // We know it isn't an <ansi-coloring-stream> because if it were,
+    // we'd be in the other method that is specialized on that.
+    make(<ansi-coloring-stream>,
+         inner-stream: stream.inner-stream)
+  else
+    stream
+  end if
+end;
+
+define method colorize-stream
+    (stream :: <ansi-coloring-stream>,
+     #key force-ansi? = #f)
+ => (coloring-stream :: <coloring-stream>)
+  // We're already an ANSI coloring stream, so we can ignore this.
+  ignore(force-ansi?);
+  stream
 end;
 
 define method stream-supports-color?

--- a/sources/lib/coloring-stream/tests/coloring-stream-test-suite.dylan
+++ b/sources/lib/coloring-stream/tests/coloring-stream-test-suite.dylan
@@ -57,13 +57,22 @@ define coloring-stream function-test colorize-stream ()
   let c = colorize-stream(*standard-output*);
   check-instance?("colorize-stream(file stream) returns a <coloring-stream>",
                   <coloring-stream>, c);
+
   let string-stream = make(<byte-string-stream>, direction: #"output");
   let c = colorize-stream(string-stream);
   check-instance?("colorize-stream(string stream) returns a <null-coloring-stream>",
                   <null-coloring-stream>, c);
+  let f = colorize-stream(c, force-ansi?: #t);
+  check-instance?("colorize-stream can be forced to rewrap as ansi stream",
+                  <ansi-coloring-stream>, f);
+  check-equal("colorize-stream on coloring stream returns same",
+              c, colorize-stream(c));
+
   let c = colorize-stream(string-stream, force-ansi?: #t);
   check-instance?("colorize-stream can be forced to return an ansi stream",
                   <ansi-coloring-stream>, c);
+  check-equal("colorize-stream on ansi coloring stream returns same",
+              c, colorize-stream(c));
 end function-test colorize-stream;
 
 define function encode-to-ansi (attributes :: false-or(<text-attributes>))


### PR DESCRIPTION
When calling colorize-stream on a coloring stream, the existing code
was returning a ``<null-coloring-stream>``, thereby removing any coloring.

* documentation/library-reference/source/coloring-stream/index.rst
  (colorize-stream): Document new behavior.

* sources/lib/coloring-stream/coloring-stream.dylan
  (colorize-stream): Define generic and 2 new specializations.

* sources/lib/coloring-stream/tests/coloring-stream-test-suite.dylan
  (function-test colorize-stream): Test new behavior.