### PR TITLE
[dylan] Remove overflow checks in linear-class-key-lookup

### DIFF
--- a/sources/dfmc/modeling/namespaces.dylan
+++ b/sources/dfmc/modeling/namespaces.dylan
@@ -2273,6 +2273,8 @@ define &module machine-word-lowlevel
          machine-word-count-low-zeros,
          machine-word-count-high-zeros;
   // arithmetic
+  create machine-word-add,
+         machine-word-subtract;
   create machine-word-add-with-overflow,
          machine-word-subtract-with-overflow,
          machine-word-multiply-with-overflow,

--- a/sources/dylan/new-dispatch.dylan
+++ b/sources/dylan/new-dispatch.dylan
@@ -774,6 +774,14 @@ define function make-by-singleton-class-discriminator
   d
 end function;
 
+//---*** FIXME: When the compiler does range analysis, this might not be needed.
+define inline-only function add-without-overflow (x :: <integer>, y :: <integer>) => (z :: <integer>)
+  let mx = interpret-integer-as-machine-word(x);
+  let my = strip-integer-tag(interpret-integer-as-machine-word(y));
+  let result = machine-word-add(mx, my);
+  interpret-machine-word-as-integer(result)
+end;
+
 define inline function linear-class-key-lookup
     (key :: <integer>, d :: <linear-class-keyed-discriminator>, default)
   let n :: <integer> = %ckd-size(d);
@@ -783,11 +791,11 @@ define inline function linear-class-key-lookup
           else
             let otherkey = %ckd-ref(d, i);
             if (pointer-id?(otherkey, key))
-              %ckd-ref(d, i + 1)
+              %ckd-ref(d, add-without-overflow(i, 1))
             // elseif (pointer-id?(otherkey, $ckd-empty))
             //   default
             else
-              loop(i + 2)
+              loop(add-without-overflow(i, 2))
             end if
           end if
         end method;


### PR DESCRIPTION
The loop in linear-class-key-lookup is known to be correct and
we don't need overflow checks when we're getting the new index
values. Removing this overflow turns the inner loop from:

    00000210  cmpl  %edi, %esi
    00000212  je  0x226
    00000214  movl  %esi, %ebx
    00000216  andl  $-0x4, %ebx
    00000219  cmpl  %ecx, 0x1c(%eax,%ebx)
    0000021d  je  0x22e
    0000021f  addl  $0x8, %esi
    00000222  jno 0x210

into:

    00000210  leal  0x1(%edi), %ebx
    00000213  andl  $-0x4, %ebx
    00000216  cmpl  %ecx, 0x1c(%edx,%ebx)
    0000021a  je  0x22b
    0000021c  addl  $0x8, %edi
    0000021f  cmpl  %edi, %esi
    00000221  jne 0x210

Here, we avoid the jno and perform the loop check at the end
of the loop rather than the start (with the LLVM back-end).

This helps lay the ground for some further optimizations in
subsequent commits.

* sources/dfmc/modeling/namespaces.dylan
  (&module machine-word-lowlevel): Export machine-word-add and
   machine-word-subtract so that other modules may use them.

* sources/dylan/new-dispatch.dylan
  (add-without-overflow): New helper function.
  (linear-class-key-lookup): Call add-without-overflow to avoid
   integer overflow checks.