### PR TITLE
Test fixes for the threads library

### DIFF
--- a/sources/common-dylan/tests/threads/notifications.dylan
+++ b/sources/common-dylan/tests/threads/notifications.dylan
@@ -174,14 +174,15 @@ define test queue-test ()
                                                    integer-to-string(i)),
                        function: reader);
   end for;
-
-  for (i from 0 below nfeeders)
-    join-thread(feeders[i]);
-  end for;
-  for (i from 0 below nreaders)
-    join-thread(readers[i]);
-  end for;
-
+  check-no-condition("queue-test completes",
+                   begin
+                     for (i from 0 below nfeeders)
+                       join-thread(feeders[i]);
+                     end for;
+                     for (i from 0 below nreaders)
+                       join-thread(readers[i]);
+                     end for;
+                   end);
 end test;
 
 

--- a/sources/common-dylan/tests/threads/simple-locks.dylan
+++ b/sources/common-dylan/tests/threads/simple-locks.dylan
@@ -46,6 +46,7 @@ define test simple-lock-multiple-claim
   let lock = make(<simple-lock>);
   check-true("First claim", wait-for(lock));
   check-condition("Second claim", <error>, wait-for(lock));
+  release(lock);
 end test simple-lock-multiple-claim;
 
 

--- a/sources/common-dylan/tests/threads/threads.dylan
+++ b/sources/common-dylan/tests/threads/threads.dylan
@@ -68,7 +68,10 @@ end test;
 // Just run thread-yield.
 //
 define test yield-test(description: "thread-yield")
-  thread-yield();
+  check-no-error("thread-yield works",
+                 begin
+                   thread-yield();
+                 end);
 end test;
 
 

--- a/sources/lib/run-time/posix-threads.c
+++ b/sources/lib/run-time/posix-threads.c
@@ -938,6 +938,13 @@ dylan_value primitive_wait_for_semaphore_timed(dylan_value l, dylan_value m)
   while (semaphore->count <= 0) {
     int res = pthread_cond_timedwait(&semaphore->cond, &semaphore->mutex, &end);
     if (res == ETIMEDOUT) {
+      /* The mutex is aquired even if the wait times out.
+       * See POSIX doc: http://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_cond_wait.html
+       */
+      if (pthread_mutex_unlock(&semaphore->mutex)) {
+        MSG0("wait-for-semaphore: pthread_mutex_unlock returned error\n");
+        return GENERAL_ERROR;
+      }
       return TIMEOUT;
     }
   }

--- a/sources/lib/run-time/posix-threads.c
+++ b/sources/lib/run-time/posix-threads.c
@@ -938,7 +938,7 @@ dylan_value primitive_wait_for_semaphore_timed(dylan_value l, dylan_value m)
   while (semaphore->count <= 0) {
     int res = pthread_cond_timedwait(&semaphore->cond, &semaphore->mutex, &end);
     if (res == ETIMEDOUT) {
-      /* The mutex is aquired even if the wait times out.
+      /* The mutex is acquired even if the wait times out.
        * See POSIX doc: http://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_cond_wait.html
        */
       if (pthread_mutex_unlock(&semaphore->mutex)) {


### PR DESCRIPTION
A couple of tests had no checks and so were marked as not implemented. Corrected some mistakes in the interface to pthreads which caused test fails/lockups in the test app.