### PR TITLE
Add hypot math function.

### DIFF
--- a/documentation/library-reference/source/common-dylan/transcendentals.rst
+++ b/documentation/library-reference/source/common-dylan/transcendentals.rst
@@ -306,6 +306,23 @@ This section contains a reference entry for each item exported from the
      - :gf:`log`
      - :func:`logn`
 
+.. generic-function:: hypot
+
+   :summary:
+     Returns the Euclidian distance.
+
+   :signature: hypot x, y => z
+
+   :parameter x: An instance of type :drm:`<number>`.
+   :parameter y: An instance of type :drm:`<number>`.
+   :value z: An instance of type :drm:`<number>`.
+
+   :description:
+
+     Returns the Euclidian distance without unnecessary overflow or underflow.
+
+     The floating point precision is given by the precision of ``x``.
+
 .. generic-function:: isqrt
 
    :summary:

--- a/documentation/release-notes/source/2016.1.rst
+++ b/documentation/release-notes/source/2016.1.rst
@@ -84,6 +84,7 @@ Common Dylan
 ============
 
 * The ``transcendentals`` module now has a ``sincos`` generic function.
+* The ``transcendentals`` module now has a ``hypot`` generic function.
 * The ``transcendentals`` module now has an ``ilog2`` function that returns
   the integer value of the logarithm of a value in base 2.
 * The transcendental and hyperbolic functions are no longer sealing their

--- a/sources/common-dylan/library.dylan
+++ b/sources/common-dylan/library.dylan
@@ -232,7 +232,8 @@ define module transcendentals
          tanh,
          asinh,
          acosh,
-         atanh;
+         atanh,
+         hypot;
 end module transcendentals;
 
 define module machine-words

--- a/sources/common-dylan/tests/specification.dylan
+++ b/sources/common-dylan/tests/specification.dylan
@@ -350,6 +350,12 @@ define module-spec transcendentals ()
 // The floating point precision of the result is given by the precision
 // of _y_.
 
+  open generic-function hypot (<number>, <number>) => (<number>);
+
+// Returns the Euclidian distance.
+
+// The floating point precision of the result is given by the precision
+// of _x_.
 
   open generic-function log (<number>) => (<number>); //  x > 0
 

--- a/sources/common-dylan/tests/transcendentals.dylan
+++ b/sources/common-dylan/tests/transcendentals.dylan
@@ -97,6 +97,19 @@ define transcendentals function-test atanh ()
   // ---*** Fill this in.
 end function-test atanh;
 
+define transcendentals function-test hypot ()
+  assert-equal(5.0s0, hypot(3.0s0, 4.0s0));
+  assert-equal(5.0s0, hypot(3.0s0, 4.0d0));
+  assert-equal(5.0d0, hypot(3.0d0, 4.0d0));
+  assert-equal(5.0d0, hypot(3.0d0, 4.0s0));
+  assert-no-errors(
+    begin
+      let z = hypot(1.0d154, 1.0d154);
+      assert-not-equal(#"infinite", classify-float(z));
+    end
+  );
+end function-test hypot;
+
 define transcendentals function-test log ()
   check-condition("log(-1) errors",
                   <error>,

--- a/sources/common-dylan/transcendentals.dylan
+++ b/sources/common-dylan/transcendentals.dylan
@@ -233,3 +233,27 @@ end macro atan2-method-definer;
 
 define atan2-method (<single-float>, $single-pi, 0.0s0) end;
 define atan2-method (<double-float>, $double-pi, 0.0d0) end;
+
+define binary-transcendental hypot (x, y);
+
+define sealed may-inline method hypot (x :: <single-float>, y :: <single-float>)
+ => (z :: <single-float>)
+  primitive-raw-as-single-float
+    (%call-c-function("hypotf")
+         (x :: <raw-single-float>, y :: <raw-single-float>)
+      => (z :: <raw-single-float>)
+         (primitive-single-float-as-raw(x),
+          primitive-single-float-as-raw(y))
+     end)
+end method hypot;
+
+define sealed may-inline method hypot (x :: <double-float>, y :: <double-float>)
+ => (z :: <double-float>)
+  primitive-raw-as-double-float
+    (%call-c-function("hypot")
+         (x :: <raw-double-float>, y :: <raw-double-float>)
+      => (z :: <raw-double-float>)
+         (primitive-double-float-as-raw(x),
+          primitive-double-float-as-raw(y))
+     end)
+end method hypot;


### PR DESCRIPTION
When calculating a hypotenuse, it is useful to have the hypot function
available as it avoids overflow / underflow when possible, at the cost
of being slower.

* documentation/library-reference/source/common-dylan/transcendentals.rst
  (hypot): Document.

* documentation/release-notes/source/2016.1.rst
  (common-dylan): Mention hypot.

* sources/common-dylan/library.dylan
  (module transcendentals): Export hypot.

* sources/common-dylan/tests/specification.dylan
  (module-spec transcendentals): Add hypot.

* sources/common-dylan/tests/transcendentals.dylan
  (function-test hypot): Add test of hypot, including that it
   avoids overflow.

* sources/common-dylan/transcendentals.dylan
  (hypot): Implement.