### PR TITLE
Fix typo in macro name

### DIFF
--- a/sources/common-dylan/tests/threads/threads.dylan
+++ b/sources/common-dylan/tests/threads/threads.dylan
@@ -68,7 +68,7 @@ end test;
 // Just run thread-yield.
 //
 define test yield-test(description: "thread-yield")
-  check-no-error("thread-yield works",
+  check-no-errors("thread-yield works",
                  begin
                    thread-yield();
                  end);


### PR DESCRIPTION
Fixes #1088