### PR TITLE
Add read-cycle-counter, read-return-address primitives.

### DIFF
--- a/documentation/hacker-guide/source/runtime/primitives.rst
+++ b/documentation/hacker-guide/source/runtime/primitives.rst
@@ -1,6 +1,46 @@
 Runtime System Functions
 ************************
 
+Primitives for Machine Information
+==================================
+
+.. primitive:: primitive-read-cycle-counter
+
+   :signature: primitive-read-cycle-counter () => (cycle-count)
+
+   :value cycle-count: An instance of :class:`<raw-machine-word>`.
+
+   :description:
+
+     On x86 and x86_64 architectures, this is equivalent to calling
+     the ``rdtsc`` instruction. For full precision, this should only
+     be used on 64 bit builds.
+
+     This is equivalent to using the LLVM intrinsic ``llvm.readcyclecounter``
+     or the Clang built-in ``__builtin_readcyclecounter``.
+
+     This has not been implemented in the HARP back-end.
+
+.. primitive:: primitive-read-return-address
+
+   :signature: primitive-read-return-address () => (return-address)
+
+   :value return-address: An instance of :class:`<raw-machine-word>`.
+
+   :description:
+
+     Returns the address to which the current function will return
+     when it exits. This yields the address of the code which
+     invoked the current function.
+
+     For best results, invoke this primitive within a function
+     which has been prevented from being inlined.
+
+     This is equivalent to using the LLVM intrinsic ``llvm.returnaddress``
+     or the Clang and GCC built-in ``__builtin_return_address``.
+
+     This has not been implemented in the HARP back-end.
+
 Primitive Functions for the threads library
 ===========================================
 

--- a/documentation/release-notes/source/2016.1.rst
+++ b/documentation/release-notes/source/2016.1.rst
@@ -198,6 +198,10 @@ Runtime
 
 * In the C runtime, the ``primitive_sleep`` now functions correctly.
 
+* Two new primitives, ``primitive-read-cycle-counter`` and
+  ``primitive-read-return-address``, have been added. These are useful
+  for writing profiling and event logging tools.
+
 system
 ======
 

--- a/sources/dfmc/c-back-end/c-primitives.dylan
+++ b/sources/dfmc/c-back-end/c-primitives.dylan
@@ -42,6 +42,8 @@ define generic emit-primitive-call
 // // Machine
 // define &primitive-descriptor primitive-word-size;
 // define &primitive-descriptor primitive-header-size;
+// define &primitive-descriptor primitive-read-cycle-counter;
+// define &primitive-descriptor primitive-read-return-address;
 //
 // // Allocation.
 // define &primitive-descriptor primitive-allocate;

--- a/sources/dfmc/harp-cg/harp-primitives.dylan
+++ b/sources/dfmc/harp-cg/harp-primitives.dylan
@@ -1006,6 +1006,18 @@ define method op--word-size(back-end :: <harp-back-end>, result) => ()
 
 end method op--word-size;
 
+define method op--read-cycle-counter(back-end :: <harp-back-end>, result) => ()
+
+  ins--move(back-end, result, 0);
+
+end method op--read-cycle-counter;
+
+define method op--read-return-address(back-end :: <harp-back-end>, result) => ()
+
+  ins--move(back-end, result, 0);
+
+end method op--read-return-address;
+
 
 define method op--abs(back-end :: <harp-back-end>, result, x) => ()
 
@@ -1775,6 +1787,8 @@ define &primitive-descriptor primitive-debug-message, emitter: op--debug-message
 // Machine
 define &primitive-descriptor primitive-word-size, emitter: op--word-size;
 define &primitive-descriptor primitive-header-size, emitter: op--word-size;
+define &primitive-descriptor primitive-read-cycle-counter, emitter: op--read-cycle-counter;
+define &primitive-descriptor primitive-read-return-address, emitter: op--read-return-address;
     
 // Allocation.
 define &primitive-descriptor primitive-allocate;

--- a/sources/dfmc/llvm-back-end/llvm-primitives-basic.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-primitives-basic.dylan
@@ -18,6 +18,16 @@ define side-effect-free stateless dynamic-extent &primitive-descriptor primitive
   llvm-builder-value(be, header-words * back-end-word-size(be))
 end;
 
+define side-effect-free stateless dynamic-extent &primitive-descriptor primitive-read-cycle-counter
+    () => (cycle-count :: <raw-machine-word>);
+  ins--call-intrinsic(be, "llvm.readcyclecounter", vector())
+end;
+
+define side-effect-free stateless dynamic-extent &primitive-descriptor primitive-read-return-address
+    () => (return-address :: <raw-machine-word>);
+  ins--call-intrinsic(be, "llvm.returnaddress", vector(i32(0)))
+end;
+
 
 /// Pointers
 

--- a/sources/dfmc/modeling/namespaces.dylan
+++ b/sources/dfmc/modeling/namespaces.dylan
@@ -62,7 +62,9 @@ define &module dylan-primitives
   // machine
   create
     primitive-word-size,
-    primitive-header-size;
+    primitive-header-size,
+    primitive-read-cycle-counter,
+    primitive-read-return-address;
 
   // Object Representation.
   create

--- a/sources/dfmc/modeling/primitives.dylan
+++ b/sources/dfmc/modeling/primitives.dylan
@@ -104,6 +104,10 @@ define side-effect-free stateless dynamic-extent &primitive-and-override primiti
 end;
 define side-effect-free stateless dynamic-extent &primitive primitive-header-size
     () => (header-size :: <raw-integer>);
+define side-effect-free stateless dynamic-extent &primitive primitive-read-cycle-counter
+    () => (cycle-count :: <raw-machine-word>);
+define side-effect-free stateless dynamic-extent &primitive primitive-read-return-address
+    () => (return-address :: <raw-machine-word>);
 
 /// RAW-TYPE
 

--- a/sources/lib/run-time/run-time.h
+++ b/sources/lib/run-time/run-time.h
@@ -874,6 +874,28 @@ extern void primitive_debug_message (dylan_value format_string, dylan_value argu
 
 #define primitive_header_size() primitive_word_size ()
 
+#if defined(OPEN_DYLAN_COMPILER_CLANG) && \
+    defined(__has_builtin) && \
+    __has_builtin(__builtin_readcyclecounter)
+#  define primitive_read_cycle_counter() __builtin_readcyclecounter()
+#elif defined(OPEN_DYLAN_COMPILER_GCC_LIKE) && \
+      (defined(OPEN_DYLAN_ARCH_X86) || defined(OPEN_DYLAN_ARCH_X86_64))
+static inline uint64_t primitive_read_cycle_counter(void)
+{
+   uint32_t hi, lo;
+   __asm__ __volatile__ ("rdtsc" : "=a"(lo), "=d"(hi));
+   return ((uint64_t)lo) | (((uint64_t)hi) << 32);
+}
+#else
+#  define primitive_read_cycle_counter() 0
+#endif
+
+#if defined(OPEN_DYLAN_COMPILER_GCC_LIKE)
+#  define primitive_read_return_address() __builtin_return_address(0)
+#else
+#  define primitive_read_return_address() 0
+#endif
+
 
 
 /* Well this wasn't right


### PR DESCRIPTION
These are useful for event logging, profiling and other low level activities.

* sources/dfmc/c-back-end/c-primitives.dylan: Add new primitives to comments.

* sources/dfmc/harp-cg/harp-primitives.dylan
  (op--read-cycle-counter, op--read-return-address): Stubs that return 0.
  (primitive-read-cycle-counter, primitive-read-return-address): Use emitter stubs.

* sources/dfmc/llvm-back-end/llvm-primitives-basic.dylan
  (primitive-read-cycle-counter, primitive-read-return-address): Implement using
   LLVM intrinsics.

* sources/dfmc/modeling/namespaces.dylan
  (&module dylan-primitives): Export new primitives.

* sources/dfmc/modeling/primitives.dylan
  (primitive-read-cycle-counter, primitive-read-return-address): Define new primitives.

* sources/lib/run-time/run-time.h
  (primitive_read_cycle_counter, primitive_read_return_address): Implement for
   Clang and GCC. Reading cycle counter with GCC is only supported on x86 and
   x86_64.

* documentation/hacker-guide/source/runtime/primitives.rst: Document new primitives.

* documentation/release-notes/source/2016.1.rst: Update release notes.