### PR TITLE
[common-dylan] Export start-profiling, stop-profiling.

### DIFF
--- a/documentation/library-reference/source/common-dylan/simple-profiling.rst
+++ b/documentation/library-reference/source/common-dylan/simple-profiling.rst
@@ -126,6 +126,18 @@ may be useful in some scenarios.
 .. method:: profiling-type-result
    :specializer: <profiling-state>, singleton(#"allocation-stats")
 
+.. function:: start-profiling
+
+   :signature: start-profiling (profiling-types) => (state)
+
+   :parameter profiling-types: A sequence of any of ``#"cpu-time-seconds"``,
+     ``#"cpu-time-microseconds"``, ``#"allocation#`` and
+     ``#"allocation-stats#``.
+   :value state: An instance of :type:`<profiling-state>`.
+
+   This is useful for when direct control over profiling is needed rather
+   than using the :macro:`profiling` macro.
+
 .. generic-function:: start-profiling-type
    :open:
 
@@ -142,6 +154,14 @@ may be useful in some scenarios.
 
 .. method:: start-profiling-type
    :specializer: <profiling-state>, singleton(#"allocation-stats")
+
+.. function:: stop-profiling
+
+   :signature: stop-profiling (state profiling-types) => ()
+
+   :parameter state: An instance of :type:`<profiling-state>`.
+   :parameter profiling-types: A sequence of :drm:`<symbol>`. These
+     symbols should be the same as those passed to :func:`start-profiling`.
 
 .. generic-function:: stop-profiling-type
    :open:

--- a/documentation/release-notes/source/2016.1.rst
+++ b/documentation/release-notes/source/2016.1.rst
@@ -106,6 +106,10 @@ Common Dylan
 * The ``thread`` module has gained a ``current-thread-id`` function. The
   ``thread-id`` is also available for any ``<thread>`` object.
 
+* The ``simple-profiling`` module now exports ``start-profiling`` and
+  ``stop-profiling`` rather than requiring that users directly invoke
+  ``start-profiling-type`` and ``stop-profiling-type`` multiple times.
+
 Compiler
 ========
 

--- a/sources/common-dylan/library.dylan
+++ b/sources/common-dylan/library.dylan
@@ -32,7 +32,9 @@ define module simple-profiling
 
   create \profiling,
          <profiling-state>,
+         start-profiling,
          start-profiling-type,
+         stop-profiling,
          stop-profiling-type,
          profiling-type-result;
 end module simple-profiling;

--- a/sources/common-dylan/tests/functions.dylan
+++ b/sources/common-dylan/tests/functions.dylan
@@ -771,9 +771,17 @@ end function-test random;
 
 /// simple-profiling tests
 
+define simple-profiling function-test start-profiling ()
+  //---*** Fill this in...
+end function-test start-profiling;
+
 define simple-profiling function-test start-profiling-type ()
   //---*** Fill this in...
 end function-test start-profiling-type;
+
+define simple-profiling function-test stop-profiling ()
+  //---*** Fill this in...
+end function-test stop-profiling;
 
 define simple-profiling function-test stop-profiling-type ()
   //---*** Fill this in...

--- a/sources/common-dylan/tests/specification.dylan
+++ b/sources/common-dylan/tests/specification.dylan
@@ -204,8 +204,10 @@ end module-spec simple-random;
 
 define module-spec simple-profiling ()
   sealed instantiable class <profiling-state> (<table>);
+  function start-profiling(<sequence>) => (<profiling-state>);
   open generic-function start-profiling-type
     (<profiling-state>, <symbol>) => ();
+  function stop-profiling(<profiling-state>, <sequence>) => ();
   open generic-function stop-profiling-type
     (<profiling-state>, <symbol>) => ();
   open generic-function profiling-type-result


### PR DESCRIPTION
For callers who want to control profiling more directly than using
the macros, it is useful to have the start-profiling and stop-profiling
functions exported and visible.

* sources/common-dylan/library.dylan
  (simple-profiling): Export start-profiling and stop-profiling.

* sources/common-dylan/tests/functions.dylan
  (function-test start-profiling,
   function-test stop-profiling): Stub implementations.

* sources/common-dylan/tests/specification.dylan
  (module-spec simple-profiling): Include start-profiling and
   stop-profiling in the simple-profiling specification test.

* documentation/library-reference/source/common-dylan/simple-profiling.rst
  (start-profiling, stop-profiling): Document.

* documentation/release-notes/source/2016.1.rst
  (common-dylan): Add note about new exports.