### PR TITLE
Make 'inline' be 'static inline.'

### DIFF
--- a/sources/lib/run-time/c-run-time.c
+++ b/sources/lib/run-time/c-run-time.c
@@ -58,7 +58,7 @@ extern dylan_object KPunboundVKi;
 #define INLINE static inline
 #define FORCE_INLINE static inline __attribute__((always_inline))
 #else
-#define INLINE inline
+#define INLINE static inline
 #define FORCE_INLINE inline __attribute__((always_inline))
 #endif
 


### PR DESCRIPTION
This is already used for clang (see line 58) and appears that it is also needed for gcc to avoid linker errors.

Proposed fix #1064 