### PR TITLE
[llvm-back-end] Create op--tag-cmp.

### DIFF
--- a/sources/dfmc/llvm-back-end/llvm-emit-type-check.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-emit-type-check.dylan
@@ -112,15 +112,6 @@ define method do-emit-instance-cmp
   ins--icmp-ne(back-end, result, emit-reference(back-end, module, &false));
 end method;
 
-define function emit-tag-cmp
-    (back-end :: <llvm-back-end>, object :: <llvm-value>, tag :: <integer>)
- => (cmp :: <llvm-value>)
-  let object-word
-    = ins--ptrtoint(back-end, object, back-end.%type-table["iWord"]);
-  let tag-bits = ins--and(back-end, object-word, ash(1, $dylan-tag-bits) - 1);
-  ins--icmp-eq(back-end, tag-bits, tag)
-end function;
-
 // Compile-time instance check against a <class> instance
 define method do-emit-instance-cmp
     (back-end :: <llvm-back-end>, object :: <llvm-value>,
@@ -132,13 +123,13 @@ define method do-emit-instance-cmp
 
   case
     type == dylan-value(#"<integer>") =>
-      emit-tag-cmp(back-end, object, $dylan-tag-integer);
+      op--tag-cmp(back-end, object, $dylan-tag-integer);
 
     type == dylan-value(#"<byte-character>") =>
-      emit-tag-cmp(back-end, object, $dylan-tag-character);
+      op--tag-cmp(back-end, object, $dylan-tag-character);
 
     type == dylan-value(#"<unicode-character>") =>
-      emit-tag-cmp(back-end, object, $dylan-tag-unichar);
+      op--tag-cmp(back-end, object, $dylan-tag-unichar);
 
     type == dylan-value(#"<boolean>") =>
       // Compare against #f
@@ -156,7 +147,7 @@ define method do-emit-instance-cmp
       let obj-bb = make(<llvm-basic-block>);
 
       // Check tag to ensure this is a heap object
-      let obj-cmp = emit-tag-cmp(back-end, object, $dylan-tag-pointer);
+      let obj-cmp = op--tag-cmp(back-end, object, $dylan-tag-pointer);
       ins--br(back-end, obj-cmp, obj-bb, result-bb);
 
       // Retrieve the <mm-wrapper> object from the object header
@@ -328,10 +319,7 @@ define method do-emit-instance-cmp
   let result-bb = make(<llvm-basic-block>);
 
   // Check the tag
-  let object-word
-    = ins--ptrtoint(back-end, object, back-end.%type-table["iWord"]);
-  let tag-bits = ins--and(back-end, object-word, ash(1, $dylan-tag-bits) - 1);
-  let tag-cmp = ins--icmp-eq(back-end, tag-bits, $dylan-tag-integer);
+  let tag-cmp = op--tag-cmp(back-end, object, $dylan-tag-integer);
   ins--br(back-end, tag-cmp, integer-bb, result-bb);
 
   // Check the range


### PR DESCRIPTION
The code for emitting type checks had a helper function, emit-tag-cmp,
which was useful but it wasn't used everywhere.

* sources/dfmc/llvm-back-end/llvm-emit-type-check.dylan
  (emit-tag-cmp): Renamed and moved.
  (do-emit-instance-cmp): Rename usages of emit-tag-cmp.
   Make another tag check use op--tag-cmp instead of doing
   it by hand.

* sources/dfmc/llvm-back-end/llvm-ops.dylan
  (op--tag-cmp): Move here from emit-tag-cmp.
  (op--object-mm-wrapper): Use op--tag-cmp.