### PR TITLE
Rename references to Mac OS X to macOS.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -356,7 +356,7 @@ install-stage:
 	@cp -R $(abs_builddir)/Bootstrap.3/bin $(prefix)
 	@cp -R $(abs_builddir)/Bootstrap.3/databases $(prefix)
 	@-cp -R $(abs_builddir)/Bootstrap.3/include/opendylan $(prefix)/include
-	@# We use force here because on Mac OS X, the lib directory likely contains read-only
+	@# We use force here because on macOS, the lib directory likely contains read-only
 	@# static libraries for the Boehm GC.
 	@cp -Rf $(abs_builddir)/Bootstrap.3/lib $(prefix)
 	@cp -Rf $(abs_builddir)/Bootstrap.3/share/opendylan $(prefix)/share

--- a/README.rst
+++ b/README.rst
@@ -64,9 +64,9 @@ Get MPS or boehm-gc, depending on your platform:
 
 * Linux x86 or FreeBSD x86 (LLVM or HARP) -> `MPS
   <http://www.ravenbrook.com/project/mps/release/1.114.0/>`_
-* Mac OS X and all 64 bit (C) -> boehm-gc
+* macOS and all 64 bit (C) -> boehm-gc
 
-On Mac OS X, you may find it easiest to install Homebrew and install
+On macOS, you may find it easiest to install Homebrew and install
 the following::
 
     brew install autoconf automake bdw-gc --universal

--- a/documentation/getting-started-cli/source/debugging-with-gdb-lldb.rst
+++ b/documentation/getting-started-cli/source/debugging-with-gdb-lldb.rst
@@ -5,7 +5,7 @@ Debugging with GDB or LLDB
    available in builds from April 11, 2013 or later.
    :class: alert alert-block alert-warning
 
-.. warning:: On Mac OS X, we recommend using lldb to debug
+.. warning:: On macOS, we recommend using lldb to debug
    rather than gdb.
    :class: alert alert-block alert-warning
 
@@ -14,7 +14,7 @@ Which compiler backend are you using?
 
 If you are using the C backend, then the information discussed here
 will be useful for debugging. We use the C backend on 64 bit Linux,
-64 bit FreeBSD and all Mac OS X versions.
+64 bit FreeBSD and all macOS versions.
 
 If you're using the HARP backend (32 bit Linux or 32 bit FreeBSD), then
 you'll be limited to getting stack traces.

--- a/documentation/hacker-guide/source/build-system.rst
+++ b/documentation/hacker-guide/source/build-system.rst
@@ -317,7 +317,7 @@ are derived from the base Jam implementation and are documented in the
    *Open Dylan extension.*
 
 ``UNIX``
-   True on non-Windows platforms, like Linux, FreeBSD and Mac OS X.
+   True on non-Windows platforms, like Linux, FreeBSD and macOS.
 
 Editing Jam Files
 =================

--- a/documentation/hacker-guide/source/duim/index.rst
+++ b/documentation/hacker-guide/source/duim/index.rst
@@ -8,8 +8,8 @@ much to document yet as we haven't learned yet.
 GTK Back-end
 ============
 
-The GTK+ back-end is usable on both Mac OS X and Linux. It is
-based on GTK+ 3.x. On Mac OS X, it assumes that the Quartz
+The GTK+ back-end is usable on both macOS and Linux. It is
+based on GTK+ 3.x. On macOS, it assumes that the Quartz
 back-end is being used rather than X11.
 
 The bindings for GTK+ are largely generated from gobject-introspection
@@ -17,10 +17,10 @@ meta-data.  Some portions are hand-edited however or entirely done by
 hand, like the Cairo bindings.  Most of the special cases for hand-editing
 are put into the binding generator (`gir-dylan`_), but not all.
 
-Getting GTK+ 3.x with Quartz on Mac OS X
+Getting GTK+ 3.x with Quartz on macOS
 ----------------------------------------
 
-Building GTK+ 3.x with Quartz on Mac OS X must be done in a specific way.
+Building GTK+ 3.x with Quartz on macOS must be done in a specific way.
 This currently can *not* be done with Homebrew.
 
 Follow the `directions`_ on the GTK+ wiki, but make sure to build
@@ -30,7 +30,7 @@ GTK+ 3.x rather than 2.x. To do this, you'll want to use the moduleset
 Once you have a build, be sure to add the appropriate directories to
 your path.
 
-We have not yet integrated GTK+'s Mac OS X integration module, so
+We have not yet integrated GTK+'s macOS integration module, so
 the menu bar will not (yet) be integrated with the system menu bar
 when running a DUIM application.
 

--- a/documentation/library-reference/source/c-ffi/index.rst
+++ b/documentation/library-reference/source/c-ffi/index.rst
@@ -417,8 +417,8 @@ specifying a search path.  For example::
 
     C-Libraries: -lGL
 
-Linking against a Mac OS X Framework
-------------------------------------
+Linking against a macOS Framework
+---------------------------------
 
 Just as with a regular shared library, the :ref:`C-Libraries <lid-c-libraries>`
 keyword in a :doc:`LID file <../lid>`.  For example::

--- a/documentation/library-reference/source/lid.rst
+++ b/documentation/library-reference/source/lid.rst
@@ -265,7 +265,7 @@ libraries can also be added with this keyword. Arbitrary linker options
 can not be specified using this keyword.
 
 On Windows, this value for this keyword is passed directly to the linker.
-However, on Unix and Mac OS X, the requirements are a bit more stringent
+However, on Unix and macOS, the requirements are a bit more stringent
 and the arguments should be passed one per line and be one of the following:
 
 ``-L path``:
@@ -288,12 +288,12 @@ and the arguments should be passed one per line and be one of the following:
 
 ``-F path``:
   Add a path to the search path for frameworks.
-  **(Mac OS X only)**
+  **(macOS only)**
 
 ``-framework framework``:
   Link against the specified shared library. This should be either in the
   regular linker search path or have a path specified via a ``-F`` flag.
-  **(Mac OS X only)**
+  **(macOS only)**
 
 Unlike the other keywords described in this section, the *C-Libraries:*
 keyword propagates to dependent libraries. For example, suppose library

--- a/documentation/release-notes/source/2016.1.rst
+++ b/documentation/release-notes/source/2016.1.rst
@@ -155,7 +155,7 @@ Debugging
 * There is a new ``dylan-lldb`` wrapper script which can be used to
   launch ``lldb`` and pre-load the Open Dylan LLDB integration scripts.
   ``lldb`` is the debugger that is part of the LLVM project. It is the
-  default debugger on Mac OS X.
+  default debugger on macOS.
 
   If you need it to launch a custom build of LLDB, you can set the
   ``OPEN_DYLAN_LLDB`` environment variable to point to an alternative

--- a/packages/unix/README
+++ b/packages/unix/README
@@ -26,7 +26,7 @@ Linux:
  * Linux kernel 2.6
  * glibc 2.3
 
-Mac OS X:
+macOS:
  * Lion
  * XCode 4.2.1
 

--- a/sources/common-dylan/darwin-common-extensions.dylan
+++ b/sources/common-dylan/darwin-common-extensions.dylan
@@ -65,7 +65,7 @@ define function darwin-sysctl
 end function;
 
 /// This code uses one sysctl() to get the process arguments, and another
-/// to get the process's filename. It only works on OS X > 10.3.
+/// to get the process's filename. It only works on macOS > 10.3.
 /// The data format returned by KERN_PROCARGS2 is:
 /// [int32] <--- argc
 /// [string] <--- cmd name (relative to current directory)

--- a/sources/dfmc/llvm-back-end/llvm-sections.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-sections.dylan
@@ -40,7 +40,7 @@ define method llvm-section-name
   end select
 end method;
 
-// Darwin is different (cf. Mac OS X ABI Mach-O File Format Reference)
+// Darwin is different (cf. macOS ABI Mach-O File Format Reference)
 // LLVM section names for Mach-O are "segment, section" (comma-separated)
 define method llvm-section-name
     (back-end :: <llvm-darwin-back-end>, section :: <symbol>,

--- a/sources/environment/reports/bug-report.dylan
+++ b/sources/environment/reports/bug-report.dylan
@@ -770,7 +770,7 @@ end method compute-bug-report-objects;
 
 define function os-variant-to-name (os-variant) => (name :: <string>)
   select (os-variant)
-    #"darwin"     => "Mac OS X";
+    #"darwin"     => "macOS";
     #"freebsd"    => "FreeBSD";
     #"linux"      => "Linux";
     #"winunknown" => "Windows (Unknown)";

--- a/sources/jamfiles/posix-build.jam
+++ b/sources/jamfiles/posix-build.jam
@@ -268,7 +268,7 @@ rule DylanLibraryCLibraries image : libraries {
   local _dll = [ FDLLName $(image) ] ;
   local _exe = [ FEXEName $(image) ] ;
 
-  # -F and -framework are OS X flags.
+  # -F and -framework are macOS flags.
   for lib in $(libraries) {
     switch $(lib) {
       case -L* : _clib_$(image[1]:L) += $(lib) ;

--- a/sources/lib/run-time/posix-threads.h
+++ b/sources/lib/run-time/posix-threads.h
@@ -51,7 +51,7 @@
   && defined(HAVE_POSIX_TIMEOUTS) \
   && !defined(OPEN_DYLAN_PLATFORM_DARWIN)
 /* POSIX Semaphores are supported */
-/* NOTE OS X does not properly implement semaphores */
+/* NOTE macOS does not properly implement semaphores */
 /* NOTE If we don't have TIMEOUTS then we also use emulation for now */
 #define HAVE_POSIX_SEMAPHORES
 #endif


### PR DESCRIPTION
This reflects Apple's change in OS naming.