### PR TITLE
[parser-generator] Fix unrecognized-keyword warning.

### DIFF
--- a/sources/lib/parser-generator/compile.dylan
+++ b/sources/lib/parser-generator/compile.dylan
@@ -5,27 +5,36 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define generic compile-grammar-file
-    (input-name, output-name, report-grammar-conflict, #key);
+    (input-name, output-name, report-grammar-conflict :: <function>,
+     #key terminal-string)
+ => ();
 
 define method compile-grammar-file
-  (input-name, output-name, report-grammar-conflict :: <function>,  #rest keys, #key)
+    (input-name, output-name, report-grammar-conflict :: <function>,
+     #key terminal-string)
+ => ()
   with-open-file (inf = input-name)
     with-open-file (outf = output-name, direction: #"output")
-      apply(compile-grammar-file, inf, outf, report-grammar-conflict, keys)
+      compile-grammar-file(inf, outf, report-grammar-conflict,
+                           terminal-string: terminal-string)
     end;
   end;
 end;
 
 define method compile-grammar-file
-  (input-name, outf :: <stream>, report-grammar-conflict :: <function>, #rest keys, #key)
+    (input-name, outf :: <stream>, report-grammar-conflict :: <function>,
+     #key terminal-string)
+ => ()
   with-open-file (inf = input-name)
-    apply(compile-grammar-file, inf, outf, report-grammar-conflict, keys)
+    compile-grammar-file(inf, outf, report-grammar-conflict,
+                         terminal-string: terminal-string)
   end;
 end;
 
 define method compile-grammar-file
     (inf :: <stream>, outf :: <stream>, report-grammar-conflict :: <function>,
      #key terminal-string)
+ => ()
   // Writing directly to a file seems to output crlf's as newlines,
   // which I don't like.  Kludge around it.
   let out = make(<string-stream>, direction: #"output");


### PR DESCRIPTION
When running the parser-generator, this warning appears:

    Warning: The function {<sealed-generic-function>:
      compile-grammar-file} was given the unrecognized keyword
      #"terminal-string" in the call with arguments
      {<simple-object-vector>: {<posix-file-locator>: ...},
                               {<posix-file-locator>: ...},
                               {<simple-method>: ???  (<grammar-conflict>) => (#rest)},
                               #"terminal-string", "define constant $%s-token = %d;"}.
    The keywords recognized for this call are {<simple-object-vector>: size 0}.

* sources/lib/parser-generator/compile.dylan
  (``compile-grammar-file``): Update generic and methods to all take a
   ``terminal-string`` keyword parameter. Switch from using apply in
   some methods to just invoking directly with the keyword supplied.
   Also, set a return value of ``()`` on each method and the generic.