### PR TITLE
Several small changes to run-time

### DIFF
--- a/sources/lib/run-time/c-run-time.c
+++ b/sources/lib/run-time/c-run-time.c
@@ -21,6 +21,10 @@
 #  define unlikely(x) x
 #endif
 
+/// Many of the short functions in this file are not used in the runtime
+//  but have been retained so that they can be called from within
+//  the debugger.
+
 /*
  stack allocation
    relies on inlining
@@ -531,15 +535,15 @@ dylan_value primitive_raw_as_string (DBSTR buffer) {
 
 /* SIGNATURES */
 
-INLINE dylan_simple_object_vector* signature_required(dylan_signature* sig) {
+dylan_simple_object_vector* signature_required(dylan_signature* sig) {
   return(sig->required);
 }
 
-INLINE dylan_simple_object_vector* signature_values(dylan_signature* sig) {
+dylan_simple_object_vector* signature_values(dylan_signature* sig) {
   return(sig->values);
 }
 
-INLINE dylan_value signature_rest_value(dylan_signature* sig) {
+dylan_value signature_rest_value(dylan_signature* sig) {
   return(sig->rest_value);
 }
 
@@ -553,41 +557,41 @@ INLINE dylan_value signature_rest_value(dylan_signature* sig) {
 #define REST_VALUE_P_MASK    0x080000
 #define NEXT_P_MASK          0x100000
 
-INLINE int signature_number_required(dylan_signature* sig) {
+int signature_number_required(dylan_signature* sig) {
   return(R(sig->properties) & NUMBER_REQUIRED_MASK);
 }
 
-INLINE int signature_number_values(dylan_signature* sig) {
+int signature_number_values(dylan_signature* sig) {
   return((R(sig->properties) & NUMBER_VALUES_MASK)
            >> NUMBER_VALUES_OFFSET);
 }
 
-INLINE int signature_key_p(dylan_signature* sig) {
+int signature_key_p(dylan_signature* sig) {
   return((R(sig->properties) & KEY_P_MASK) > 0);
 }
 
-INLINE int signature_all_keys_p(dylan_signature* sig) {
+int signature_all_keys_p(dylan_signature* sig) {
   return((R(sig->properties) & ALL_KEYS_P_MASK) > 0);
 }
 
-INLINE int signature_rest_p(dylan_signature* sig) {
+int signature_rest_p(dylan_signature* sig) {
   return((R(sig->properties) & REST_P_MASK) > 0);
 }
 
-INLINE int signature_optionals_p(dylan_signature* sig) {
+int signature_optionals_p(dylan_signature* sig) {
   return((R(sig->properties) & OPTIONALS_P_MASK) > 0);
 }
 
 
-INLINE int signature_rest_value_p(dylan_signature* sig) {
+int signature_rest_value_p(dylan_signature* sig) {
   return((R(sig->properties) & REST_VALUE_P_MASK) > 0);
 }
 
-INLINE int signature_next_p(dylan_signature* sig) {
+int signature_next_p(dylan_signature* sig) {
   return((R(sig->properties) & NEXT_P_MASK) > 0);
 }
 
-INLINE dylan_value signature_make_properties
+dylan_value signature_make_properties
     (int number_required, int number_values,
      int key_p, int all_keys_p, int rest_p, int rest_value_p) {
   return(I(number_required
@@ -600,7 +604,7 @@ INLINE dylan_value signature_make_properties
 
 /* FUNCTION */
 
-INLINE DFN function_xep(dylan_simple_method* function) {
+DFN function_xep(dylan_simple_method* function) {
   return(function->xep);
 }
 
@@ -608,56 +612,56 @@ DFN primitive_function_xep(dylan_value function) {
   return(function_xep((dylan_simple_method*)function));
 }
 
-INLINE DLFN function_mep(dylan_simple_method* function) {
+DLFN function_mep(dylan_simple_method* function) {
   return(function->mep);
 }
 
-INLINE DLFN function_iep(dylan_simple_method* function) {
+DLFN function_iep(dylan_simple_method* function) {
   return(function->mep);
 }
 
-INLINE DLFN keyword_function_iep(dylan_simple_method* function) {
+DLFN keyword_function_iep(dylan_simple_method* function) {
   return(((dylan_keyword_method*)function)->iep);
 }
 
-INLINE dylan_value method_keyword_specifiers(dylan_simple_method* method) {
+dylan_value method_keyword_specifiers(dylan_simple_method* method) {
   return(((dylan_keyword_method*)method)->keyword_specifiers);
 }
 
-INLINE dylan_simple_object_vector* function_specializers(dylan_simple_method* function) {
+dylan_simple_object_vector* function_specializers(dylan_simple_method* function) {
   return(signature_required(function->signature));
 }
 
-INLINE int function_number_required(dylan_simple_method* function) {
+int function_number_required(dylan_simple_method* function) {
   return(signature_number_required(function->signature));
 }
 
-INLINE int function_number_values(dylan_simple_method* function) {
+int function_number_values(dylan_simple_method* function) {
   return(signature_number_values(function->signature));
 }
 
-INLINE int function_key_p(dylan_simple_method* function) {
+int function_key_p(dylan_simple_method* function) {
   return(signature_key_p(function->signature));
 }
 
-INLINE int function_all_keys_p(dylan_simple_method* function) {
+int function_all_keys_p(dylan_simple_method* function) {
   return(signature_all_keys_p(function->signature));
 }
 
-INLINE int function_rest_p(dylan_simple_method* function) {
+int function_rest_p(dylan_simple_method* function) {
   return(signature_rest_p(function->signature));
 }
 
-INLINE int function_optionals_p(dylan_simple_method* function) {
+int function_optionals_p(dylan_simple_method* function) {
   return(signature_optionals_p(function->signature));
 }
 
 
-INLINE int function_rest_value_p(dylan_simple_method* function) {
+int function_rest_value_p(dylan_simple_method* function) {
   return(signature_rest_value_p(function->signature));
 }
 
-INLINE int function_next_p(dylan_simple_method* function) {
+int function_next_p(dylan_simple_method* function) {
   return(signature_next_p(function->signature));
 }
 
@@ -1400,35 +1404,6 @@ INLINE void process_keyword_parameters
 }
 
 extern dylan_value unknown_keyword_argument_errorVKi(dylan_value function, dylan_value keyword);
-
-INLINE void process_keyword_parameters_into_with_checking
-    (dylan_simple_method* function, int number_required,
-     int number_keywords, dylan_value keyword_specifiers[],
-     int argument_count, dylan_value arguments[], dylan_value new_arguments[]) {
-  int i,j,k;
-
-  int allow_other_keys_p = function_all_keys_p(function);
-  int size_keyword_specifiers = number_keywords * 2;
-  for (i=argument_count-1; i>=number_required;) {
-    dylan_value value   = arguments[i--];
-    dylan_value keyword = arguments[i--];
-    for (j=0,k=number_required;;k++,j+=2) {
-      if (j == size_keyword_specifiers) {
-        if (!allow_other_keys_p) {
-          unknown_keyword_argument_errorVKi(function, keyword);
-        } else {
-          break;
-        }
-      } else {
-        dylan_value lambda_keyword = keyword_specifiers[j];
-        if (keyword == lambda_keyword) {
-          new_arguments[k] = value;
-          break;
-        }
-      }
-    }
-  }
-}
 
 INLINE int process_keyword_call_into
     (dylan_value* new_arguments, dylan_simple_method* function, int argument_count,

--- a/sources/lib/run-time/c-run-time.c
+++ b/sources/lib/run-time/c-run-time.c
@@ -525,7 +525,7 @@ dylan_value primitive_raw_as_string (DBSTR buffer) {
   size_t len = strlen(buffer);
   size_t size = round_up_to_word(base_size + len + 1);
   dylan_value string = primitive_alloc_leaf_r(size, &KLbyte_stringGVKdW, len, 1);
-  memcpy(((dylan_byte_string*)string)->data, buffer, len);
+  memcpy(((dylan_byte_string*)string)->data, buffer, len + 1);
   return string;
 }
 

--- a/sources/lib/run-time/llvm-runtime.h
+++ b/sources/lib/run-time/llvm-runtime.h
@@ -18,7 +18,7 @@ typedef float                   DSFLT;
 typedef double                  DDFLT;
 
 #define ITAG 1
-#define I(n) ((dylan_value) (((intptr_t)(n) << 2) | ITAG))
+#define I(n) ((dylan_value) (((unsigned long)(n) << 2) | ITAG))
 
 #include OPEN_DYLAN_RUNTIME_HEADER
 

--- a/sources/lib/run-time/posix-threads.c
+++ b/sources/lib/run-time/posix-threads.c
@@ -145,7 +145,6 @@ extern void *make_dylan_vector(size_t size);
 /*****************************************************************************/
 
 void  initialize_threads_primitives(void);
-static int   priority_map(int);
 
 static TLV_VECTOR grow_tlv_vector(TLV_VECTOR vector, size_t newsize);
 static void grow_all_tlv_vectors(size_t newsize);
@@ -230,11 +229,6 @@ PURE_FUNCTION static inline void *get_current_thread(void)
 static inline void set_current_thread(void *thread)
 {
   get_teb()->thread = thread;
-}
-
-PURE_FUNCTION static inline void *get_current_thread_handle(void)
-{
-  return get_teb()->thread_handle;
 }
 
 static inline void set_current_thread_handle(void *handle)
@@ -511,8 +505,6 @@ dylan_value primitive_make_thread(dylan_value t, dylan_value f, DBOOL s)
 
   thread->handle1 = 0;       // runtime thread flags
   thread->handle2 = rthread; // runtime thread object
-
-  // param.sched_priority = priority_map(priority);
 
   if (pthread_attr_init(&attr)) {
     MSG0("make-thread: error attr_init\n");
@@ -1664,38 +1656,4 @@ dylan_value primitive_unlock_recursive_lock(dylan_value l)
     return GENERAL_ERROR;
   }
   return OK;
-}
-
-
-/* The priority_map function maps dylan thread priorities to windows priorities
- * as below:
- *
- *   Dylan Priorities        windows priority
- *      < -1249            THREAD_PRIORITY_IDLE
- *    -1249 to -750       THREAD_PRIORITY_LOWEST
- *     -749 to -250    THREAD_PRIORITY_BELOW_NORMAL
- *     -250 to  249       THREAD_PRIORITY_NORMAL
- *    250 to  749      THREAD_PRIORITY_ABOVE_NORMAL
- *    750 to 1249         THREAD_PRIORITY_HIGHEST
- *      > 1249         THREAD_PRIORITY_TIME_CRITICAL
- */
-static int priority_map(int dylan_priority)
-{
-  return dylan_priority;
-  /*
-  int priority;
-
-  if (dylan_priority < 0)
-    if (dylan_priority < -1249)
-      priority = THREAD_PRIORITY_IDLE;
-    else
-      priority = (dylan_priority - 250) / 500;
-  else
-    if (dylan_priority > 1249)
-      priority = THREAD_PRIORITY_TIME_CRITICAL;
-    else
-      priority = (dylan_priority + 250) / 500;
-
-  return (priority);
-  */
 }

--- a/sources/lib/run-time/run-time.h
+++ b/sources/lib/run-time/run-time.h
@@ -1609,8 +1609,12 @@ extern DMINT primitive_unwrap_abstract_integer(dylan_value);
 #define primitive_machine_word_bit_field_extract(o, s, x)         (((x) & (((1 << (s)) - 1) << (o))) >> (o))
 
 #ifdef OPEN_DYLAN_COMPILER_GCC_LIKE
-#define primitive_machine_word_count_low_zeros(x) __builtin_ctzl(x)
-#define primitive_machine_word_count_high_zeros(x) __builtin_clzl(x)
+static inline DMINT primitive_machine_word_count_low_zeros(DMINT x) {
+  return x ? __builtin_ctzl(x) : (8 * sizeof(x));
+}
+static inline DMINT primitive_machine_word_count_high_zeros(DMINT x) {
+  return x ? __builtin_clzl(x) : (8 * sizeof(x));
+}
 #else
 extern DMINT primitive_machine_word_count_low_zeros(DMINT);
 extern DMINT primitive_machine_word_count_high_zeros(DMINT);


### PR DESCRIPTION
This PR gets rid of a few warnings when compiling the run-time library. It also fixes one test fail ("run-application input stream" in the system test suite) and one problem with LLVm code gen (fixes #1066)