### PR TITLE
Add rpath to linker flags for DLLs.

### DIFF
--- a/sources/jamfiles/x86_64-linux-build.jam
+++ b/sources/jamfiles/x86_64-linux-build.jam
@@ -14,6 +14,7 @@ CCFLAGS  += -DOPEN_DYLAN_PLATFORM_UNIX -DOPEN_DYLAN_PLATFORM_LINUX
 # Library search path
 #
 LINKFLAGSEXE ?= -Wl,-z,origin -Wl,-rpath,\\$ORIGIN/../lib/ ;
+LINKFLAGSDLL ?= -Wl,-z,origin -Wl,-rpath,\\$ORIGIN/ ;
 
 #
 # Common build script


### PR DESCRIPTION
On newer versions of the linker, built executables fail at runtime because dependencies are
not followed through transitively.

Proposed to fix #1062 