### PR TITLE
[build] Build dylan-environment by default.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -222,7 +222,8 @@ BOOTSTRAP_3_ENV = \
 	OPEN_DYLAN_USER_REGISTRIES=$(abs_srcdir)/sources/registry \
 	OPEN_DYLAN_USER_SOURCES=$(abs_srcdir)/sources
 
-BOOTSTRAP_3_LIBRARIES = dylan-compiler parser-compiler dswank make-dylan-app
+BOOTSTRAP_3_LIBRARIES = \
+  dylan-compiler dylan-environment parser-compiler dswank make-dylan-app
 
 BOOTSTRAP_3_COMPILER = \
 	$(abs_builddir)/Bootstrap.2/bin/dylan-compiler -build -verbose


### PR DESCRIPTION
This builds `dylan-environment` by default in the third stage of the
build.

* Makefile.in
  (`BOOTSTRAP_3_LIBRARIES`): Add `dylan-environment`.