### PR TITLE
Aux rule error report

### DIFF
--- a/sources/dfmc/macro-expander/pattern-back-end.dylan
+++ b/sources/dfmc/macro-expander/pattern-back-end.dylan
@@ -25,11 +25,11 @@ end serious-program-warning;
 
 define serious-program-warning
     <macro-aux-rule-match-error> (<macro-match-error>)
-  slot condition-rule-set,
-    required-init-keyword: rule-set:;
+  slot condition-rule-set-name,
+    required-init-keyword: rule-set-name:;
   format-string
     "Invalid syntax for %s in %s macro call.";
-  format-arguments rule-set, macro-name;
+  format-arguments rule-set-name, macro-name;
 end serious-program-warning;
 
 define serious-program-warning
@@ -50,7 +50,7 @@ define function macro-aux-rule-match-error (f*, name, set)
   note(<macro-aux-rule-match-error>,
        source-location: spanning(f*),
        macro-name: name,
-       rule-set: rule-set-name(set));
+       rule-set-name: rule-set-name(set));
 end function;
 
 //// Body/list destructuring.

--- a/sources/dfmc/macro-expander/pattern-back-end.dylan
+++ b/sources/dfmc/macro-expander/pattern-back-end.dylan
@@ -50,7 +50,7 @@ define function macro-aux-rule-match-error (f*, name, set)
   note(<macro-aux-rule-match-error>,
        source-location: spanning(f*),
        macro-name: name,
-       rule-set: set);
+       rule-set: rule-set-name(set));
 end function;
 
 //// Body/list destructuring.

--- a/sources/dfmc/macro-expander/pattern-to-code.dylan
+++ b/sources/dfmc/macro-expander/pattern-to-code.dylan
@@ -59,9 +59,8 @@ define method generate-match-failure
     (exp, set :: <aux-rewrite-rule-set>, rules)
   let exp-name = expander-name(exp);
   let name = if (exp-name) as(<symbol>, exp-name) else #"macro-case" end;
-  let set-name = rule-set-name(set);
   #{ macro-aux-rule-match-error
-       (_f*_, dylan-variable-name(?name), ?set-name); }
+       (_f*_, dylan-variable-name(?name), ?set); }
 end method;
 
 define method generate-match-failure

--- a/sources/dfmc/macro-expander/pattern-to-function.dylan
+++ b/sources/dfmc/macro-expander/pattern-to-function.dylan
@@ -72,9 +72,8 @@ end method;
 define method generate-match-failure-function
     (exp, set :: <aux-rewrite-rule-set>, rules)
   let name = expander-name(exp);
-  let set-name = rule-set-name(set);
   method (_f*_)
-    macro-aux-rule-match-error(_f*_, name, set-name);
+    macro-aux-rule-match-error(_f*_, name, set);
   end
 end method;
 


### PR DESCRIPTION
This is part 1 of a change that will improve error reporting in macro auxiliary rule match failures.