### PR TITLE
[system] Add current-thread-id.

### DIFF
--- a/documentation/library-reference/source/system/operating-system.rst
+++ b/documentation/library-reference/source/system/operating-system.rst
@@ -71,6 +71,7 @@ information.
 - :func:`application-filename`
 - :func:`tokenize-command-string`
 - :func:`current-process-id`
+- :func:`current-thread-id`
 - :func:`parent-process-id`
 
 Working with shared libraries
@@ -193,6 +194,24 @@ System library's operating-system module.
 
    :seealso:
 
+     - :func:`current-thread-id`
+     - :func:`parent-process-id`
+
+.. function:: current-thread-id
+
+   Returns the integer value for the current thread ID.
+
+   :signature: current-thread-id => *tid*
+
+   :value tid: An instance of :drm:`<integer>`.
+
+   :description:
+
+     Returns the integer value of the current thread ID.
+
+   :seealso:
+
+     - :func:`current-process-id`
      - :func:`parent-process-id`
 
 .. function:: environment-variable
@@ -447,6 +466,7 @@ System library's operating-system module.
    :seealso:
 
      - :func:`current-process-id`
+     - :func:`current-thread-id`
 
 .. constant:: $platform-name
 

--- a/documentation/release-notes/source/2016.1.rst
+++ b/documentation/release-notes/source/2016.1.rst
@@ -198,5 +198,7 @@ system
   ``<file-system-file-locator>`` classes. These aren't typically used but
   their omission led to possible confusion for users.
 
+* The ``operating-system`` module has gained a ``current-thread-id`` function.
+
 .. _issue #899: https://github.com/dylan-lang/opendylan/issues/899
 .. _documented in the library reference: http://opendylan.org/documentation/library-reference/coloring-stream/

--- a/sources/system/arm-linux-system.lid
+++ b/sources/system/arm-linux-system.lid
@@ -30,6 +30,7 @@ Files: library
        settings/settings
        settings/dummy-settings
 C-Source-Files: unix-portability.c
+                thread-id.c
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.

--- a/sources/system/library.dylan
+++ b/sources/system/library.dylan
@@ -68,6 +68,7 @@ define module operating-system
          signal-application-event,
          load-library,
          current-process-id,
+         current-thread-id,
          parent-process-id;
 
   create command-line-option-prefix;

--- a/sources/system/tests/operating-system.dylan
+++ b/sources/system/tests/operating-system.dylan
@@ -338,6 +338,12 @@ define operating-system function-test current-process-id ()
   check-true("current-process-id > 0", pid > 0);
 end;
 
+define operating-system function-test current-thread-id ()
+  let tid = current-thread-id();
+  check-true("current-thread-id is an integer", instance?(tid, <integer>));
+  check-true("current-thread-id > 0", tid > 0);
+end;
+
 define operating-system function-test parent-process-id ()
   let pid = parent-process-id();
   check-true("parent-process-id is an integer", instance?(pid, <integer>));

--- a/sources/system/tests/specification.dylan
+++ b/sources/system/tests/specification.dylan
@@ -204,6 +204,7 @@ define module-spec operating-system ()
     (<application-process>) => (<integer>, false-or(<integer>));
   function load-library (<string>) => (<object>);
   function current-process-id () => (<integer>);
+  function current-thread-id () => (<integer>);
   function parent-process-id () => (<integer>);
 
   // Application startup handling

--- a/sources/system/thread-id.c
+++ b/sources/system/thread-id.c
@@ -1,0 +1,32 @@
+#include <stdint.h>
+
+#if defined(OPEN_DYLAN_PLATFORM_LINUX) || defined(OPEN_DYLAN_PLATFORM_OPENBSD)
+#include <unistd.h>
+#include <sys/syscall.h>
+#elif defined(OPEN_DYLAN_PLATFORM_DARWIN)
+#include <pthread.h>
+#elif defined(OPEN_DYLAN_PLATFORM_FREEBSD)
+#include <pthread_np.h>
+#elif defined(OPEN_DYLAN_PLATFORM_NETBSD)
+#include <lwp.h>
+#endif
+
+uint64_t system_current_thread_id(void)
+{
+#if defined(OPEN_DYLAN_PLATFORM_LINUX)
+  return syscall(SYS_gettid);
+#elif defined(OPEN_DYLAN_PLATFORM_DARWIN)
+  uint64_t tid;
+  pthread_threadid_np(pthread_self(), &tid);
+  return tid;
+#elif defined(OPEN_DYLAN_PLATFORM_FREEBSD)
+  return pthread_getthreadid_np();
+#elif defined(OPEN_DYLAN_PLATFORM_NETBSD)
+  return _lwp_self();
+#elif defined(OPEN_DYLAN_PLATFORM_OPENBSD)
+  return syscall(SYS_getthrid);
+#else
+  #error system_current_thread_id is not yet implemented.
+#endif
+  return 0;
+}

--- a/sources/system/unix-operating-system.dylan
+++ b/sources/system/unix-operating-system.dylan
@@ -570,6 +570,14 @@ define function current-process-id
                  end);
 end;
 
+define function current-thread-id
+    () => (tid :: <integer>)
+  raw-as-integer(%call-c-function("system_current_thread_id")
+                     () => (tid :: <raw-c-signed-int>)
+                     ()
+                 end);
+end;
+
 define function parent-process-id
     () => (pid :: <integer>)
   raw-as-integer(%call-c-function("getppid")

--- a/sources/system/x86-darwin-system.lid
+++ b/sources/system/x86-darwin-system.lid
@@ -31,6 +31,7 @@ Files: library
        settings/settings
        settings/dummy-settings
 C-Source-Files: unix-portability.c
+                thread-id.c
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.

--- a/sources/system/x86-freebsd-system.lid
+++ b/sources/system/x86-freebsd-system.lid
@@ -30,6 +30,7 @@ Files: library
        settings/settings
        settings/dummy-settings
 C-Source-Files: unix-portability.c
+                thread-id.c
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.

--- a/sources/system/x86-linux-system.lid
+++ b/sources/system/x86-linux-system.lid
@@ -30,6 +30,7 @@ Files: library
        settings/settings
        settings/dummy-settings
 C-Source-Files: unix-portability.c
+                thread-id.c
 C-Libraries: -ldl
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.

--- a/sources/system/x86-netbsd-system.lid
+++ b/sources/system/x86-netbsd-system.lid
@@ -30,6 +30,7 @@ Files: library
        settings/settings
        settings/dummy-settings
 C-Source-Files: unix-portability.c
+                thread-id.c
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.

--- a/sources/system/x86-win32-operating-system.dylan
+++ b/sources/system/x86-win32-operating-system.dylan
@@ -1279,6 +1279,14 @@ define function current-process-id
                  end);
 end;
 
+define function current-thread-id
+    () => (tid :: <integer>)
+  raw-as-integer(%call-c-function("GetCurrentThreadId", c-modifiers: "__stdcall")
+                     () => (tid :: <raw-c-unsigned-int>)
+                     ()
+                 end);
+end;
+
 define function parent-process-id
     () => (pid :: <integer>)
   0

--- a/sources/system/x86_64-darwin-system.lid
+++ b/sources/system/x86_64-darwin-system.lid
@@ -31,6 +31,7 @@ Files: library
        settings/settings
        settings/dummy-settings
 C-Source-Files: unix-portability.c
+                thread-id.c
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.

--- a/sources/system/x86_64-freebsd-system.lid
+++ b/sources/system/x86_64-freebsd-system.lid
@@ -30,6 +30,7 @@ Files: library
        settings/settings
        settings/dummy-settings
 C-Source-Files: unix-portability.c
+                thread-id.c
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.

--- a/sources/system/x86_64-linux-system.lid
+++ b/sources/system/x86_64-linux-system.lid
@@ -30,6 +30,7 @@ Files: library
        settings/settings
        settings/dummy-settings
 C-Source-Files: unix-portability.c
+                thread-id.c
 C-Libraries: -ldl
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.

--- a/sources/system/x86_64-netbsd-system.lid
+++ b/sources/system/x86_64-netbsd-system.lid
@@ -30,6 +30,7 @@ Files: library
        settings/settings
        settings/dummy-settings
 C-Source-Files: unix-portability.c
+                thread-id.c
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.


### PR DESCRIPTION
* documentation/library-reference/source/system/operating-system.rst
  (``current-process-id``): See also ``current-thread-id``.
  (``current-thread-id``): Document.
  (``parent-process-id``): See also ``current-thread-id``.

* documentation/release-notes/source/2015.1.rst: Add release note.

* sources/system/library.dylan
  (``module operating-system``): Export ``current-thread-id``.

* sources/system/tests/operating-system.dylan
  (``function-test current-thread-id``): Implement.

* sources/system/tests/specification.dylan
  (``module-spec operating-system``): Add ``current-thread-id``.

* sources/system/thread-id.c
  (``system_get_thread_id``): Implement for Linux, OS X, FreeBSD, NetBSD and OpenBSD.

* sources/system/unix-operating-system.dylan
  (``current-thread-id``): Call ``system_get_thread_id``.

* sources/system/x86-win32-operating-system.dylan
  (``current-thread-id``): Implement for Windows via ``GetCurrentThreadId``.

* sources/system/arm-linux-system.lid: Build thread-id.c

* sources/system/x86-darwin-system.lid: Likewise.

* sources/system/x86-freebsd-system.lid: Likewise.

* sources/system/x86-linux-system.lid: Likewise.

* sources/system/x86_64-darwin-system.lid: Likewise.

* sources/system/x86_64-freebsd-system.lid: Likewise.

* sources/system/x86_64-linux-system.lid: Likewise.