### PR TITLE
[dfmc-conversion] Fix destructuring bind.

### DIFF
--- a/sources/dfmc/conversion/convert.dylan
+++ b/sources/dfmc/conversion/convert.dylan
@@ -386,7 +386,7 @@ define function pad-multiple-values
     mv[i] := ref;
   finally
     for (j :: <integer> from i below max-size)
-      mv[i] := make-object-reference(#f);
+      mv[j] := make-object-reference(#f);
     end for;
   end for;
   mv


### PR DESCRIPTION
When the ``<values>`` doesn't have enough elements in it, it is supposed
to be padded with references to the ``#f`` object. Instead, it was writing
with the wrong loop index, so the ``<values>`` object was incorrect:

      *t3(3) := [VALUES ^#t ^#f #f]

Note that the last element is ``#f`` and not ``^#f``.

This resulted in confusing type check errors at compile time as detailed
in issue #363 where this code:

    let (ign, ore, maybe-a :: false-or(<string>)) = #t;
    let a :: <string> = maybe-a | "a";

Would result in a warning:

    Type check can fail - singleton(#f :: <boolean>) inferred, <string> expected.

This was found while minimizing a test case from the peg-parser, but is
not the same bug as the peg-parser is experiencing.

Fixes #363.

* sources/dfmc/conversion/convert.dylan
  (``pad-multiple-values``): Write ``#f`` object references at the correct
   index into the vector. (Use the right loop index value, ``j``, instead
   of ``i``.)