### PR TITLE
[common-dylan] Add hexstring and from-hexstring to byte-vector.

### DIFF
--- a/documentation/library-reference/source/common-dylan/byte-vector.rst
+++ b/documentation/library-reference/source/common-dylan/byte-vector.rst
@@ -180,3 +180,34 @@ The byte-vector Module
 .. method:: copy-bytes
    :specializer: <simple-object-vector>, <integer>, <byte-vector>, <integer>, <integer>
    :sealed:
+
+.. method:: hexstring
+   :specializer: <byte-vector>
+   :sealed:
+
+   Returns a string of lowercase hexadecimal digits representing the data.
+
+   :signature: hexstring (data) => (result)
+
+   :parameter data: An instance of :class:`<byte-vector>`.
+   :value result: An instance of :drm:`<byte-string>`.
+   
+   :seealso:
+
+     - :meth:`from-hexstring(<byte-string>)`
+
+.. method:: from-hexstring
+   :specializer: <byte-string>
+   :sealed:
+
+   Returns a <byte-vector> containing `data` interpreted as a hexadecimal
+   representation of a series bytes.
+
+   :signature: from-hexstring (string) => (result)
+
+   :parameter string: An instance of :drm:`<byte-string>`.
+   :value result: An instance of :class:`<vector>`.
+   
+   :seealso:
+
+     - :meth:`hexstring(<byte-vector>)`

--- a/documentation/release-notes/source/2016.1.rst
+++ b/documentation/release-notes/source/2016.1.rst
@@ -102,7 +102,9 @@ Common Dylan
 * The ``common-dylan`` library now provides a ``classify-float``
   method which will return if the given float is ``#"normal"``,
   ``#"zero"``, ``#"infinite"``, ``#"nan"``, or ``#"subnormal"``.
-
+* The ``common-dylan`` library now provides ``hexstring`` and
+  ``from-hexstring`` methods for fast conversion from and to
+  hexadecimal strings.
 * The ``thread`` module has gained a ``current-thread-id`` function. The
   ``thread-id`` is also available for any ``<thread>`` object.
 

--- a/sources/common-dylan/byte-vector.dylan
+++ b/sources/common-dylan/byte-vector.dylan
@@ -222,7 +222,7 @@ define sealed inline method byte-storage-offset-address
               (the-buffer, primitive-repeated-slot-offset(the-buffer)))))
 end method;
 
-define method from-hexstring (string :: <byte-string>)
+define sealed method from-hexstring (string :: <byte-string>)
   => (result :: <byte-vector>)
   if (odd?(string.size))
     error("String size must be multiple of 2.");
@@ -235,7 +235,7 @@ define method from-hexstring (string :: <byte-string>)
       let hi :: <byte> = as(<byte>, string[i]);
       let lo :: <byte> = as(<byte>, string[i + 1]);
       let b  :: <byte> = ash(logand(hi, 15) + 9 * ash(hi, -6), 4) +
-        logand(lo, 15) + 9 * ash(lo, -6);
+                             logand(lo, 15) + 9 * ash(lo, -6);
       result[floor/(i, 2)] := b;
     end for;
   end without-bounds-checks;
@@ -243,7 +243,7 @@ define method from-hexstring (string :: <byte-string>)
   result;
 end method;
 
-define method hexstring (data :: <byte-vector>)
+define sealed method hexstring (data :: <byte-vector>)
   => (result :: <byte-string>)
   let result :: <byte-string> = make(<byte-string>, size: data.size * 2);
 

--- a/sources/common-dylan/library.dylan
+++ b/sources/common-dylan/library.dylan
@@ -57,6 +57,7 @@ define module byte-vector
          copy-bytes,
          byte-storage-address,
          byte-storage-offset-address,
+         hexstring, from-hexstring
 end module byte-vector;
 
 define module common-extensions


### PR DESCRIPTION
- sources/common-dylan/library.dylan
  (module byte-vector): Export hexstring and from-hexstring.
- sources/common-dylan/byte-vector.dylan
  Added hexstring and from-hexstring methods.
