### PR TITLE
[environment] Colorize compilation notes.

### DIFF
--- a/documentation/release-notes/source/2015.1.rst
+++ b/documentation/release-notes/source/2015.1.rst
@@ -116,6 +116,9 @@ Compiler
   function pointer is given to be invoked rather than a direct
   function call).
 
+* Warnings and errors are now colorized when printing on supporting
+  output devices.
+
 Debugging
 =========
 

--- a/sources/environment/protocols/library.dylan
+++ b/sources/environment/protocols/library.dylan
@@ -10,6 +10,7 @@ define library environment-protocols
   use dylan;
   use common-dylan;
   use io;
+  use coloring-stream;
   use source-records;
   use file-source-records;
   use system;

--- a/sources/environment/protocols/module.dylan
+++ b/sources/environment/protocols/module.dylan
@@ -51,6 +51,8 @@ end module environment-imports;
 
 define module environment-protocols
   use environment-imports;
+  use coloring-stream;
+  use print;
 
   // Server objects
   export <server>,

--- a/sources/environment/protocols/naming.dylan
+++ b/sources/environment/protocols/naming.dylan
@@ -590,6 +590,23 @@ define method print-environment-object-name
   end
 end method print-environment-object-name;
 
+define constant $locus-attributes
+  = text-attributes(intensity: $bright-intensity);
+define constant $quote-attributes
+  = text-attributes(intensity: $bright-intensity);
+define constant $error-attributes
+  = text-attributes(foreground: $color-red,
+                    intensity: $bright-intensity);
+define constant $serious-warning-attributes
+  = text-attributes(foreground: $color-red,
+                    intensity: $bright-intensity);
+define constant $warning-attributes
+  = text-attributes(foreground: $color-magenta,
+                    intensity: $bright-intensity);
+define constant $caret-attributes
+  = text-attributes(foreground: $color-green,
+                    intensity: $bright-intensity);
+
 define method print-environment-object-name
     (stream :: <stream>, server :: <server>,
      warning :: <warning-object>,
@@ -598,20 +615,25 @@ define method print-environment-object-name
      #all-keys)
  => ()
   ignore(namespace);
+  let stream = colorize-stream(stream);
   let location = environment-object-source-location(server, warning);
   if (full-message?)
     if (location)
+      print($locus-attributes, stream);
       print-source-location(stream, location);
+      print($reset-attributes, stream);
       write(stream, ": ");
     end;
-    format(stream, "%s - ", environment-object-type-name(warning));
+    let warning-class-text = $serious-warning-attributes;
+    format(stream, "%=%s%= - ", warning-class-text,
+           environment-object-type-name(warning), $reset-attributes);
   end;
   let message
     = case
         full-message? => compiler-warning-full-message(server, warning);
         otherwise     => compiler-warning-short-message(server, warning);
       end;
-  write(stream, message);
+  format(stream, "%=%s%=", $quote-attributes, message, $reset-attributes);
   if (full-message? & location)
     new-line(stream);
     let record       = location.source-location-source-record;
@@ -628,7 +650,8 @@ define method print-environment-object-name
                      if (lines & lines.size > 1) lineno else ' ' end,
                      if (line) line else ' ' end);
             end method output-line;
-      format(stream, "%4s  %s\n", ' ', upper-dec);
+      format(stream, "%4s  %=%s%=\n", ' ', $caret-attributes,
+             upper-dec, $reset-attributes);
       let no-of-lines = lines.size;
       if (no-of-lines <= $warning-max-lines)
         for (line in lines, number from start-line)
@@ -644,7 +667,8 @@ define method print-environment-object-name
           output-line(start-line + index, lines[index])
         end
       end;
-      format(stream, "%4s  %s", ' ', lower-dec);
+      format(stream, "%4s  %=%s%=", ' ', $caret-attributes,
+             lower-dec, $reset-attributes);
     end
   end
 end method print-environment-object-name;


### PR DESCRIPTION
* sources/environment/protocols/library.dylan
  (library ``environment-protocols``): Import ``coloring-stream``.

* sources/environment/protocols/module.dylan
  (module ``environment-protocols``): Import ``coloring-stream``, ``print``.

* sources/environment/protocols/naming.dylan
  (``$locus-attributes``,
   ``$quote-attributes``,
   ``$error-attributes``,
   ``$serious-warning-attributes``,
   ``$warning-attributes``,
   ``$caret-attributes``): Text attributes used when printing compiler
    notes. The names for locus, quote and caret come from existing
    gcc and clang terminology.
  (``print-environment-object-name``) Use color when printing compiler notes.

* documentation/release-notes/source/2015.1.rst: Update.