### PR TITLE
Initial internal foundation for limited functions.

### DIFF
--- a/sources/dfmc/modeling/limited-functions.dylan
+++ b/sources/dfmc/modeling/limited-functions.dylan
@@ -1,0 +1,76 @@
+Module:   dfmc-modeling
+Synopsis: Limited function type models
+Author:   Bruce Mitchener, Jr.
+Copyright:    Original Code is Copyright (c) 2015 Dylan Hackers.
+License:      See License.txt in this distribution for details.
+Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
+
+//// The limited function type.
+
+define primary &class <limited-function> (<limited-type>)
+  constant &slot limited-function-signature,
+    required-init-keyword: signature:;
+end &class;
+
+//// Base type.
+
+// "The base type of limited(C, ...) is C"
+
+define method ^base-type (lf :: <&limited-function>) => (type :: <&type>)
+  dylan-value(#"<function>")
+end method;
+
+//// Instance? relationships.
+
+define method ^instance? (o :: <model-value>, lf :: <&limited-function>)
+ => (well? :: <boolean>)
+  #f
+end method;
+
+define method ^instance? (i :: <&function>, lf :: <&limited-function>)
+ => (well? :: <boolean>)
+  #f // XXX: Implement
+end method;
+
+//// Subtype? relationships.
+
+// With other limited function types
+
+define method ^subtype?
+    (lf1 :: <&limited-function>, lf2 :: <&limited-function>)
+ => (well? :: <boolean>)
+  #f // XXX: Implement
+end method;
+
+// With other function types
+
+define method ^subtype? (class :: <&class>, lf :: <&limited-function>)
+ => (well? :: <boolean>)
+  #f
+end method;
+
+define method ^subtype? (lf :: <&limited-function>, class :: <&class>)
+ => (well? :: <boolean>)
+  ^subtype?(^base-type(lf), class)
+end method;
+
+//// Disjointness relationships.
+
+define method ^known-disjoint?
+    (lf1 :: <&limited-function>, lf2 :: <&limited-function>)
+ => (well? :: <boolean>)
+  #f // XXX: Implement
+end method;
+
+// "A limited type is disjoint from a class if their base types are
+// disjoint."
+
+define method ^known-disjoint?
+    (lf :: <&limited-function>, t :: <&type>) => (well? :: <boolean>)
+  ^known-disjoint?(^base-type(lf), t)
+end method;
+
+define method ^known-disjoint?
+    (t :: <&type>, lf :: <&limited-function>) => (well? :: <boolean>)
+  ^known-disjoint?(lf, t)
+end method;

--- a/sources/dfmc/modeling/modeling-library.dylan
+++ b/sources/dfmc/modeling/modeling-library.dylan
@@ -408,6 +408,8 @@ define module-with-models dfmc-modeling
       &getter limited-collection-size,
       &getter limited-collection-dimensions,
       lookup-any-limited-collection-element-type,
+    <&limited-function>,
+      &getter limited-function-signature,
     <&limited-integer>,
       ^limited-integer,
       &getter limited-integer-min,

--- a/sources/dfmc/modeling/modeling.lid
+++ b/sources/dfmc/modeling/modeling.lid
@@ -13,6 +13,7 @@ Files:   modeling-library
          classes
          singletons
          unions
+         limited-functions
          limited-integers
          limited-collections
          subclasses

--- a/sources/dfmc/modeling/namespaces.dylan
+++ b/sources/dfmc/modeling/namespaces.dylan
@@ -847,6 +847,9 @@ define &module dylan-extensions
   create type-union-members,
          <type-union-classification>, classify-type-union;
 
+  create
+    <limited-function>, limited-function-signature;
+
   /// TEMPORARILY FOR METHOD DISPATCH
 
   create

--- a/sources/dylan/dylan.lid
+++ b/sources/dylan/dylan.lid
@@ -60,6 +60,7 @@ Files:     dfmc-boot
            type
            signature
            function
+           limited-function
            method
            generic-function
            dispatch

--- a/sources/dylan/limited-function.dylan
+++ b/sources/dylan/limited-function.dylan
@@ -1,0 +1,106 @@
+Module:    internal
+Synopsis:  Limited function types
+Author:    Bruce Mitchener, Jr.
+Copyright:    Original Code is Copyright (c) 2015 Dylan Hackers.
+              All rights reserved.
+License:      See License.txt in this distribution for details.
+Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
+
+//// The limited function type
+
+// BOOTED: define ... class <limited-function> ... end;
+
+define method limited
+    (class == <function>, #key signature :: <signature> = #f)
+ => (result :: <type>)
+  if (signature)
+    let type :: <limited-function> = make(<limited-function>, signature: signature);
+    unless (instance?-iep(type))
+      instance?-iep(type) := simple-method-iep(limited-function-instance?-function);
+    end unless;
+    type
+  else
+    <function>
+  end
+end method;
+
+define inline method limits (lf :: <limited-function>) => (result == <function>)
+  <function>
+end method;
+
+//// Instance? relationships
+
+define function limited-function-instance?-function
+    (f, lf :: <limited-function>) => (result :: <boolean>)
+  if (instance?(f, <function>))
+    let f :: <function> = f;
+    let signature = lf.limited-function-signature;
+    congruent?(signature, function-signature(f))
+  else
+    #f
+  end if
+end function;
+
+define method instance?-function (t :: <limited-function>) => (m :: <method>)
+  limited-function-instance?-function
+end method;
+
+//// Subtype? relationships
+
+// With other limited function types
+
+define method subtype?
+    (lf1 :: <limited-function>, lf2 :: <limited-function>)
+ => (result :: <boolean>)
+  #f
+end method;
+
+define method subjunctive-subtype? (lf1 :: <limited-function>, lf2 :: <limited-function>,
+                                    scu :: <subjunctive-class-universe>)
+ => (result :: <boolean>)
+  subtype?(lf1, lf2)
+end method;
+
+
+// With other function types
+
+define method subtype?
+    (class :: <class>, lf :: <limited-function>) => (result == #f)
+  #f
+end method;
+
+define method subtype?
+    (lf :: <limited-function>, class :: <class>) => (result :: <boolean>)
+  subclass?(limits(lf), class)
+end method;
+
+define method subjunctive-subtype? (class :: <class>, lf :: <limited-function>,
+                                    scu :: <subjunctive-class-universe>)
+ => (result == #f)
+  #f
+end method;
+
+define method subjunctive-subtype? (lf :: <limited-function>, class :: <class>,
+                                    scu :: <subjunctive-class-universe>)
+ => (result :: <boolean>)
+  subjunctive-subtype?(limits(lf), class, scu)
+end method;
+
+//// Disjointness
+
+define method disjoint-types-1? (t1 :: <limited-function>, t2 :: <limited-function>,
+                                 scu :: <subjunctive-class-universe>,
+                                 dep :: <false-or-dependent-generic-function>)
+ => (well? :: <boolean>)
+  // For now, just assume any 2 limited functions are disjoint.
+  #t
+end method;
+
+
+///// Potential instance relationships
+
+define method has-instances? (class :: <class>, lf :: <limited-function>,
+                              scu :: <subjunctive-class-universe>)
+ => (some? :: <boolean>, all? == #f)
+  values(subjunctive-subtype?(<function>, class, scu) | subjunctive-subtype?(class, <function>, scu), #f)
+end method;

--- a/sources/io/print.dylan
+++ b/sources/io/print.dylan
@@ -904,6 +904,13 @@ define method print-specializer (type :: <union>, stream :: <stream>)
   end select;
 end method print-specializer;
 
+define method print-specializer (type :: <limited-function>, stream :: <stream>)
+    => ();
+  printing-logical-block (stream, prefix: "fn(", suffix: ")")
+    print-signature(type.limited-function-signature, stream);
+  end;
+end method print-specializer;
+
 
 /// Print-object methods for <type> and its subclasses.
 ///
@@ -932,6 +939,13 @@ define sealed method print-object
              print-specializer(object, stream);
            end method,
      suffix: "}");
+end method print-object;
+
+define sealed method print-object
+    (object :: <limited-function>, stream :: <stream>) => ()
+  write(stream, "{limited-function ");
+  print-signature(object.limited-function-signature, stream);
+  write(stream, "}");
 end method print-object;
 
 /// For classes, we just print the class name if there is one.


### PR DESCRIPTION
This is not ready for use and not fully implemented. But
it is a start and further iteration can be done from this
base.

* sources/dylan/limited-function.dylan: New file.

* sources/dylan/dylan.lid: Build limited-function.dylan.

* sources/dfmc/modeling/limited-functions.dylan: New file.

* sources/dfmc/modeling/modeling.lid: Build limited-functions.dylan.

* sources/dfmc/modeling/modeling-library.dylan
  (module ``dfmc-modeling``): Export ``<&limited-function>`` and
   ``limited-function-signature``.

* sources/dfmc/modeling/namespaces.dylan
  (module ``dylan-extensions``): Export ``<limited-function>`` and
   ``limited-function-signature``.

* sources/dfmc/modeling/objects.dylan
  (``<model-value>``): ``<function>`` can be a ``<model-value>`` now.

* sources/common-dylan/format.dylan
  (``print-unique-name`` on ``<limited-function>``): Implement.
  (``print-specializer`` on ``<limited-function>``): Likewise.
  (``print-method``): Call print-signature to print the signature
    rather than doing it inline.
  (``print-signature``): Hoist the code from print-method for
    printing the signature into a separate set of methods
    so that it can be used for printing ``<signature>`` objects
    as well for ``<limited-function>`` printing.

* sources/io/print.dylan
  (``print-object`` on ``<limited-function>``): Implement.
  (``print-specializer`` on ``<limited-function>``): Likewise.