### PR TITLE
[llvm run-time] Don't use sys_errlist.

### DIFF
--- a/sources/lib/run-time/llvm-posix-threads.c
+++ b/sources/lib/run-time/llvm-posix-threads.c
@@ -2,6 +2,7 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <string.h>
 #include <unistd.h>
 #include <errno.h>
 #include <pthread.h>
@@ -854,7 +855,7 @@ dylan_value primitive_wait_for_simple_lock_timed(dylan_value l, dylan_value ms)
         return TIMEOUT;
       } else {
         fprintf(stderr, "%s: pthread_cond_timedwait returned %s\n",
-                __func__, sys_errlist[rc]);
+                __func__, strerror(rc));
         return GENERAL_ERROR;
       }
     }


### PR DESCRIPTION
``sys_errlist`` has long been deprecated and isn't supported on all
platforms.

* sources/lib/run-time/llvm-posix-threads.c
  (``primitive_wait_for_simple_lock_timed``): Use ``strerror``
   instead of ``sys_errlist``.