### PR TITLE
Threads cleanup

### DIFF
--- a/documentation/hacker-guide/source/runtime/primitives.rst
+++ b/documentation/hacker-guide/source/runtime/primitives.rst
@@ -16,15 +16,11 @@ primitive-make-thread
 
 Signature
 
-(thread :: <thread>, name :: false-or(<byte-string>), priority :: <integer>, function :: <function>) => ()
+(thread :: <thread>, function :: <function>) => ()
 
 Arguments
 
 *thread* A Dylan thread object.
-
-*name* The name of the thread (as a :drm:`<byte-string>`) or *#f*.
-
-*priority* The priority at which the thread is to run.
 
 *function* The initial function to run after the thread is created.
 

--- a/sources/dfmc/llvm-back-end/llvm-primitives-thread.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-primitives-thread.dylan
@@ -112,9 +112,7 @@ define thread-local runtime-variable %tlv-initializations-local-cursor :: <raw-i
 /// Thread primitives
 
 define side-effecting stateful dynamic-extent &c-primitive-descriptor primitive-make-thread
-    (thread :: <object>, name :: <object>,
-     priority :: <integer>, function :: <function>,
-     synchronous? :: <raw-boolean>)
+    (thread :: <object>, function :: <function>, synchronous? :: <raw-boolean>)
   => (res :: <integer>);
 
 define side-effecting stateful dynamic-extent &c-primitive-descriptor primitive-destroy-thread

--- a/sources/dfmc/modeling/thread-primitives.dylan
+++ b/sources/dfmc/modeling/thread-primitives.dylan
@@ -8,8 +8,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 /// Threads
 
 define side-effecting stateful dynamic-extent &primitive primitive-make-thread
-    (thread :: <object>, name :: <object>,
-     priority :: <integer>, function :: <function>,
+    (thread :: <object>, function :: <function>,
      synchronous? :: <raw-boolean>) => (res :: <integer>);
 
 define side-effecting stateful dynamic-extent &primitive primitive-destroy-thread

--- a/sources/dylan/thread.dylan
+++ b/sources/dylan/thread.dylan
@@ -30,6 +30,8 @@ define sealed class <thread> (<portable-double-container>)
 
 end class;
 
+ignore(priority);
+
 define sealed class <synchronous-thread> (<thread>)
 end class;
 
@@ -74,8 +76,7 @@ define sealed method initialize (thr :: <thread>, #key) => ()
     primitive-initialize-special-thread(thr); // This is the first thread
   else
     let res =
-      primitive-make-thread(thr, thr.thread-name, thr.priority,
-                            thr.trampoline-function,
+      primitive-make-thread(thr, thr.trampoline-function,
                             primitive-boolean-as-raw
                               (instance?(thr, <synchronous-thread>)));
     if  (res ~= $success)

--- a/sources/lib/run-time/dummy-threads.c
+++ b/sources/lib/run-time/dummy-threads.c
@@ -130,8 +130,8 @@ dylan_value primitive_initialize_special_thread(dylan_value t) {
 dylan_value primitive_current_thread() {
   return(THREAD_SUCCESS);
 }
-dylan_value primitive_make_thread(dylan_value t, dylan_value n, dylan_value p, dylan_value f, DBOOL s) {
-  ignore(t); ignore(n); ignore(p); ignore(f); ignore(s);
+dylan_value primitive_make_thread(dylan_value t, dylan_value f, DBOOL s) {
+  ignore(t); ignore(f); ignore(s);
   /* threads_get_stuffed(); */
   return(THREAD_SUCCESS);  /* Keeps some compilers happy -- Won't actually get here */
 }

--- a/sources/lib/run-time/llvm-posix-threads.c
+++ b/sources/lib/run-time/llvm-posix-threads.c
@@ -268,7 +268,7 @@ static void *trampoline(void *arg)
 }
 
 // primitive-make-thread
-dylan_value primitive_make_thread(dylan_value t, dylan_value n, dylan_value p, dylan_value f, DBOOL s)
+dylan_value primitive_make_thread(dylan_value t, dylan_value f, DBOOL s)
 {
   struct KLthreadGYthreadsVdylan *thread
     = (struct KLthreadGYthreadsVdylan *) t;

--- a/sources/lib/run-time/posix-threads.c
+++ b/sources/lib/run-time/posix-threads.c
@@ -520,17 +520,16 @@ static void *trampoline (void *arg)
 dylan_value primitive_make_thread(dylan_value t, dylan_value n, dylan_value p, dylan_value f, DBOOL s)
 {
   DTHREAD *thread = (DTHREAD *)t;
-  ZINT     zpriority = (ZINT)p;
 
   THREAD*             rthread;
   pthread_attr_t      attr;
   // struct sched_param  param;
-  // int                 priority = (int)zpriority >> 2;
+  // int priority = (int)thread->priority >> 2
 
   ignore(s);
 
   assert(thread != NULL);
-  assert(IS_ZINT(zpriority));
+  assert(IS_ZINT(thread->priority));
   assert(f != NULL);
 
   rthread = MMAllocMisc(sizeof(THREAD));

--- a/sources/lib/run-time/posix-threads.c
+++ b/sources/lib/run-time/posix-threads.c
@@ -489,8 +489,8 @@ static void *trampoline (void *arg)
 
   f = rthread->function;
 
-  if (rthread->name) {
-    const char *raw = primitive_string_as_raw(rthread->name);
+  if (thread->thread_name != &KPfalseVKi) {
+    const char *raw = primitive_string_as_raw(thread->thread_name);
     trace_threads("Thread %p has name \"%s\"", thread, raw);
     set_current_thread_name(raw);
   }
@@ -534,7 +534,6 @@ dylan_value primitive_make_thread(dylan_value t, dylan_value n, dylan_value p, d
   assert(f != NULL);
 
   rthread = MMAllocMisc(sizeof(THREAD));
-  rthread->name = n;
   rthread->function = f;
 
   thread->handle1 = 0;       // runtime thread flags

--- a/sources/lib/run-time/posix-threads.c
+++ b/sources/lib/run-time/posix-threads.c
@@ -517,7 +517,7 @@ static void *trampoline (void *arg)
 
 
 /* 1 */
-dylan_value primitive_make_thread(dylan_value t, dylan_value n, dylan_value p, dylan_value f, DBOOL s)
+dylan_value primitive_make_thread(dylan_value t, dylan_value f, DBOOL s)
 {
   DTHREAD *thread = (DTHREAD *)t;
 

--- a/sources/lib/run-time/posix-threads.h
+++ b/sources/lib/run-time/posix-threads.h
@@ -124,7 +124,11 @@ typedef struct _ctr2
 {
   dylan_value class;
   void *handle1;
-  void *handle2;
+  dylan_value handle2;
+  dylan_value priority;
+  dylan_value thread_name;
+  dylan_value function;
+  dylan_value function_results;
 } DTHREAD;
 
 typedef void * D_NAME;

--- a/sources/lib/run-time/posix-threads.h
+++ b/sources/lib/run-time/posix-threads.h
@@ -146,7 +146,6 @@ typedef dylan_value *TLV_VECTOR;
 typedef struct thread {
   pthread_t tid;
   TEB* teb;
-  dylan_value name;
   dylan_value function;
 } THREAD;
 

--- a/sources/lib/run-time/run-time.h
+++ b/sources/lib/run-time/run-time.h
@@ -1963,7 +1963,7 @@ extern dylan_value primitive_thread_join_single(dylan_value t);
 extern dylan_value primitive_initialize_current_thread(dylan_value t, DBOOL s);
 extern dylan_value primitive_initialize_special_thread(dylan_value t);
 extern dylan_value primitive_current_thread(void);
-extern dylan_value primitive_make_thread(dylan_value t, dylan_value n, dylan_value p, dylan_value f, DBOOL s);
+extern dylan_value primitive_make_thread(dylan_value t, dylan_value f, DBOOL s);
 extern dylan_value primitive_destroy_thread(dylan_value t);
 extern dylan_value primitive_destroy_notification(dylan_value n);
 extern dylan_value primitive_release_all_notification(dylan_value n, dylan_value l);

--- a/sources/lib/run-time/tests/queue_test.c
+++ b/sources/lib/run-time/tests/queue_test.c
@@ -237,10 +237,10 @@ main()
 	start = GetTickCount();
 
 	/* Start the threads */
-	assert(primitive_make_thread(&tfeeder1, NULL, (ZINT)I(0), feeder1) == 1);
-	assert(primitive_make_thread(&tfeeder2, NULL, (ZINT)I(0), feeder2) == 1);
-	assert(primitive_make_thread(&treader1, NULL, (ZINT)I(0), reader1) == 1);
-	assert(primitive_make_thread(&treader2, NULL, (ZINT)I(0), reader2) == 1);
+	assert(primitive_make_thread(&tfeeder1, feeder1) == 1);
+	assert(primitive_make_thread(&tfeeder2, feeder2) == 1);
+	assert(primitive_make_thread(&treader1, reader1) == 1);
+	assert(primitive_make_thread(&treader2, reader2) == 1);
 
 	/* Wait for the threads to terminate */
 	primitive_thread_join_single(&treader1);

--- a/sources/lib/run-time/tests/threads_primitives_test.c
+++ b/sources/lib/run-time/tests/threads_primitives_test.c
@@ -172,7 +172,7 @@ Z test_sl5()
 	CHECK("lock not owned",
 		primitive_owned_simple_lock(&simple_lock) == (ZINT)I(0));
 	CHECK("make thread",
-		primitive_make_thread(&thread, NULL, (ZINT)I(0), test_sl5a) == OK);
+		primitive_make_thread(&thread, test_sl5a) == OK);
 	Sleep(1000);
 	CHECK("wait-for lock",
 		primitive_wait_for_simple_lock(&simple_lock) == OK);
@@ -219,7 +219,7 @@ Z test_sl6()
 	CHECK("make lock",
 		primitive_make_simple_lock(&simple_lock, NULL) == OK);
 	CHECK("make thread",
-		primitive_make_thread(&thread, NULL, (ZINT)I(0), test_sl6a));
+		primitive_make_thread(&thread, test_sl6a));
 	Sleep(1000);
 	CHECK("wait-for lock with timeout",
 		primitive_wait_for_simple_lock_timed(&simple_lock, (ZINT)I(1000)) == TIMEOUT);
@@ -362,7 +362,7 @@ Z test_rl5()
 	CHECK("make lock",
 		primitive_make_recursive_lock(&recursive_lock, name) == OK);
 	CHECK("make thread",
-		primitive_make_thread(&thread, NULL, (ZINT)I(0), test_rl5a) == OK);
+		primitive_make_thread(&thread, test_rl5a) == OK);
 	Sleep(1000);
 	CHECK("wait-for lock",
 		primitive_wait_for_recursive_lock(&recursive_lock) == OK);
@@ -404,7 +404,7 @@ Z test_rl6()
 	CHECK("make lock",
 		primitive_make_recursive_lock(&recursive_lock, NULL) == OK);
 	CHECK("make thread",
-		primitive_make_thread(&thread, NULL, (ZINT)I(0), test_rl6a) == OK);
+		primitive_make_thread(&thread, test_rl6a) == OK);
 	Sleep(1000);
 	CHECK("timed wait-for lock",
 		primitive_wait_for_recursive_lock_timed(&recursive_lock, (ZINT)I(1000)) == TIMEOUT);
@@ -533,7 +533,7 @@ Z test_s5()
 
 	printf("\n5 - Claim semaphore from another thread\n");
 	primitive_make_semaphore(&semaphore, NULL, (ZINT)I(5), (ZINT)I(5));
-	primitive_make_thread(&thread, NULL, (ZINT)I(0), test_s5a);
+	primitive_make_thread(&thread, test_s5a);
 
 	Sleep(500);
 	CHECK("wait-for semaphore",
@@ -595,7 +595,7 @@ Z test_n2()
 	CHECK("make lock",
 		primitive_make_simple_lock(&simple_lock, NULL) == OK);
 	CHECK("make thread",
-		primitive_make_thread(&thread, name, (ZINT)I(0), test_n2a) == OK);
+		primitive_make_thread(&thread, test_n2a) == OK);
 	CHECK("wait-for lock",
 		primitive_wait_for_simple_lock(&simple_lock) == OK);
 	CHECK("wait-for notification",
@@ -636,7 +636,7 @@ Z test_n3()
 	CHECK("make lock",
 		primitive_make_simple_lock(&simple_lock, name) == OK);
 	CHECK("make thread",
-		primitive_make_thread(&thread, name, (ZINT)I(0), test_n3a) == OK);
+		primitive_make_thread(&thread, test_n3a) == OK);
 
 	CHECK("wait-for lock",
 		primitive_wait_for_simple_lock(&simple_lock) == OK);
@@ -681,7 +681,7 @@ Z test_n4()
 	primitive_make_notification(&notification, NULL);
 	primitive_make_simple_lock(&simple_lock, NULL);
 	for (i=0; i<10; i++)
-		primitive_make_thread(&thread[i], NULL, (ZINT)I(0), test_n4a);
+		primitive_make_thread(&thread[i], test_n4a);
 
 	Sleep(1000);
 	CHECK("wait-for lock",
@@ -737,7 +737,7 @@ Z test_n5()
 
 	primitive_make_simple_lock(&simple_lock, NULL);
 	primitive_make_notification(&notification, NULL);
-	primitive_make_thread(&thread, NULL, (ZINT)I(0), test_n5a);
+	primitive_make_thread(&thread, test_n5a);
 
 	printf("\n5 - Timed waits for notification\n");
 	for (i=0; i<15; i++) {
@@ -777,7 +777,7 @@ Z test_t1()
 
 	printf("\n1 - Make a new thread, then join it.\n");
     CHECK("make thread",
-		primitive_make_thread(&thread, name, (ZINT)I(0), test_t1a) == OK);
+		primitive_make_thread(&thread, test_t1a) == OK);
 //	Sleep(1000);
 	CHECK("join thread",
 		primitive_thread_join_single(&thread) == OK);
@@ -809,7 +809,7 @@ Z test_t2()
 
 	for (i=0; i<N_THREADS; i++) {
 		CHECK("make thread",
-			primitive_make_thread(&thread[i], name, (ZINT)I(0), test_t2a) == OK);
+			primitive_make_thread(&thread[i], test_t2a) == OK);
 //		Sleep(500);
 	}
 
@@ -956,8 +956,8 @@ Z test_t6()
 	v1 = primitive_allocate_thread_variable(I(100));
 	v2 = primitive_allocate_thread_variable(I(200));
 
-	primitive_make_thread(&thread1, name, (ZINT)I(0), test_t6a);
-	primitive_make_thread(&thread2, name, (ZINT)I(0), test_t6b);
+	primitive_make_thread(&thread1, test_t6a);
+	primitive_make_thread(&thread2, test_t6b);
 
 	CHECK("v1 = 100",
 		primitive_read_thread_variable(v1) == I(100));

--- a/sources/lib/run-time/unix-threads-primitives.c
+++ b/sources/lib/run-time/unix-threads-primitives.c
@@ -152,13 +152,11 @@ extern void *dylan_false;
 
 /* 1 */
 THREADS_RUN_TIME_API  ZINT
-primitive_make_thread(DTHREAD *newthread, D_NAME name,
-                      ZINT zpriority, ZFN func, BOOL synchronize)
+primitive_make_thread(DTHREAD *newthread, ZFN func, BOOL synchronize)
 {
   int status;
   DTHREAD **newthread_ptr;
 
-  unused(name);
   unused(synchronize);
 
   newthread_ptr = (DTHREAD **)(dylan__malloc__ambig(4));

--- a/sources/lib/run-time/unix-threads-primitives.c
+++ b/sources/lib/run-time/unix-threads-primitives.c
@@ -155,19 +155,17 @@ THREADS_RUN_TIME_API  ZINT
 primitive_make_thread(DTHREAD *newthread, D_NAME name,
                       ZINT zpriority, ZFN func, BOOL synchronize)
 {
-  int    priority = (int)zpriority >> 2;
   int status;
   DTHREAD **newthread_ptr;
 
   unused(name);
   unused(synchronize);
-  unused(priority);
 
   newthread_ptr = (DTHREAD **)(dylan__malloc__ambig(4));
   newthread_ptr[0] = newthread;
 
   assert(newthread != NULL);
-  assert(IS_ZINT(zpriority));
+  assert(IS_ZINT(newthread->priority));
   assert(func != NULL);
 
 

--- a/sources/lib/run-time/unix-threads-primitives.h
+++ b/sources/lib/run-time/unix-threads-primitives.h
@@ -80,6 +80,10 @@ typedef struct _ctr2
   Z class;
   void *handle1;
   void *handle2;
+  void *priority;
+  void *thread_name;
+  void *function;
+  void *function_results;
 } DTHREAD;
 
 typedef void * D_NAME;

--- a/sources/lib/run-time/unix-threads-primitives.h
+++ b/sources/lib/run-time/unix-threads-primitives.h
@@ -130,8 +130,7 @@ typedef struct tlv_vector_list_element
 
 
 THREADS_RUN_TIME_API  ZINT
-primitive_make_thread(DTHREAD * newthread, D_NAME name, ZINT priority,
-                      ZFN func, BOOL synchronize);
+primitive_make_thread(DTHREAD * newthread, ZFN func, BOOL synchronize);
 
 THREADS_RUN_TIME_API  ZINT
 primitive_destroy_thread(DTHREAD * thread);

--- a/sources/lib/run-time/windows-threads-primitives.c
+++ b/sources/lib/run-time/windows-threads-primitives.c
@@ -324,14 +324,14 @@ primitive_make_thread(DTHREAD *newthread, D_NAME name,
   HANDLE hThread;
   HANDLE  *  events;
   DWORD  idThread;
-  int    priority = (int)zpriority >> 2;
+  int    priority = newthread->priority >> 2;
   DTHREAD **newthread_ptr;
 
   newthread_ptr = (DTHREAD **)(dylan__malloc__ambig(4));
   newthread_ptr[0] = newthread;
 
   assert(newthread != NULL);
-  assert(IS_ZINT(zpriority));
+  assert(IS_ZINT(newthread->priority));
   assert(func != NULL);
 
 

--- a/sources/lib/run-time/windows-threads-primitives.c
+++ b/sources/lib/run-time/windows-threads-primitives.c
@@ -318,8 +318,7 @@ extern void *dylan_false;
 
 /* 1 */
 THREADS_RUN_TIME_API  ZINT
-primitive_make_thread(DTHREAD *newthread, D_NAME name,
-                      ZINT zpriority, ZFN func, BOOL synchronize)
+primitive_make_thread(DTHREAD *newthread, ZFN func, BOOL synchronize)
 {
   HANDLE hThread;
   HANDLE  *  events;

--- a/sources/lib/run-time/windows-threads-primitives.h
+++ b/sources/lib/run-time/windows-threads-primitives.h
@@ -127,8 +127,7 @@ typedef struct tlv_vector_list_element
 
 
 THREADS_RUN_TIME_API  ZINT
-primitive_make_thread(DTHREAD * newthread, D_NAME name, ZINT priority,
-                      ZFN func, BOOL synchronize);
+primitive_make_thread(DTHREAD * newthread, ZFN func, BOOL synchronize);
 
 THREADS_RUN_TIME_API  ZINT
 primitive_destroy_thread(DTHREAD * thread);

--- a/sources/lib/run-time/windows-threads-primitives.h
+++ b/sources/lib/run-time/windows-threads-primitives.h
@@ -82,6 +82,10 @@ typedef struct _ctr2
   Z class;
   void *handle1;
   void *handle2;
+  void *priority;
+  void *thread_name;
+  void *function;
+  void *function_results;
 } DTHREAD;
 
 typedef void * D_NAME;


### PR DESCRIPTION
This is a precursor to moving the thread ID changes from the `current-thread-id` branch into the runtime code.