### PR TITLE
[dfmc-llvm-back-end] Add %running-dylan-spy-function?.

### DIFF
--- a/sources/dfmc/llvm-back-end/llvm-primitives-debug.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-primitives-debug.dylan
@@ -56,3 +56,11 @@ define c-callable auxiliary &runtime-primitive-descriptor class-allocation-break
   ins--call-intrinsic(be, "llvm.debugtrap", #[]);
   emit-reference(be, module, &false)
 end;
+
+// %running-dylan-spy-function? is a variable that indicates
+// whether or not the debugger is executing a function via the spy thread.
+// By default it is set to 0. The Dylan debugger will set it to something
+// else if it is executing code within the app.
+//
+define runtime-variable %running-dylan-spy-function? :: <raw-integer>
+  = make-raw-literal(0);


### PR DESCRIPTION
%running-dylan-spy-function? is a variable which indicates
whether that the debugger is executing a function via the spy thread.
By default it is set to 0. The Dylan debugger will set it to something
else if it is executing code within the app.

The HARP run-time provides this and some code within the collector
requires it to exist when building the MPS collector.

* sources/dfmc/llvm-back-end/llvm-primitives-spy.dylan
  (%running-dylan-spy-function?): Define new runtime-variable.

* sources/dfmc/llvm-back-end/llvm-back-end.lid: Build new file.