### PR TITLE
[configure] Handle MPS config for LLVM run-time.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -168,6 +168,12 @@ AC_ARG_WITH(mps,
                           [Memory Pool System (MPS) source directory]))
 
 AS_IF([test -n "$SUPPORT_HARP" && test x$HARP_COLLECTOR = xMPS],
+      [VALIDATE_MPS=yes])
+
+AS_IF([test -n "$SUPPORT_LLVM" && test x$LLVM_COLLECTOR = xMPS],
+      [VALIDATE_MPS=yes])
+
+AS_IF([test -n "$VALIDATE_MPS"],
       [MPS_CFLAGS="-I${with_mps}/code"
        MPS_LIBS=
        save_CPPFLAGS="$CPPFLAGS"


### PR DESCRIPTION
While we don't yet support MPS for the LLVM run-time, we can at
least handle it correctly in an undocumented fashion.

* configure.ac: Validate MPS and set up the correct variables for
  both HARP and LLVM run-times when it has been requested.