### PR TITLE
Re-implement current-thread-id in the thread code.

### DIFF
--- a/documentation/library-reference/source/common-dylan/threads.rst
+++ b/documentation/library-reference/source/common-dylan/threads.rst
@@ -460,6 +460,7 @@ Operations on threads
 
      - :func:`thread-name` Returns the name of a thread, or ``#f`` if no name was
        supplied.
+     - :gf:`thread-id` Returns the ID of a thread.
      - :func:`join-thread` Blocks until one of the specified threads has terminated,
        and returns the values of its function.
 
@@ -476,6 +477,24 @@ Operations on threads
 
      Returns the name of *thread* as a string. If *thread* does not have
      a name, this function returns ``#f``.
+
+.. generic-function:: thread-id
+
+   Returns the thread ID of a thread.
+
+   :signature: thread-id *thread* => *thread-id*
+
+   :parameter thread: An instance of :class:`<thread>`.
+   :value thread-id: An instance of :drm:`<integer>`.
+
+   :description:
+
+     Returns the thread ID of a thread. This is similar to the process ID for
+     an operating system process.
+
+     This is a value controlled by the underlying operating system. It is
+     most useful when trying to correlate thread activity with reports from
+     other tools.
 
 .. function:: join-thread
 
@@ -554,6 +573,22 @@ Operations on threads
    :description:
 
      Returns the current thread.
+
+.. function:: current-thread-id
+
+   Returns the ID of the current thread.
+
+   :signature: current-thread-id () => *thread-id*
+
+   :value thread-id: An instance of :drm:`<integer>`.
+
+   :description:
+
+     Returns the ID of the current thread.
+
+   :seealso:
+
+     - :gf:`thread-id`
 
 Synchronization protocol
 ========================

--- a/documentation/library-reference/source/system/operating-system.rst
+++ b/documentation/library-reference/source/system/operating-system.rst
@@ -71,7 +71,6 @@ information.
 - :func:`application-filename`
 - :func:`tokenize-command-string`
 - :func:`current-process-id`
-- :func:`current-thread-id`
 - :func:`parent-process-id`
 
 Working with shared libraries
@@ -195,23 +194,6 @@ System library's operating-system module.
    :seealso:
 
      - :func:`current-thread-id`
-     - :func:`parent-process-id`
-
-.. function:: current-thread-id
-
-   Returns the integer value for the current thread ID.
-
-   :signature: current-thread-id => *tid*
-
-   :value tid: An instance of :drm:`<integer>`.
-
-   :description:
-
-     Returns the integer value of the current thread ID.
-
-   :seealso:
-
-     - :func:`current-process-id`
      - :func:`parent-process-id`
 
 .. function:: environment-variable

--- a/documentation/release-notes/source/2016.1.rst
+++ b/documentation/release-notes/source/2016.1.rst
@@ -102,6 +102,9 @@ Common Dylan
   method which will return if the given float is ``#"normal"``,
   ``#"zero"``, ``#"infinite"``, ``#"nan"``, or ``#"subnormal"``.
 
+* The ``thread`` module has gained a ``current-thread-id`` function. The
+  ``thread-id`` is also available for any ``<thread>`` object.
+
 Compiler
 ========
 
@@ -197,8 +200,6 @@ system
   from strings for the ``<file-system-directory-locator>`` and
   ``<file-system-file-locator>`` classes. These aren't typically used but
   their omission led to possible confusion for users.
-
-* The ``operating-system`` module has gained a ``current-thread-id`` function.
 
 .. _issue #899: https://github.com/dylan-lang/opendylan/issues/899
 .. _documented in the library reference: http://opendylan.org/documentation/library-reference/coloring-stream/

--- a/sources/common-dylan/tests/specification.dylan
+++ b/sources/common-dylan/tests/specification.dylan
@@ -431,10 +431,12 @@ define module-spec threads ()
   constant $interactive-priority :: <object>;
   constant $high-priority :: <object>;
   function thread-name (<thread>) => (false-or(<string>));
+  function thread-id (<thread>) => (<integer>);
   function join-thread (<thread>, #"rest") => (<thread>, #"rest");
   class <duplicate-join-error> (<thread-error>);
   function thread-yield () => ();
   function current-thread () => (<thread>);
+  function current-thread-id () => (<integer>);
 
   // Synchronization protocol
   open abstract class <synchronization> (<object>);

--- a/sources/common-dylan/tests/threads/threads-spec.dylan
+++ b/sources/common-dylan/tests/threads/threads-spec.dylan
@@ -42,6 +42,10 @@ define threads function-test thread-name ()
   //---*** Fill this in...
 end function-test thread-name;
 
+define threads function-test thread-id ()
+  //---*** Fill this in...
+end function-test thread-id;
+
 define threads function-test join-thread ()
   //---*** Fill this in...
 end function-test join-thread;
@@ -58,3 +62,5 @@ define threads function-test current-thread ()
   //---*** Fill this in...
 end function-test current-thread;
 
+define threads function-test current-thread-id ()
+end function-test current-thread-id;

--- a/sources/dfmc/modeling/namespaces.dylan
+++ b/sources/dfmc/modeling/namespaces.dylan
@@ -1824,10 +1824,12 @@ define &module threads
 
     // <Thread>
     <thread>, <synchronous-thread>,
+    thread-id,
     thread-name,
     join-thread,
     thread-yield,
     current-thread,
+    current-thread-id,
     $low-priority,
     $background-priority,
     $normal-priority,

--- a/sources/dylan/locks.dylan
+++ b/sources/dylan/locks.dylan
@@ -109,7 +109,7 @@ end method;
 
 define inline sealed method release (lock :: <semaphore>, #key) => ()
   debug-out(#"lock", "Releasing lock %= in thread %=\n",
-            lock, current-thread-id());
+            lock, current-thread-ident());
   let res = primitive-release-semaphore(lock);
   lock-release-result(lock, res);
 end method;
@@ -117,14 +117,14 @@ end method;
 
 define inline sealed method wait-for (lock :: <semaphore>, #key timeout) => (success?)
   debug-out(#"lock", "Waiting for lock %= in thread %=\n",
-            lock, current-thread-id());
+            lock, current-thread-ident());
   let res = if (timeout)
                primitive-wait-for-semaphore-timed(lock, timeout.millisecs)
              else
                primitive-wait-for-semaphore(lock)
              end if;
   debug-out(#"lock", "Waiting for lock %= in thread %= returned %=\n",
-            lock, current-thread-id(), res);
+            lock, current-thread-ident(), res);
   lock-wait-result(lock, res);
 end method;
 
@@ -190,7 +190,7 @@ end method;
 
 define inline sealed method release (lock :: <recursive-lock>, #key) => ()
   debug-out(#"lock", "Releasing lock %= in thread %=\n",
-            lock, current-thread-id());
+            lock, current-thread-ident());
   let res = primitive-release-recursive-lock(lock);
   lock-release-result(lock, res);
 end method;
@@ -199,14 +199,14 @@ end method;
 define inline sealed method wait-for
       (lock :: <recursive-lock>, #key timeout) => (success?)
   debug-out(#"lock", "Waiting for lock %= in thread %=\n",
-            lock, current-thread-id());
+            lock, current-thread-ident());
   let res = if (timeout)
                primitive-wait-for-recursive-lock-timed(lock, timeout.millisecs)
              else
                primitive-wait-for-recursive-lock(lock)
              end if;
   debug-out(#"lock", "Waiting for lock %= in thread %= returned %=\n",
-            lock, current-thread-id(), res);
+            lock, current-thread-ident(), res);
   lock-wait-result(lock, res);
 end method;
 
@@ -274,7 +274,7 @@ end method;
 
 define inline sealed method release (lock :: <simple-lock>, #key) => ()
   debug-out(#"lock", "Releasing lock %= in thread %=\n",
-            lock, current-thread-id());
+            lock, current-thread-ident());
   let res = primitive-release-simple-lock(lock);
   lock-release-result(lock, res);
 end method;
@@ -283,14 +283,14 @@ end method;
 define inline sealed method wait-for
       (lock :: <simple-lock>, #key timeout) => (success?)
   debug-out(#"lock", "Waiting for lock %= in thread %=\n",
-            lock, current-thread-id());
+            lock, current-thread-ident());
   let res = if (timeout)
                primitive-wait-for-simple-lock-timed(lock, timeout.millisecs)
              else
                primitive-wait-for-simple-lock(lock)
              end if;
   debug-out(#"lock", "Waiting for lock %= in thread %= returned %=\n",
-            lock, current-thread-id(), res);
+            lock, current-thread-ident(), res);
   lock-wait-result(lock, res);
 end method;
 
@@ -349,7 +349,7 @@ end method;
 
 define sealed method release (lock :: <read-write-lock>, #key) => ()
   debug-out(#"lock", "Releasing lock %= in thread %=\n",
-            lock, current-thread-id());
+            lock, current-thread-ident());
   let monitor = lock.internal-monitor;
   let inner-lock = monitor.associated-lock;
   let res =
@@ -383,7 +383,7 @@ define sealed method wait-for
       (lock :: <read-write-lock>, #key timeout, mode = #"read") => (success?)
   if (mode == #"read" | mode == #"write")
     debug-out(#"lock", "Waiting for lock %= in thread %=\n",
-              lock, current-thread-id());
+              lock, current-thread-ident());
     let monitor = lock.internal-monitor;
     let inner-lock = monitor.associated-lock;
     block (exit)
@@ -393,7 +393,7 @@ define sealed method wait-for
           until (lock.lock-is-free?)
             unless (wait-for(monitor, timeout: timeout))
               debug-out(#"lock", "Acquired lock %= in thread %=\n",
-                        lock, current-thread-id());
+                        lock, current-thread-ident());
               exit(#f);
             end unless;
           end until;
@@ -403,7 +403,7 @@ define sealed method wait-for
           until (lock.lock-is-free-for-reading?)
             unless (wait-for(monitor, timeout: timeout))
               debug-out(#"lock", "Acquired lock %= in thread %=\n",
-                        lock, current-thread-id());
+                        lock, current-thread-ident());
               exit(#f);
             end unless;
           end until;
@@ -452,6 +452,6 @@ end method;
 
 
 //Helper for debug output
-define inline function current-thread-id () => (res)
+define inline function current-thread-ident () => (res)
   current-thread().thread-name | current-thread();
 end;

--- a/sources/dylan/thread.dylan
+++ b/sources/dylan/thread.dylan
@@ -28,6 +28,8 @@ define sealed class <thread> (<portable-double-container>)
 
   slot function-results :: <simple-object-vector> = #[];
 
+  constant slot thread-id :: <integer> = 0;
+
 end class;
 
 ignore(priority);
@@ -153,6 +155,9 @@ define function current-thread () => (thread :: <thread>)
   primitive-current-thread();
 end;
 
+define function current-thread-id () => (thread-id :: <integer>)
+  current-thread().thread-id
+end;
 
 
 ///// Sleep

--- a/sources/lib/run-time/Makefile.in
+++ b/sources/lib/run-time/Makefile.in
@@ -119,6 +119,7 @@ HARP_RUNTIME_OBJS = \
 		  $(OBJDIR_HARP)/collector.o \
 		  $(OBJDIR_HARP)/debug-print.o \
 		  $(OBJDIR_HARP)/stack-walker.o \
+		  $(OBJDIR_HARP)/thread-utils.o \
 		  $(OBJDIR_HARP)/trace.o \
 		  $(OBJDIR_HARP)/unix-harp-support.o \
 		  $(OBJDIR_HARP)/unix-spy-interfaces.o \
@@ -144,6 +145,7 @@ LLVM_RUNTIME_OBJS = \
 		  $(OBJDIR_LLVM)/break.o \
 		  $(OBJDIR_LLVM)/collector.o \
 		  $(OBJDIR_LLVM)/stack-walker.o \
+		  $(OBJDIR_LLVM)/thread-utils.o \
 		  $(OBJDIR_LLVM)/unix-spy-interfaces.o \
 		  $(OBJDIR_LLVM)/llvm-runtime-init.o \
 		  $(OBJDIR_LLVM)/llvm-nlx.o \
@@ -176,6 +178,7 @@ C_RUNTIME_OBJS	= $(OBJDIR_C)/break.o \
 		  $(OBJDIR_C)/collector.o \
 		  $(OBJDIR_C)/debug-print.o \
 		  $(OBJDIR_C)/stack-walker.o \
+		  $(OBJDIR_C)/thread-utils.o \
 		  $(OBJDIR_C)/trace.o \
 		  $(OBJDIR_C)/unix-spy-interfaces.o \
 		  $(OBJDIR_C)/c-run-time.o \

--- a/sources/lib/run-time/llvm-posix-threads.c
+++ b/sources/lib/run-time/llvm-posix-threads.c
@@ -10,6 +10,7 @@
 
 #include "llvm-runtime.h"
 #include "mm.h"
+#include "thread-utils.h"
 
 // The BDW GC wants to wrap pthreads functions
 #if defined(GC_USE_BOEHM)
@@ -409,12 +410,19 @@ void primitive_initialize_current_thread(dylan_value t, DBOOL synchronize)
     = (struct KLthreadGYthreadsVdylan *) t;
   thread->handle2 = NULL;      // Drop reference to trampoline closure
 
+  thread->thread_id = I(dylan_current_thread_id());
+
   Pteb.teb_current_thread = t;
 }
 
 // primitive-initialize-special-thread
 void primitive_initialize_special_thread(dylan_value t)
 {
+  struct KLthreadGYthreadsVdylan *thread
+    = (struct KLthreadGYthreadsVdylan *) t;
+
+  thread->thread_id = I(dylan_current_thread_id());
+
   Pteb.teb_current_thread = t;
 }
 

--- a/sources/lib/run-time/posix-threads.c
+++ b/sources/lib/run-time/posix-threads.c
@@ -39,6 +39,7 @@
 #include <pthread_np.h>
 #endif
 
+#include "thread-utils.h"
 
 static void timespec_add_msecs(struct timespec *tp, long msecs) {
   long secs = msecs / 1000;
@@ -481,7 +482,6 @@ static void *trampoline (void *arg)
   THREAD     *rthread;
 
   assert(thread != NULL);
-
 
   rthread = (THREAD*)(thread->handle2);
 
@@ -1605,6 +1605,8 @@ dylan_value primitive_initialize_current_thread(dylan_value t, DBOOL synchronize
 
   ignore(synchronize);
   assert(thread != NULL);
+
+  thread->thread_id = I(dylan_current_thread_id());
 
   rthread = (THREAD*)(thread->handle2);
 

--- a/sources/lib/run-time/posix-threads.h
+++ b/sources/lib/run-time/posix-threads.h
@@ -129,6 +129,7 @@ typedef struct _ctr2
   dylan_value thread_name;
   dylan_value function;
   dylan_value function_results;
+  dylan_value thread_id;
 } DTHREAD;
 
 typedef void * D_NAME;

--- a/sources/lib/run-time/thread-utils.c
+++ b/sources/lib/run-time/thread-utils.c
@@ -1,4 +1,4 @@
-#include <stdint.h>
+#include "thread-utils.h"
 
 #if defined(OPEN_DYLAN_PLATFORM_LINUX) || defined(OPEN_DYLAN_PLATFORM_OPENBSD)
 #include <unistd.h>
@@ -11,7 +11,7 @@
 #include <lwp.h>
 #endif
 
-uint64_t system_current_thread_id(void)
+uint64_t dylan_current_thread_id(void)
 {
 #if defined(OPEN_DYLAN_PLATFORM_LINUX)
   return syscall(SYS_gettid);
@@ -26,7 +26,7 @@ uint64_t system_current_thread_id(void)
 #elif defined(OPEN_DYLAN_PLATFORM_OPENBSD)
   return syscall(SYS_getthrid);
 #else
-  #error system_current_thread_id is not yet implemented.
+  #error dylan_current_thread_id is not yet implemented.
 #endif
   return 0;
 }

--- a/sources/lib/run-time/thread-utils.h
+++ b/sources/lib/run-time/thread-utils.h
@@ -1,0 +1,3 @@
+#include <stdint.h>
+
+uint64_t dylan_current_thread_id(void);

--- a/sources/lib/run-time/unix-threads-primitives.c
+++ b/sources/lib/run-time/unix-threads-primitives.c
@@ -25,6 +25,8 @@
 
 #include "unix-threads-primitives.h"
 
+#include "thread-utils.h"
+
 #define unused(x) (void)x
 
 /*****************************************************************************/
@@ -1206,6 +1208,8 @@ primitive_initialize_current_thread(DTHREAD *thread, BOOL synchronize)
 
   /* @@@@#!"£$ no support for "synchronized" threads */
   assert(thread != NULL);
+
+  thread->thread_id = I(dylan_current_thread_id());
 
   // race conditions mean handle may not be set up yet by father thread in pthread_create,
   // so do it here explicitly.

--- a/sources/lib/run-time/unix-threads-primitives.h
+++ b/sources/lib/run-time/unix-threads-primitives.h
@@ -84,6 +84,7 @@ typedef struct _ctr2
   void *thread_name;
   void *function;
   void *function_results;
+  void *thread_id;
 } DTHREAD;
 
 typedef void * D_NAME;

--- a/sources/lib/run-time/windows-threads-primitives.c
+++ b/sources/lib/run-time/windows-threads-primitives.c
@@ -24,6 +24,7 @@
 #include <windows.h>
 
 #include "windows-threads-primitives.h"
+#include "thread-utils.h"
 
 
 /*****************************************************************************/
@@ -1389,6 +1390,8 @@ primitive_initialize_current_thread(DTHREAD *thread, BOOL synchronize)
   int         size;
 
   assert(thread != NULL);
+
+  thread->thread_id = I(dylan_current_thread_id());
 
   if (synchronize) {
     events = thread->handle1;

--- a/sources/lib/run-time/windows-threads-primitives.h
+++ b/sources/lib/run-time/windows-threads-primitives.h
@@ -86,6 +86,7 @@ typedef struct _ctr2
   void *thread_name;
   void *function;
   void *function_results;
+  void *thread_id;
 } DTHREAD;
 
 typedef void * D_NAME;

--- a/sources/system/arm-linux-system.lid
+++ b/sources/system/arm-linux-system.lid
@@ -30,7 +30,6 @@ Files: library
        settings/settings
        settings/dummy-settings
 C-Source-Files: unix-portability.c
-                thread-id.c
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.

--- a/sources/system/library.dylan
+++ b/sources/system/library.dylan
@@ -68,7 +68,6 @@ define module operating-system
          signal-application-event,
          load-library,
          current-process-id,
-         current-thread-id,
          parent-process-id;
 
   create command-line-option-prefix;

--- a/sources/system/tests/operating-system.dylan
+++ b/sources/system/tests/operating-system.dylan
@@ -338,12 +338,6 @@ define operating-system function-test current-process-id ()
   check-true("current-process-id > 0", pid > 0);
 end;
 
-define operating-system function-test current-thread-id ()
-  let tid = current-thread-id();
-  check-true("current-thread-id is an integer", instance?(tid, <integer>));
-  check-true("current-thread-id > 0", tid > 0);
-end;
-
 define operating-system function-test parent-process-id ()
   let pid = parent-process-id();
   check-true("parent-process-id is an integer", instance?(pid, <integer>));

--- a/sources/system/tests/specification.dylan
+++ b/sources/system/tests/specification.dylan
@@ -204,7 +204,6 @@ define module-spec operating-system ()
     (<application-process>) => (<integer>, false-or(<integer>));
   function load-library (<string>) => (<object>);
   function current-process-id () => (<integer>);
-  function current-thread-id () => (<integer>);
   function parent-process-id () => (<integer>);
 
   // Application startup handling

--- a/sources/system/unix-operating-system.dylan
+++ b/sources/system/unix-operating-system.dylan
@@ -570,14 +570,6 @@ define function current-process-id
                  end);
 end;
 
-define function current-thread-id
-    () => (tid :: <integer>)
-  raw-as-integer(%call-c-function("system_current_thread_id")
-                     () => (tid :: <raw-c-signed-int>)
-                     ()
-                 end);
-end;
-
 define function parent-process-id
     () => (pid :: <integer>)
   raw-as-integer(%call-c-function("getppid")

--- a/sources/system/x86-darwin-system.lid
+++ b/sources/system/x86-darwin-system.lid
@@ -31,7 +31,6 @@ Files: library
        settings/settings
        settings/dummy-settings
 C-Source-Files: unix-portability.c
-                thread-id.c
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.

--- a/sources/system/x86-freebsd-system.lid
+++ b/sources/system/x86-freebsd-system.lid
@@ -30,7 +30,6 @@ Files: library
        settings/settings
        settings/dummy-settings
 C-Source-Files: unix-portability.c
-                thread-id.c
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.

--- a/sources/system/x86-linux-system.lid
+++ b/sources/system/x86-linux-system.lid
@@ -30,7 +30,6 @@ Files: library
        settings/settings
        settings/dummy-settings
 C-Source-Files: unix-portability.c
-                thread-id.c
 C-Libraries: -ldl
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.

--- a/sources/system/x86-netbsd-system.lid
+++ b/sources/system/x86-netbsd-system.lid
@@ -30,7 +30,6 @@ Files: library
        settings/settings
        settings/dummy-settings
 C-Source-Files: unix-portability.c
-                thread-id.c
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.

--- a/sources/system/x86-win32-operating-system.dylan
+++ b/sources/system/x86-win32-operating-system.dylan
@@ -1279,14 +1279,6 @@ define function current-process-id
                  end);
 end;
 
-define function current-thread-id
-    () => (tid :: <integer>)
-  raw-as-integer(%call-c-function("GetCurrentThreadId", c-modifiers: "__stdcall")
-                     () => (tid :: <raw-c-unsigned-int>)
-                     ()
-                 end);
-end;
-
 define function parent-process-id
     () => (pid :: <integer>)
   0

--- a/sources/system/x86_64-darwin-system.lid
+++ b/sources/system/x86_64-darwin-system.lid
@@ -31,7 +31,6 @@ Files: library
        settings/settings
        settings/dummy-settings
 C-Source-Files: unix-portability.c
-                thread-id.c
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.

--- a/sources/system/x86_64-freebsd-system.lid
+++ b/sources/system/x86_64-freebsd-system.lid
@@ -30,7 +30,6 @@ Files: library
        settings/settings
        settings/dummy-settings
 C-Source-Files: unix-portability.c
-                thread-id.c
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.

--- a/sources/system/x86_64-linux-system.lid
+++ b/sources/system/x86_64-linux-system.lid
@@ -30,7 +30,6 @@ Files: library
        settings/settings
        settings/dummy-settings
 C-Source-Files: unix-portability.c
-                thread-id.c
 C-Libraries: -ldl
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.

--- a/sources/system/x86_64-netbsd-system.lid
+++ b/sources/system/x86_64-netbsd-system.lid
@@ -30,7 +30,6 @@ Files: library
        settings/settings
        settings/dummy-settings
 C-Source-Files: unix-portability.c
-                thread-id.c
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.


### PR DESCRIPTION
This moves the current-thread-id implementation from the system library
to the actual thread implementation in the dylan library.

Now, when a thread is initialized, the thread-id is stored in a slot on
the <thread> object. A helper function current-thread-id is provided.

* documentation/library-reference/source/common-dylan/threads.rst
  (current-thread-id): Document thread-id and current-thread-id here.

* documentation/library-reference/source/system/operating-system.rst
  (current-thread-id): Remove documentation for current-thread-id.

* documentation/release-notes/source/2016.1.rst: Update to move discussion
  of current-thread-id to the appropriate section now that it has moved.

* sources/common-dylan/tests/specification.dylan
  (module-spec threads): Add thread-id and current-thread-id.

* sources/common-dylan/tests/threads/threads-spec.dylan
  (function-test thread-id, function-test current-thread-id): Add stub tests.

* sources/dfmc/modeling/namespaces.dylan
  (&module threads): Export thread-id and current-thread-id.

* sources/dylan/locks.dylan
  (current-thread-id): Rename helper function and usages to current-thread-ident.

* sources/dylan/thread.dylan
  (<thread>): Add slot for thread-id.
  (current-thread-id): Implement.

* sources/system/thread-id.c: Move to sources/lib/run-time/thread-utils.c

* sources/lib/run-time/thread-utils.h: New file.

* sources/lib/run-time/Makefile.in: Build thread-utils.c

* sources/lib/run-time/llvm-posix-threads.c
  (primitive_initialize_current_thread): Set thread_id on the thread object.
  (primitive_initialize_special_thread): Likewise.

* sources/lib/run-time/posix-threads.c
  (primitive_initialize_current_thread): Set thread_id on the thread object.

* sources/lib/run-time/posix-threads.h
  (struct DTHREAD): Add member for thread_id slot.

* sources/lib/run-time/unix-threads-primitives.c
  (primitive_initialize_current_thread): Set thread_id on the thread object.

* sources/lib/run-time/unix-threads-primitives.h
  (struct DTHREAD): Add member for thread_id slot.

* sources/lib/run-time/windows-threads-primitives.c
  (primitive_initialize_current_thread): Set thread_id on the thread object.

* sources/lib/run-time/windows-threads-primitives.h
  (struct DTHREAD): Add member for thread_id slot.

* sources/system/library.dylan
  (module operating-system): No longer export current-thread-id.

* sources/system/tests/operating-system.dylan
  (function-test current-thread-id): Remove.

* sources/system/tests/specification.dylan
  (module-spec operating-system): Remove current-thread-id.

* sources/system/unix-operating-system.dylan
  (current-thread-id): Remove.

* sources/system/x86-win32-operating-system.dylan
  (current-thread-id): Remove.

* sources/system/arm-linux-system.lid
  sources/system/x86-darwin-system.lid
  sources/system/x86-freebsd-system.lid
  sources/system/x86-linux-system.lid
  sources/system/x86-netbsd-system.lid
  sources/system/x86_64-darwin-system.lid
  sources/system/x86_64-freebsd-system.lid
  sources/system/x86_64-linux-system.lid
  sources/system/x86_64-netbsd-system.lid: No longer build thread-id.c