### PR TITLE
[io] buffered-stream generics specialize on <buffered-stream>.

### DIFF
--- a/documentation/release-notes/source/2015.1.rst
+++ b/documentation/release-notes/source/2015.1.rst
@@ -145,6 +145,9 @@ IO
   output has been added. See ``<indented-stream>``, ``indent``, and
   ``with-indentation`` in the ``streams`` module.
 
+* Some generic functions that apply to ``<buffered-stream>`` have had
+  their signatures tightened.
+
 Runtime
 =======
 

--- a/sources/io/library.dylan
+++ b/sources/io/library.dylan
@@ -240,6 +240,7 @@ define module streams-internals
 
   // "High performance"
   export \copy-down-stream-definer,
+         \copy-down-buffered-stream-definer,
          read-skip,
          write-fill;
 

--- a/sources/io/streams/buffered-stream.dylan
+++ b/sources/io/streams/buffered-stream.dylan
@@ -116,7 +116,7 @@ end function next-input-buffer;
 // Look for interesting methods under <double-buffered-stream> and
 // <file-stream> and <multi-buffered-stream>
 define open generic do-next-input-buffer
-    (stream :: <stream>, #key wait?, bytes)
+    (stream :: <buffered-stream>, #key wait?, bytes)
  => (buffer :: false-or(<buffer>));
 
 // This can only be called when 'stream-input-buffer' has a buffer in it
@@ -128,7 +128,7 @@ define inline function release-input-buffer
 end function release-input-buffer;
 
 define open generic do-release-input-buffer
-    (stream :: <stream>) => ();
+    (stream :: <buffered-stream>) => ();
 
 define method do-release-input-buffer
     (stream :: <buffered-stream>) => ()
@@ -143,7 +143,7 @@ define inline function input-available-at-source?
 end function input-available-at-source?;
 
 define open generic do-input-available-at-source?
-    (stream :: <stream>)
+    (stream :: <buffered-stream>)
  => (input-available? :: <boolean>);
 
 define method do-input-available-at-source?
@@ -185,7 +185,7 @@ end function get-output-buffer;
 
 // No default method for this
 define open generic do-get-output-buffer
-    (stream :: <stream>, #key bytes)
+    (stream :: <buffered-stream>, #key bytes)
  => (buffer :: false-or(<buffer>));
 
 
@@ -206,7 +206,7 @@ define inline function release-output-buffer
 end function release-output-buffer;
 
 define open generic do-release-output-buffer
-    (stream :: <stream>) => ();
+    (stream :: <buffered-stream>) => ();
 
 define method do-release-output-buffer
     (stream :: <buffered-stream>) => ()
@@ -491,10 +491,10 @@ define method do-force-output
 end method do-force-output;
 
 define open generic force-output-buffers
-    (stream :: <stream>) => ();
+    (stream :: <buffered-stream>) => ();
 
 define open generic do-force-output-buffers
-    (stream :: <stream>) => ();
+    (stream :: <buffered-stream>) => ();
 
 define method discard-output
     (stream :: <buffered-stream>) => ()

--- a/sources/io/streams/file-stream.dylan
+++ b/sources/io/streams/file-stream.dylan
@@ -58,10 +58,10 @@ define open class <byte-file-stream>
 end class;
 
 /*---*** andrewa: how can we get these to work?
-define copy-down-stream <byte-char-file-stream>
+define copy-down-buffered-stream <byte-char-file-stream>
    element <byte-character> sequence <byte-string>;
 
-define copy-down-stream <byte-file-stream>
+define copy-down-buffered-stream <byte-file-stream>
    element <byte> sequence <byte-string>;
 */
 

--- a/sources/io/streams/native-speed.dylan
+++ b/sources/io/streams/native-speed.dylan
@@ -8,13 +8,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define macro copy-down-stream-definer
   { define copy-down-stream ?:name element ?elt:name sequence ?seq:name }
-    => { define sealed domain do-get-input-buffer (?name);
-         define sealed domain do-next-input-buffer (?name);
-         define sealed domain do-release-input-buffer (?name);
-         define sealed domain do-get-output-buffer (?name);
-         define sealed domain do-next-output-buffer (?name);
-         define sealed domain do-release-output-buffer (?name);
-         define sealed domain coerce-to-element
+    => { define sealed domain coerce-to-element
            (?name, <buffer>, <integer>);
          define sealed domain coerce-from-element
            (?name, <buffer>, <integer>, <object>);
@@ -71,6 +65,18 @@ define macro copy-down-stream-definer
              (stream :: ?name, n :: <integer>, seq :: ?seq,
               #key start :: <integer> = 0, on-end-of-stream = unsupplied())
           => (n-read) }
+end macro;
+
+define macro copy-down-buffered-stream-definer
+  { define copy-down-buffered-stream ?:name element ?elt:name sequence ?seq:name }
+    => { define sealed domain do-get-input-buffer (?name);
+         define sealed domain do-next-input-buffer (?name);
+         define sealed domain do-release-input-buffer (?name);
+         define sealed domain do-get-output-buffer (?name);
+         define sealed domain do-next-output-buffer (?name);
+         define sealed domain do-release-output-buffer (?name);
+         define copy-down-stream ?name element ?elt sequence ?seq;
+       }
 end macro;
 
 define copy-down-stream <byte-string-stream>


### PR DESCRIPTION
Some of the generics related to buffered streams were defined for
``<stream>`` rather than ``<buffered-stream>``. In addition,
``copy-down-stream-definer`` was creating definitions for both regular
and buffered streams, which was not valid for the single use of
this macro (on ``<byte-string-stream>`` which is not buffered).

* sources/io/streams/buffered-stream.dylan
  (``do-next-input-buffer``,
   ``do-release-input-buffer``,
   ``do-input-available-at-source?``,
   ``do-get-output-buffer``,
   ``do-release-output-buffer``,
   ``force-output-buffers``,
   ``do-force-output-buffers``): Specialize generic functions on
   ``<buffered-stream>`` rather than ``<stream>``.

* sources/io/streams/native-speed.dylan
  (``copy-down-stream-definer``): Remove portions that deal with
   buffered streams.
  (``copy-down-buffered-stream-definer``): New macro that supplies
   buffered stream definitions in addition to what ``copy-down-stream-definer``
   supplies.

* sources/io/streams/file-stream.dylan: Update commented out code
   that used ``copy-down-stream`` for ``<byte-char-file-stream>`` and
   ``<byte-file-stream>`` to use ``copy-down-buffered-stream`` instead.
   We should look at enabling this code in the future.

* sources/io/library.dylan
  (module ``streams-internals``): Export ``copy-down-buffered-stream-definer``.