### PR TITLE
dylan: Fix size parameter handling in range

### DIFF
--- a/sources/dylan/range.dylan
+++ b/sources/dylan/range.dylan
@@ -75,14 +75,14 @@ define method make
     else
       if (size)
         if (to)
-          let new-to = from + by * (size + 1);
-          if (new-to <= to)
+          let new-to = from + by * (size - 1);
+          if (abs(new-to) <= abs(to))
             to := new-to
           else
             size := floor/(to + by - from, by);
           end if;
         else
-          to := from + by * (size + 1);
+          to := from + by * (size - 1);
         end if;
       else
         size := floor/(to + by - from, by);


### PR DESCRIPTION
Current implementation of range gives preference to size over to/below
parameters and modifies to accordingly if needed. This modification is
not correct as current as test range-5 in apple dylan test suite shows.

This change fixes size's behaviour according to current implementation,
making every test case in range-5 pass.

* sources/dylan/range.dylan
  (make): Fix size parameter handling