### PR TITLE
dfmc-modeling: Preserve <primitive> signature specifications

### DIFF
--- a/sources/dfmc/conversion/convert-c-ffi.dylan
+++ b/sources/dfmc/conversion/convert-c-ffi.dylan
@@ -91,6 +91,7 @@ define method convert-%c-call-function
            c-function-name: name & as-string(name),
            c-signature: ffi-signature,
            signature: signature,
+           signature-spec: sig-spec,
            c-modifiers: as-string(modifiers));
   convert-primitive-call(env, context, <primitive-call>, function, arguments);
 end method;
@@ -117,6 +118,7 @@ define method convert-%c-call-function-indirect
      = make(<&c-function>,
             c-function-name: #f,
             signature: signature,
+            signature-spec: sig-spec,
             c-signature: ffi-signature,
             value: #f,
             c-modifiers: as-string(modifiers));
@@ -182,6 +184,7 @@ define method convert-%objc-msgsend
            c-function-name: format-to-string("objc_msgSend", modifiers),
            c-signature: ffi-signature,
            signature: signature,
+           signature-spec: sig-spec,
            c-modifiers: modifiers);
   convert-primitive-call(env, context, <primitive-call>, function, arguments);
 end method;

--- a/sources/dfmc/conversion/define-primitive.dylan
+++ b/sources/dfmc/conversion/define-primitive.dylan
@@ -10,12 +10,13 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define compiler-sideways method compute-form-model-object
     (form :: <primitive-definition>, variable-name :: <variable-name-fragment>)
-      => (model)
-  let signature
-    = compute-signature(form, form-signature(form));
+ => (model)
+  let signature-spec = form-signature(form);
+  let signature = compute-signature(form, signature-spec);
   let primitive
     =  make(<&primitive>,
             signature:       signature,
+            signature-spec:  signature-spec,
             getter-name:     as(<symbol>, variable-name),
             side-effecting?: form.form-primitive-side-effecting?,
             stateless?:      form.form-primitive-stateless?,

--- a/sources/dfmc/modeling/modeling-library.dylan
+++ b/sources/dfmc/modeling/modeling-library.dylan
@@ -721,6 +721,7 @@ define module-with-models dfmc-modeling
     <&primitive>,
       primitive-value,
       primitive-signature,
+      primitive-signature-spec,
       primitive-descriptor-getter-name,
       primitive-side-effecting?,
       primitive-dynamic-extent?,

--- a/sources/dfmc/modeling/raw-types.dylan
+++ b/sources/dfmc/modeling/raw-types.dylan
@@ -12,6 +12,8 @@ define virtual-compiler-model-class <primitive> (<callable-object>, <object>) (<
     init-keyword: getter-name:;
   constant slot primitive-signature :: <&signature>,
     init-keyword: signature:;
+  lazy constant slot primitive-signature-spec :: <signature-spec>,
+    init-value: #f, init-keyword: signature-spec:;
   constant slot primitive-value = #f,
     init-keyword: value:;
   slot primitive-properties :: <integer> = 0;


### PR DESCRIPTION
Preserve signature-spec information for <primitive> and <c-function>
models so that parameter names can be included in error messages
concerning them.

* sources/dfmc/modeling/raw-types.dylan
  (primitive-signature-spec): New slot added to <primitive>.

* sources/dfmc/modeling/modeling-library.dylan
  (module dfmc-modeling): Export primitive-signature-spec.

* sources/dfmc/conversion/define-primitive.dylan
  (compute-form-model-object on <primitive-definition>): Preserve the
   signature-spec when constructing the <primitive> model.

* sources/dfmc/conversion/convert-c-ffi.dylan
  (convert-%c-call-function, convert-%c-call-function-indirect,
   convert-%objc-msgsend): Preserve the signature-spec when
   constructing the respective model.