### PR TITLE
MacOS fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,7 @@ SUPPORT_LLVM=
 BDW_GC_STATIC=
 BDW_GC_MODULE=bdw-gc
 ADDITIONAL_RUNTIME_TARGET_PLATFORMS=
+MACOS_SDK=
 
 AC_CANONICAL_TARGET
 
@@ -34,14 +35,12 @@ case $host in
     ;;
   i*86-*-darwin*)
       OPEN_DYLAN_TARGET_PLATFORM=x86-darwin;
-      ADDITIONAL_RUNTIME_TARGET_PLATFORMS="x86_64-darwin";
-      BDW_GC_STATIC=true
+      MACOS_SDK=`xcrun --show-sdk-path`
       SUPPORT_LLVM=yes
     ;;
   x86_64-*-darwin*)
-      OPEN_DYLAN_TARGET_PLATFORM=x86-darwin;
-      ADDITIONAL_RUNTIME_TARGET_PLATFORMS="x86_64-darwin";
-      BDW_GC_STATIC=true
+      OPEN_DYLAN_TARGET_PLATFORM="x86_64-darwin";
+      MACOS_SDK=`xcrun --show-sdk-path`
       SUPPORT_LLVM=yes
     ;;
   amd64-*-freebsd* | x86_64-*-freebsd*)
@@ -68,6 +67,8 @@ case $host in
 esac
 AC_SUBST(OPEN_DYLAN_TARGET_PLATFORM)
 AC_SUBST(ADDITIONAL_RUNTIME_TARGET_PLATFORMS)
+
+AC_SUBST(MACOS_SDK)
 
 AM_INIT_AUTOMAKE
 

--- a/sources/app/llvm-runtime-generator/llvm-runtime-generator.dylan
+++ b/sources/app/llvm-runtime-generator/llvm-runtime-generator.dylan
@@ -331,7 +331,7 @@ define function generate-runtime
      platform-name :: <symbol>)
  => ();
   let output-basename
-    = format-to-string("%s-runtime", platform-name);
+    = format-to-string("%s-runtime", as(<string>, platform-name));
   let dummy-source-locator
     = make(<file-locator>, base: output-basename, extension: "ll",
            directory: working-directory());
@@ -377,8 +377,8 @@ define function generate-runtime
 
 	// Write out the generated header file
 	let header-basename
-	  = format-to-string("llvm-%s-runtime",
-			     platform-name);
+	  = format-to-string("llvm-%s",
+			     output-basename);
 	let header-locator
 	  = make(<file-locator>, base: header-basename, extension: "h");
 	generate-runtime-header(back-end, header-locator)

--- a/sources/dfmc/modeling/signatures.dylan
+++ b/sources/dfmc/modeling/signatures.dylan
@@ -54,7 +54,7 @@ end function;
 
 define function compute-signature-type-vector-definition-name
     (type-name :: <symbol>) => (definition-name :: <symbol>)
-  as(<symbol>, format-to-string("$signature-%s-types", type-name))
+  as(<symbol>, format-to-string("$signature-%s-types", as(<string>, type-name)))
 end function;
 
 define macro signature-type-vector-table-definer
@@ -243,7 +243,7 @@ define function compute-signature-definition-name
  => (definition-name :: <symbol>)
   as(<symbol>,
      format-to-string
-       ("$signature-%s-%s-rest-value-%d", type-name,
+       ("$signature-%s-%s-rest-value-%d", as(<string>, type-name),
         if (rest-value?) "object" else "no" end, size))
 end function;
 

--- a/sources/lib/run-time/Makefile.in
+++ b/sources/lib/run-time/Makefile.in
@@ -167,7 +167,7 @@ endif
 
 ifdef DARWIN
 mach_exc.h mach_excServer.c:
-	mig /usr/include/mach/mach_exc.defs
+	mig @MACOS_SDK@/usr/include/mach/mach_exc.defs
 
 $(OBJDIR_LLVM)/llvm-exceptions.o: mach_exc.h
 

--- a/sources/lib/run-time/run-time.h
+++ b/sources/lib/run-time/run-time.h
@@ -1631,7 +1631,7 @@ extern DMINT primitive_machine_word_multiply_lowShigh(DMINT, DMINT);
 extern DMINT primitive_machine_word_multiply_low_with_overflow(DMINT, DMINT);
 extern DMINT primitive_machine_word_multiply_with_overflow(DMINT, DMINT);
 
-#define primitive_machine_word_negative(x)                (-(signed)(x))
+#define primitive_machine_word_negative(x)                (-(DMINT)(x))
 #define primitive_machine_word_abs(x)                     ((x)<0?-(x):(x))
 
 extern DMINT primitive_machine_word_negative_with_overflow(DMINT);

--- a/sources/registry/x86_64-darwin/dood
+++ b/sources/registry/x86_64-darwin/dood
@@ -1,1 +1,1 @@
-abstract://dylan/lib/dood/dood.lid
+abstract://dylan/lib/dood/dood-64.lid

--- a/sources/system/file-system/unix-file-system.dylan
+++ b/sources/system/file-system/unix-file-system.dylan
@@ -86,7 +86,7 @@ define function %file-exists?
   let file = %expand-pathname(file);
   with-stack-stat (st, file)
     ~primitive-raw-as-boolean
-       (%call-c-function ("stat") (path :: <raw-byte-string>, st :: <raw-c-pointer>)
+       (%call-c-function ("system_stat") (path :: <raw-byte-string>, st :: <raw-c-pointer>)
          => (failed? :: <raw-c-signed-int>)
           (primitive-string-as-raw(as(<byte-string>, file)),
            primitive-cast-raw-as-pointer(primitive-unwrap-machine-word(st)))
@@ -230,7 +230,7 @@ define function %file-properties
   let properties = make(<table>);
   with-stack-stat (st, file)
     if (primitive-raw-as-boolean
-          (%call-c-function ("stat") (path :: <raw-byte-string>, st :: <raw-c-pointer>)
+          (%call-c-function ("system_stat") (path :: <raw-byte-string>, st :: <raw-c-pointer>)
             => (failed? :: <raw-c-signed-int>)
              (primitive-string-as-raw(as(<byte-string>, file)),
               primitive-cast-raw-as-pointer(primitive-unwrap-machine-word(st)))
@@ -263,7 +263,7 @@ define method %file-property
   let file = %expand-pathname(file);
   with-stack-stat (st, file)
     if (primitive-raw-as-boolean
-          (%call-c-function ("stat") (path :: <raw-byte-string>, st :: <raw-c-pointer>)
+          (%call-c-function ("system_stat") (path :: <raw-byte-string>, st :: <raw-c-pointer>)
             => (failed? :: <raw-c-signed-int>)
              (primitive-string-as-raw(as(<byte-string>, file)),
               primitive-cast-raw-as-pointer(primitive-unwrap-machine-word(st)))
@@ -291,7 +291,7 @@ define method %file-property
   let file = %expand-pathname(file);
   with-stack-stat (st, file)
     if (primitive-raw-as-boolean
-          (%call-c-function ("stat") (path :: <raw-byte-string>, st :: <raw-c-pointer>)
+          (%call-c-function ("system_stat") (path :: <raw-byte-string>, st :: <raw-c-pointer>)
             => (failed? :: <raw-c-signed-int>)
              (primitive-string-as-raw(as(<byte-string>, file)),
               primitive-cast-raw-as-pointer(primitive-unwrap-machine-word(st)))
@@ -309,7 +309,7 @@ define method %file-property
   let file = %expand-pathname(file);
   with-stack-stat (st, file)
     if (primitive-raw-as-boolean
-          (%call-c-function ("stat") (path :: <raw-byte-string>, st :: <raw-c-pointer>)
+          (%call-c-function ("system_stat") (path :: <raw-byte-string>, st :: <raw-c-pointer>)
             => (failed? :: <raw-c-signed-int>)
              (primitive-string-as-raw(as(<string>, file)),
               primitive-cast-raw-as-pointer(primitive-unwrap-machine-word(st)))
@@ -327,7 +327,7 @@ define method %file-property
   let file = %expand-pathname(file);
   with-stack-stat (st, file)
     if (primitive-raw-as-boolean
-          (%call-c-function ("stat") (path :: <raw-byte-string>, st :: <raw-c-pointer>)
+          (%call-c-function ("system_stat") (path :: <raw-byte-string>, st :: <raw-c-pointer>)
             => (failed? :: <raw-c-signed-int>)
              (primitive-string-as-raw(as(<byte-string>, file)),
               primitive-cast-raw-as-pointer(primitive-unwrap-machine-word(st)))
@@ -345,7 +345,7 @@ define method %file-property
   let file = %expand-pathname(file);
   with-stack-stat (st, file)
     if (primitive-raw-as-boolean
-          (%call-c-function ("stat") (path :: <raw-byte-string>, st :: <raw-c-pointer>)
+          (%call-c-function ("system_stat") (path :: <raw-byte-string>, st :: <raw-c-pointer>)
             => (failed? :: <raw-c-signed-int>)
              (primitive-string-as-raw(as(<byte-string>, file)),
               primitive-cast-raw-as-pointer(primitive-unwrap-machine-word(st)))
@@ -382,7 +382,7 @@ define function accessible?-setter
   let file = %expand-pathname(file);
   with-stack-stat (st, file)
     if (primitive-raw-as-boolean
-          (%call-c-function ("stat") (path :: <raw-byte-string>, st :: <raw-c-pointer>)
+          (%call-c-function ("system_stat") (path :: <raw-byte-string>, st :: <raw-c-pointer>)
             => (failed? :: <raw-c-signed-int>)
              (primitive-string-as-raw(as(<byte-string>, file)),
               primitive-cast-raw-as-pointer(primitive-unwrap-machine-word(st)))

--- a/sources/system/file-system/unix-interface.dylan
+++ b/sources/system/file-system/unix-interface.dylan
@@ -80,7 +80,7 @@ define thread variable *stat-buffer* = make(<byte-vector>, size: $stat-size, fil
 
 define function unix-file-exists? (path :: <byte-string>) => (exists? :: <boolean>)
   ~primitive-raw-as-boolean
-    (%call-c-function ("stat")
+    (%call-c-function ("system_stat")
        (path :: <raw-byte-string>, statbuf :: <raw-pointer>)
       => (result :: <raw-c-signed-int>)
        (primitive-string-as-raw(path),

--- a/sources/system/unix-portability.c
+++ b/sources/system/unix-portability.c
@@ -3,6 +3,7 @@
 #include <errno.h>
 #include <dlfcn.h>
 #include <dirent.h>
+#include <sys/stat.h>
 
 #ifdef __APPLE__
 #include <crt_externs.h>
@@ -88,4 +89,9 @@ struct dirent *system_readdir(DIR *dirp)
 const char *system_dirent_name(struct dirent *dirent)
 {
   return dirent->d_name;
+}
+
+int system_stat(const char* path, struct stat* buf)
+{
+  return stat(path, buf);
 }


### PR DESCRIPTION
This allows building a 32-bit MacOS version from the 2013.2 release (this is the latest binary available from opendylan.org) A 64-bit MacOS version can be built from the 32-bit version. It's not possible to go straight from 2013.2 to 64-bit current, I think because of #705.