### PR TITLE
[common-dylan] Add sincos.

### DIFF
--- a/documentation/library-reference/source/common-dylan/transcendentals.rst
+++ b/documentation/library-reference/source/common-dylan/transcendentals.rst
@@ -231,6 +231,7 @@ This section contains a reference entry for each item exported from the
    :seealso:
 
      - :gf:`sin`
+     - :gf:`sincos`
      - :gf:`tan`
 
 .. generic-function:: cosh
@@ -396,7 +397,29 @@ This section contains a reference entry for each item exported from the
    :seealso:
 
      - :gf:`cos`
+     - :gf:`sincos`
      - :gf:`tan`
+
+.. generic-function:: sincos
+
+   :summary:
+     Returns both the sine and the cosine of its argument.
+
+   :signature: sincos x => (s, c)
+
+   :parameter x: An instance of type :drm:`<real>`. The angle, in radians.
+   :value s: An instance of type :drm:`<float>`. The result of ``sin(x)``.
+   :value c: An instance of type :drm:`<float>`. The result of ``cos(x)``.
+
+   :description:
+
+     Returns both the sine and the cosine of its argument. The floating point
+     precision of the results is given by the precision of ``x``.
+
+   :seealso:
+
+     :gf:`cos`
+     :gf:`sin`
 
 .. constant:: $single-e
 

--- a/documentation/release-notes/source/2015.1.rst
+++ b/documentation/release-notes/source/2015.1.rst
@@ -80,6 +80,11 @@ Coloring-Stream
   supports ANSI codes on Unix terminals. It has been
   `documented in the library reference`_.
 
+Common Dylan
+============
+
+* The ``transcendentals`` module now has a ``sincos`` generic function.
+
 Compiler
 ========
 

--- a/sources/common-dylan/library.dylan
+++ b/sources/common-dylan/library.dylan
@@ -219,6 +219,7 @@ define module transcendentals
          sin,
          cos,
          tan,
+         sincos,
          asin,
          acos,
          atan,

--- a/sources/common-dylan/tests/specification.dylan
+++ b/sources/common-dylan/tests/specification.dylan
@@ -313,6 +313,10 @@ define module-spec transcendentals ()
 // The floating point precision of the result is given by the precision
 // of _x_.  The result will be a <single-float> if _x_ is an integer.
 
+  open generic-function sincos(<number>) => (<number>, <number>);
+
+// As above, but returns both the sine and cosine of _x_.
+
   open generic-function asin(<number>) => (<number>); // -1 <= y <= +1
   open generic-function acos(<number>) => (<number>); // -1 <= y <= +1
 

--- a/sources/common-dylan/tests/transcendentals.dylan
+++ b/sources/common-dylan/tests/transcendentals.dylan
@@ -53,6 +53,10 @@ define transcendentals function-test tan ()
   // ---*** Fill this in.
 end function-test tan;
 
+define transcendentals function-test sincos ()
+  // ---*** Fill this in.
+end function-test sincos;
+
 define transcendentals function-test asin ()
   // ---*** Fill this in.
 end function-test asin;

--- a/sources/common-dylan/transcendentals.dylan
+++ b/sources/common-dylan/transcendentals.dylan
@@ -70,6 +70,19 @@ define unary-transcendental sin (x) end;
 define unary-transcendental cos (x) end;
 define unary-transcendental tan (x) end;
 
+define open generic sincos (x :: <number>) => (sine :: <number>, cosine :: <number>);
+define sealed domain sincos (<real>);
+
+define sealed may-inline method sincos (x :: <single-float>)
+ => (sine :: <single-float>, cosine :: <single-float>)
+  values(sin(x), cos(x))
+end method sincos;
+
+define sealed may-inline method sincos (x :: <double-float>)
+ => (sine :: <double-float>, cosine :: <double-float>)
+  values(sin(x), cos(x))
+end method sincos;
+
 define unary-transcendental asin (x)
   if (abs(x) > 1)
     error("ASIN would produce complex number")


### PR DESCRIPTION
Inspired by seeing that @tarballs-are-good is looking at adding this to SBCL, I decided to give it a go here.

I didn't (yet?) add a compiler primitive to try to ensure that the right native code happens. On some platforms, in the right circumstances, LLVM can optimize a call to ``sin`` and a call to ``cos`` into a call to the platform-specific code for ``sincos``. I haven't observed this happening in practice yet.

* documentation/library-reference/source/common-dylan/transcendentals.rst
  (``sincos``): Document.

* sources/common-dylan/library.dylan
  (module ``transcendentals``): Export ``sincos``.

* sources/common-dylan/tests/specification.dylan
  (module-spec ``transcendentals``): Add ``sincos``.

* sources/common-dylan/tests/transcendentals.dylan
  (function-test ``sincos``): Stub.

* sources/common-dylan/transcendentals.dylan
  (sincos): Add open generic, seal domain over ``<real>``,
   add methods for single and double floats.