### PR TITLE
[dfmc-c-linker] Fix indirect C-functions.

### DIFF
--- a/documentation/release-notes/source/2015.1.rst
+++ b/documentation/release-notes/source/2015.1.rst
@@ -112,6 +112,10 @@ Compiler
   used have been fixed. These are typically edge cases like ``+.5``
   or ``-3d3`` rather than commonly used literal notations.
 
+* The C back-end correctly handles indirect C-functions (where a
+  function pointer is given to be invoked rather than a direct
+  function call).
+
 Debugging
 =========
 

--- a/sources/dfmc/c-linker/c-link-c-object.dylan
+++ b/sources/dfmc/c-linker/c-link-c-object.dylan
@@ -8,20 +8,18 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 define method emit-parameter-types
     (back-end :: <c-back-end>, stream :: <stream>, o :: <&c-function>) => ()
   format(stream, "(");
-  for (type in if (o.c-function-name)
-                 o.c-signature.^signature-required
-               else
-                 // If there's no C name, it's an indirect function and the
-                 // first parameter is actually the function itself.
-                 //---*** Better: Add a slot to <&c-function> or a <&c-indirect-function>
-                 copy-sequence(o.c-signature.^signature-required, start: 1)
-               end,
-       first? = #t then #f)
-    unless (first?)
-      format(stream, ", ");
-    end unless;
-    format-emit*(back-end, stream, "^", type);
-  end for;
+  let required = o.c-signature.^signature-required;
+  if (empty?(required))
+    format(stream, "void");
+  else
+    for (type in required,
+         first? = #t then #f)
+      unless (first?)
+        format(stream, ", ");
+      end unless;
+      format-emit*(back-end, stream, "^", type);
+    end for;
+  end if;
   format(stream, ")");
 end method;
 

--- a/sources/lib/c-ffi/test/main.c
+++ b/sources/lib/c-ffi/test/main.c
@@ -244,14 +244,34 @@ int mix_it_up(int *a)
 
 /* for c-function-indirect test */
 
-int a_function(int a)
+int a_function_0(void)
+{
+  return(5);
+}
+
+int (*gimme_a_function_0(void))(void)
+{
+  return(a_function_0);
+}
+
+int a_function_1(int a)
 {
   return(a);
 }
 
-int (*gimme_a_function())()
+int (*gimme_a_function_1(int a))(void)
 {
-  return(a_function);
+  return(a_function_1);
+}
+
+int a_function_2(int a, int b)
+{
+  return(a + b);
+}
+
+int (*gimme_a_function_2(int a, int b))(void)
+{
+  return(a_function_2);
 }
 
 

--- a/sources/lib/c-ffi/test/tests.dylan
+++ b/sources/lib/c-ffi/test/tests.dylan
@@ -1013,21 +1013,47 @@ end;
 // -------------
 // tests for indirect: option to define c-function
 
-define c-function call-indirect
+define c-function call-indirect-0
+  indirect: #t;
+  result val :: <C-int>;
+end;
+
+define c-function gimme-a-function-0
+  result fun :: <C-function-pointer>;
+  c-name: "gimme_a_function_0";
+end;
+
+define c-function call-indirect-1
   indirect: #t;
   parameter param1 :: <C-int>;
   result val :: <C-int>;
 end;
 
-define c-function gimme-a-function
+define c-function gimme-a-function-1
   result fun :: <C-function-pointer>;
-  c-name: "gimme_a_function";
+  c-name: "gimme_a_function_1";
+end;
+
+define c-function call-indirect-2
+  indirect: #t;
+  parameter param1 :: <C-int>;
+  parameter param2 :: <C-int>;
+  result val :: <C-int>;
+end;
+
+define c-function gimme-a-function-2
+  result fun :: <C-function-pointer>;
+  c-name: "gimme_a_function_2";
 end;
 
 
 define test c-function-indirect ()
-  let fun = gimme-a-function();
-  check-equal("c-function indirect option", call-indirect(fun, 7), 7);
+  let fun-0 = gimme-a-function-0();
+  let fun-1 = gimme-a-function-1();
+  let fun-2 = gimme-a-function-2();
+  check-equal("c-function indirect option, 0 args", call-indirect-0(fun-0), 5);
+  check-equal("c-function indirect option, 1 arg",  call-indirect-1(fun-1, 7), 7);
+  check-equal("c-function indirect option, 2 args", call-indirect-2(fun-2, 4, 5), 9);
 end;
 
 


### PR DESCRIPTION
Prior to this commit, indirect C-functions only worked on the C back-end
when they had a single parameter. If they had no parameters, then dylan-compiler
would error, and if they had 2 or more, then the generated C would be incorrect
and result in a C compiler error.

Fixes #990. Fixes #991.

* sources/dfmc/c-linker/c-link-c-object.dylan
  (emit-parameter-types): Emit all of the required parameters, even
   if it is indirect as the function pointer won't be present in this
   required parameter list. Also, handle having no required parameters
   and correctly generating "(void)" as the parameter list rather than
   "()" which means the wrong thing in C.