### PR TITLE
[coloring-stream] Start to improve Windows support.

### DIFF
--- a/sources/lib/coloring-stream/coloring-stream.dylan
+++ b/sources/lib/coloring-stream/coloring-stream.dylan
@@ -33,7 +33,15 @@ define method coloring-stream-class-for-stream
     (stream :: <file-stream>)
  => (coloring-stream-class :: <class>)
   if (stream-supports-color?(stream))
-    <ansi-coloring-stream>
+    if ($os-name == #"win32")
+      if (environment-variable("ConEmuANSI") = "ON")
+        <ansi-coloring-stream>
+      else
+        <windows-coloring-stream>
+      end if
+    else
+      <ansi-coloring-stream>
+    end if
   else
     <null-coloring-stream>
   end if
@@ -102,3 +110,12 @@ define method print-object
  => ()
   ignore(attributes, stream);
 end method print-object;
+
+// We define this here so that it is present on all platforms,
+// but we define the print-object method for it elsewhere so
+// that it is Windows only.
+define class <windows-coloring-stream> (<coloring-stream>)
+end class <windows-coloring-stream>;
+
+define sealed domain make(singleton(<windows-coloring-stream>));
+define sealed domain initialize(<windows-coloring-stream>);

--- a/sources/lib/coloring-stream/library.dylan
+++ b/sources/lib/coloring-stream/library.dylan
@@ -43,7 +43,7 @@ define module coloring-stream-internals
   use common-dylan;
   use streams;
   use streams-internals, import { stream-console? };
-  use operating-system, import { environment-variable };
+  use operating-system, import { environment-variable, $os-name };
   use print, import: { print-object };
   use coloring-stream, export all;
 

--- a/sources/lib/coloring-stream/windows-coloring-stream.dylan
+++ b/sources/lib/coloring-stream/windows-coloring-stream.dylan
@@ -1,0 +1,13 @@
+Module:    coloring-stream-internals
+Author:    Bruce Mitchener, Jr.
+Copyright: Original Code is Copyright 2015 Dylan Hackers.
+           All rights reserved.
+License:   See License.txt in this distribution for details.
+Warranty:  Distributed WITHOUT WARRANTY OF ANY KIND
+
+define method print-object
+    (attributes :: <text-attributes>,
+     stream :: <windows-coloring-stream>)
+ => ()
+  ignore(attributes, stream);
+end method print-object;

--- a/sources/lib/coloring-stream/windows-coloring-stream.lid
+++ b/sources/lib/coloring-stream/windows-coloring-stream.lid
@@ -1,0 +1,13 @@
+Library:      coloring-stream
+Target-Type:  dll
+Files:        library
+              text-color
+              text-attributes
+              coloring-stream
+              ansi-coloring-stream
+              windows-coloring-stream
+Copyright:    Original Code is Copyright 2015 Dylan Hackers.
+              All rights reserved.
+License:      See License.txt in this distribution for details.
+Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
+

--- a/sources/registry/x86-win32/coloring-stream
+++ b/sources/registry/x86-win32/coloring-stream
@@ -1,0 +1,1 @@
+abstract://dylan/lib/coloring-stream/windows-coloring-stream.lid


### PR DESCRIPTION
* sources/lib/coloring-stream/coloring-stream.dylan
  (coloring-stream-class-for-stream): On Windows, if running under
    ConEmu (like with cmder), return an ANSI stream, otherwise
    return a Windows coloring stream.
  (``<windows-coloring-stream>``): Define new class to anchor setting
    text attributes on Windows. This is here so that it is available
    everywhere to simplify code in coloring-stream-class-for-stream.

* sources/lib/coloring-stream/library.dylan
  (module coloring-stream-internals): Import $os-name.

* sources/lib/coloring-stream/windows-coloring-stream.dylan
  (print-object): Provide null implementation for now.

* sources/lib/coloring-stream/windows-coloring-stream.lid: Build
  windows-coloring-stream.dylan on Windows so that the implementation
  of print-object is available.

* sources/registry/x86-win32/coloring-stream: Point to the new
  windows-coloring-stream.lid.