### PR TITLE
[llvm run-time] Hook up setting thread name.

### DIFF
--- a/sources/app/llvm-runtime-generator/llvm-runtime-generator.dylan
+++ b/sources/app/llvm-runtime-generator/llvm-runtime-generator.dylan
@@ -66,7 +66,8 @@ define constant $runtime-referenced-classes
       #"<simple-lock>",
       #"<read-write-lock>",
       #"<notification>",
-      #"<simple-object-vector>"];
+      #"<simple-object-vector>",
+      #"<byte-string>"];
 
 define constant $debug-producer = "Open Dylan LLVM Runtime Generator";
 

--- a/sources/lib/run-time/llvm-posix-threads.c
+++ b/sources/lib/run-time/llvm-posix-threads.c
@@ -413,6 +413,13 @@ void primitive_initialize_current_thread(dylan_value t, DBOOL synchronize)
   thread->thread_id = I(dylan_current_thread_id());
 
   Pteb.teb_current_thread = t;
+
+  if (thread->thread_name != &KPfalseVKi) {
+    struct KLbyte_stringGVKd *thread_name
+      = (struct KLbyte_stringGVKd *) thread->thread_name;
+    const char *raw = (const char *)thread_name->string_element;
+    dylan_set_current_thread_name(raw);
+  }
 }
 
 // primitive-initialize-special-thread
@@ -424,6 +431,13 @@ void primitive_initialize_special_thread(dylan_value t)
   thread->thread_id = I(dylan_current_thread_id());
 
   Pteb.teb_current_thread = t;
+
+  if (thread->thread_name != &KPfalseVKi) {
+    struct KLbyte_stringGVKd *thread_name
+      = (struct KLbyte_stringGVKd *) thread->thread_name;
+    const char *raw = (const char *)thread_name->string_element;
+    dylan_set_current_thread_name(raw);
+  }
 }
 
 // primitive-sleep


### PR DESCRIPTION
This sets the OS thread name to match the Dylan thread name
in the LLVM run-time when using POSIX threads.

* sources/app/llvm-runtime-generator/llvm-runtime-generator.dylan
  (``$runtime-referenced-classes``): Add ``<byte-string>`` as we need to
   get access to the string data for the thread name and we don't
   have a ``primitive_string_as_raw`` or similar.

* sources/lib/run-time/llvm-posix-threads.c
  (``primitive_initialize_current_thread``,
   ``primitive_initialize_special_thread``): If the ``thread_name`` is set,
    then set the thread's name at the OS level.