### PR TITLE
Use <C-size-t> and <C-ssize-t> more.

### DIFF
--- a/sources/common-dylan/darwin-common-extensions.dylan
+++ b/sources/common-dylan/darwin-common-extensions.dylan
@@ -32,7 +32,7 @@ define function darwin-sysctl
   when (raw-as-integer(%call-c-function ("sysctl")
     (mib :: <raw-byte-string>, cnt :: <raw-c-unsigned-int>,
      out :: <raw-byte-string> , osize :: <raw-byte-string>,
-     in :: <raw-byte-string>, isize :: <raw-c-unsigned-int>)
+     in :: <raw-byte-string>, isize :: <raw-c-size-t>)
     => (ret :: <raw-c-signed-int>)
     (primitive-string-as-raw(rmib), integer-as-raw(rmib-size),
      primitive-cast-raw-as-pointer(integer-as-raw(0)),
@@ -40,20 +40,20 @@ define function darwin-sysctl
      primitive-cast-raw-as-pointer(integer-as-raw(0)),
      integer-as-raw(0)) end) >= 0)
 
-    let osize = raw-as-integer(primitive-c-unsigned-long-at
+    let osize = raw-as-integer(primitive-c-size-t-at
       (primitive-string-as-raw(rosize),
        integer-as-raw(0), integer-as-raw(0))) + 1;
     let out = make(<byte-string>, size: osize, fill: '\0');
 
-    primitive-c-unsigned-long-at(primitive-string-as-raw(rosize),
-                                 integer-as-raw(0), integer-as-raw(0))
+    primitive-c-size-t-at(primitive-string-as-raw(rosize),
+                          integer-as-raw(0), integer-as-raw(0))
       := integer-as-raw(osize);
 
     // do the actual sysctl
     when(raw-as-integer(%call-c-function ("sysctl")
       (mib :: <raw-byte-string>, cnt :: <raw-c-unsigned-int>,
        out :: <raw-byte-string>, osize :: <raw-byte-string>,
-       in :: <raw-byte-string>, isize :: <raw-c-unsigned-int>)
+       in :: <raw-byte-string>, isize :: <raw-c-size-t>)
       => (ret :: <raw-c-signed-int>)
       (primitive-string-as-raw(rmib), integer-as-raw(mib-size),
        primitive-string-as-raw(out), primitive-string-as-raw(rosize),

--- a/sources/common-dylan/linux-common-extensions.dylan
+++ b/sources/common-dylan/linux-common-extensions.dylan
@@ -31,8 +31,8 @@ define inline-only function get-application-commandline
           := raw-as-integer(%call-c-function ("read")
                               (fd :: <raw-c-signed-int>,
                                buffer :: <raw-byte-string>,
-                               size :: <raw-c-unsigned-long>)
-                              => (count :: <raw-c-signed-int>)
+                               size :: <raw-c-size-t>)
+                              => (count :: <raw-c-ssize-t>)
                               (integer-as-raw(cmdline-fd),
                                primitive-string-as-raw(buffer),
                                integer-as-raw(8192))
@@ -61,8 +61,8 @@ define inline-only function get-application-filename
     = raw-as-integer(%call-c-function ("readlink")
                        (path :: <raw-byte-string>,
                         buffer :: <raw-byte-string>,
-                        bufsize :: <raw-c-unsigned-long>)
-                       => (count :: <raw-c-signed-int>)
+                        bufsize :: <raw-c-size-t>)
+                       => (count :: <raw-c-ssize-t>)
                        (primitive-string-as-raw(exe-path),
                         primitive-string-as-raw(buffer),
                         integer-as-raw(8192))

--- a/sources/common-dylan/unix-common-extensions.dylan
+++ b/sources/common-dylan/unix-common-extensions.dylan
@@ -23,8 +23,8 @@ define inline function write-console
       end;
   let string-size :: <integer> = _end | size(string);
   %call-c-function ("write")
-      (fd :: <raw-c-signed-int>, buffer :: <raw-byte-string>, size :: <raw-c-unsigned-long>)
-   => (count :: <raw-c-signed-int>)
+      (fd :: <raw-c-signed-int>, buffer :: <raw-byte-string>, size :: <raw-c-size-t>)
+   => (count :: <raw-c-ssize-t>)
     (integer-as-raw(istream), primitive-string-as-raw(string), integer-as-raw(string-size))
   end;
   //---*** NOTE: Should we do something here if we can't do the I/O???

--- a/sources/io/unix-interface.dylan
+++ b/sources/io/unix-interface.dylan
@@ -43,8 +43,8 @@ define function unix-read
     raw-as-integer
       (%call-c-function ("read")
            (fd :: <raw-c-unsigned-int>, address :: <raw-pointer>,
-            size :: <raw-c-unsigned-long>)
-        => (result :: <raw-c-signed-int>)
+            size :: <raw-c-size-t>)
+        => (result :: <raw-c-ssize-t>)
          (integer-as-raw(fd),
           primitive-cast-raw-as-pointer
             (primitive-machine-word-add
@@ -62,8 +62,8 @@ define function unix-write
     raw-as-integer
       (%call-c-function ("write")
            (fd :: <raw-c-unsigned-int>, address :: <raw-pointer>,
-            size :: <raw-c-unsigned-long>)
-        => (result :: <raw-c-signed-int>)
+            size :: <raw-c-size-t>)
+        => (result :: <raw-c-ssize-t>)
          (integer-as-raw(fd),
           primitive-cast-raw-as-pointer
             (primitive-machine-word-add

--- a/sources/system/file-system/unix-file-system.dylan
+++ b/sources/system/file-system/unix-file-system.dylan
@@ -132,8 +132,8 @@ define function %link-target
     let count
       = raw-as-integer(%call-c-function ("readlink")
                            (path :: <raw-byte-string>, buffer :: <raw-byte-string>,
-                            bufsize :: <raw-c-unsigned-long>)
-                        => (count :: <raw-c-signed-int>)
+                            bufsize :: <raw-c-size-t>)
+                        => (count :: <raw-c-ssize-t>)
                            (primitive-string-as-raw(as(<byte-string>, link)),
                             primitive-string-as-raw(buffer),
                             integer-as-raw(8192))
@@ -599,7 +599,7 @@ define function %working-directory
             (primitive-cast-pointer-as-raw(primitive-string-as-raw(buffer)),
              primitive-cast-pointer-as-raw
                (%call-c-function ("getcwd")
-                    (buf :: <raw-byte-string>, size :: <raw-c-unsigned-long>)
+                    (buf :: <raw-byte-string>, size :: <raw-c-size-t>)
                  => (result :: <raw-pointer>)
                   (primitive-string-as-raw(buffer), integer-as-raw(bufsiz))
                 end)))

--- a/sources/system/file-system/unix-interface.dylan
+++ b/sources/system/file-system/unix-interface.dylan
@@ -64,8 +64,8 @@ define function unix-raw-read
     raw-as-integer
       (%call-c-function ("read")
            (fd :: <raw-c-unsigned-int>, address :: <raw-pointer>,
-            size :: <raw-c-unsigned-long>)
-        => (result :: <raw-c-signed-int>)
+            size :: <raw-c-size-t>)
+        => (result :: <raw-c-ssize-t>)
          (integer-as-raw(fd),
           primitive-cast-raw-as-pointer
             (primitive-unwrap-machine-word(address)),


### PR DESCRIPTION
There are places within our core libraries where we could / should
be using <C-size-t> or <C-ssize-t> but are not yet.

This addresses the non-Windows cases apart from the network library
which is slated to be replaced.

* sources/common-dylan/darwin-common-extensions.dylan
  (``darwin-sysctl``): Use ``<raw-c-size-t>`` and ``primitive-c-size-t-at``
   for the size parameters.

* sources/common-dylan/linux-common-extensions.dylan
  (``get-application-commandline``,
   ``get-application-filename``): ``read`` and ``readlink`` take ``<raw-c-size-t>``
    and return ``<raw-c-ssize-t>`` values.

* sources/common-dylan/unix-common-extensions.dylan
  (``write-console``): ``write`` takes a ``<raw-c-size-t>`` and returns
   a ``<raw-c-ssize-t>``.

* sources/io/unix-interface.dylan
  (``unix-read``): ``read`` takes a ``<raw-c-size-t>`` and returns
   a ``<raw-c-ssize-t>``.
  (``unix-write``): ``write`` takes a ``<raw-c-size-t>`` and returns
   a ``<raw-c-ssize-t>``.

* sources/system/file-system/unix-file-system.dylan
  (``%link-target``): ``readlink`` takes a ``<raw-c-size-t>`` and returns
   a ``<raw-c-ssize-t>``.
  (``%working-directory``): ``getcwd`` takes a ``<raw-c-size-t>`` value.

* sources/system/file-system/unix-interface.dylan
  (``unix-raw-read``): ``read`` takes a ``<raw-c-size-t>`` and returns
   a ``<raw-c-ssize-t>``.