### PR TITLE
[run-time] Move dylan_main to own file.

### DIFF
--- a/sources/lib/run-time/Makefile.win32
+++ b/sources/lib/run-time/Makefile.win32
@@ -38,7 +38,7 @@ CC	 = $(cc)
 LINKLIB	 = $(implib) /nologo /out:
 CFLAGS	 = $(cflags) $(cvarsmt) $(cdebug) /I$(INCLUDEDEST) /I. /I.. /I$(SDK4MEMORY_POOL_SYSTEM)\code $(OPEN_DYLAN_C_FLAGS) /DOPEN_DYLAN_PLATFORM_WINDOWS /DGC_USE_MPS /DOPEN_DYLAN_ARCH_X86 /DOPEN_DYLAN_BACKEND_HARP
 HEAPOBJS = heap-display.obj heap-utils.obj heap-trail.obj heap-order1.obj heap-order2.obj heap-table.obj
-OBJS	 = collector.obj break.obj $(HEAPOBJS) harp-support\x86-windows\runtime.obj windows-threads-primitives.obj windows-spy-interfaces.obj
+OBJS	 = collector.obj break.obj $(HEAPOBJS) harp-support\x86-windows\runtime.obj windows-threads-primitives.obj windows-spy-interfaces.obj windows-harp-support.obj
 LIBFILE	 = pentium-run-time.lib
 USEROBJ	 = harp-support\x86-windows\dylan-support.obj
 USERLIB	 = dylan-support.lib
@@ -166,7 +166,7 @@ install: ensure-dirs install-stripped install-build
 # Only delete the products that should be built by this makefile.
 # (The files runtime.obj & dylan-support.obj are checked out from HOPE)
 clean:
-	pushd . & (del /f /q *collector.obj break.obj $(HEAPOBJS) windows-threads-primitives.obj windows-spy-interfaces.obj) & popd
+	pushd . & (del /f /q *collector.obj break.obj $(HEAPOBJS) windows-threads-primitives.obj windows-spy-interfaces.obj windows-harp-support.obj) & popd
         pushd . & (del /f /q *pentium-run-time.lib $(USERLIB)) & popd
         pushd . & (del /f /q $(MINCRT) mincrt.def) & popd
         pushd . & (del /f /q $(DYLANPLINTH) $(PLINTHOBJS)) & popd

--- a/sources/lib/run-time/collector.c
+++ b/sources/lib/run-time/collector.c
@@ -632,18 +632,6 @@ void *wrapper_class(void *wrapper)
   return class;
 }
 
-#ifndef OPEN_DYLAN_PLATFORM_UNIX
-
-extern void dylan_main ();
-
-int main ()
-{
-  dylan_main();
-  return 0;
-}
-
-#endif
-
 #ifndef OPEN_DYLAN_BACKEND_LLVM
 #include "exceptions.c"
 #endif

--- a/sources/lib/run-time/windows-harp-support.c
+++ b/sources/lib/run-time/windows-harp-support.c
@@ -1,0 +1,7 @@
+extern void dylan_main ();
+
+int main ()
+{
+  dylan_main();
+  return 0;
+}


### PR DESCRIPTION
This was only needed on Windows and with HARP, so move it out
to remove some #ifdef-ery.

* sources/lib/run-time/collector.c
  (dylan_main): Move this to own file.

* sources/lib/run-time/windows-harp-support.c
  (dylan_main): New home.

* sources/lib/run-time/Makefile.win32: Build windows-harp-support.c