### PR TITLE
[dfmc-conversion] Improve runtime message for missing init keyword.

### DIFF
--- a/sources/dfmc/conversion/define-class.dylan
+++ b/sources/dfmc/conversion/define-class.dylan
@@ -585,7 +585,7 @@ define method compute-slot-initialization-code
                   (class, slotd);
             #{ ?keyword ?name = ?init }
           elseif (^init-keyword-required?(slotd))
-            #{ ?keyword ?name = error("Missing init keyword %=", ?keyword) }
+            #{ ?keyword ?name = error("Missing init keyword \"%=:\"", ?keyword) }
           else
             #{ ?keyword ?name = ?$unbound }
           end;


### PR DESCRIPTION
Prior to this change, the error looked like:

  Error: Missing init keyword specializer

After:

  Error: Missing init keyword "specializer:"

* sources/dfmc/conversion/define-class.dylan
  (compute-slot-initialization-code): Improve error text.