### PR TITLE
[dylan] Call new invoke-handler function.

### DIFF
--- a/sources/dylan/condition.dylan
+++ b/sources/dylan/condition.dylan
@@ -91,8 +91,9 @@ define method signal (condition :: <condition>, #rest noise)
       let _handler = head(handlers);
       let remaining = tail(handlers);
       if (handler-matches?(_handler, condition))
-        handler-function(_handler)
-          (condition, method () search(remaining) end method)
+        invoke-handler(_handler,
+                       condition,
+                       method () search(remaining) end method)
       else
         search(remaining)
       end if
@@ -108,6 +109,13 @@ define method handler-matches? (_handler :: <handler>, condition :: <condition>)
       ~test | test(condition)
     end
 end method handler-matches?;
+
+// This is useful for setting a breakpoint within the runtime.
+define not-inline method invoke-handler
+    (_handler :: <handler>, condition :: <condition>,
+     continue-search :: <function>)
+  handler-function(_handler)(condition, continue-search)
+end method invoke-handler;
 
 define method error (condition :: <condition>, #rest noise)
  => (will-never-return :: <bottom>)


### PR DESCRIPTION
When debugging, it is useful to be able to set some breakpoints
for when an exception is going to be handled. This moves the
invocation of a handler from something that happens in the search
loop to a separate function to make it easier to create a breakpoint.

(Setting it by file:line number isn't going to work out well once
the debugger is more aware of Dylan since it is better to set
a breakpoint on a well known function within the runtime.)

* sources/dylan/condition.dylan
  (``signal``): Move invoking handler function to ``invoke-handler``.
  (``invoke-handler``): New function.