### PR TITLE
Work on remove for ranges

### DIFF
--- a/sources/dylan/range.dylan
+++ b/sources/dylan/range.dylan
@@ -6,6 +6,20 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 /// <range> classes
+///
+/// Calling make on the abstract class <range> will return an instance
+/// of one of its concrete subclasses, which are not specified by the DRM.
+///
+/// In this implementation they are:
+/// <empty-range> - a range with no members
+/// <finite-range> - a bounded range with at least one member
+/// <infinite-range> - an unbounded range with (potentially) infinite members
+/// <constant-range> - a sequence comprising a (potentially infinite) number
+/// of repeats of the same element
+///
+/// NOTE: attempting to create an empty range using make, or by removing
+/// elements from a <finite-range> or <constant-range> will always return
+/// the singleton instance of <empty-range>, called $empty-range in this file.
 
 define abstract primary class <range> (<sequence>)
   slot range-from :: <number>, required-init-keyword: from:;
@@ -418,6 +432,8 @@ define sealed method remove!
   //--- What about 'test'?
   if (~count | count > 0)
     case
+      (range.size = 1 & elt = range.range-from) =>
+        $empty-range;
       (elt = range.last) =>
         range.size := range.size - 1;
         range;
@@ -425,8 +441,6 @@ define sealed method remove!
         range.size := range.size - 1;
         range.range-from := range.range-from + range.range-by;
         range;
-      (range.size = 1 & elt = range.range-from) =>
-        $empty-range;
       otherwise =>
         if (count & count > 0 & member?(elt, range))
           remove!(shallow-copy(range), elt, test: test, count: count)

--- a/sources/dylan/tests/regressions.dylan
+++ b/sources/dylan/tests/regressions.dylan
@@ -240,6 +240,15 @@ define test issue-440 ()
               map(identity, cis), cis);
 end;
 
+define test issue-1091 ()
+  let test-range = range(from: 1, size: 1);
+  check-false("one element range is not empty", empty?(test-range)); 
+  check-equal("one element range has size 1", 1, size(test-range));
+  test-range := remove(test-range, 1);
+  check-true("empty range is empty", empty?(test-range)); 
+  check-equal("empty range has size 0", 0, size(test-range));
+end;
+
 define suite dylan-regressions ()
   test bug-2766;
   test bug-5800;
@@ -260,5 +269,6 @@ define suite dylan-regressions ()
   test issue-189;
   test issue-203;
   test issue-440;
+  test issue-1091
 end suite dylan-regressions;
 

--- a/sources/dylan/tests/regressions.dylan
+++ b/sources/dylan/tests/regressions.dylan
@@ -240,6 +240,7 @@ define test issue-440 ()
               map(identity, cis), cis);
 end;
 
+// Issue 1091: remove on <range> can return an invalid object (https://github.com/dylan-lang/opendylan/issues/1091)
 define test issue-1091 ()
   let test-range = range(from: 1, size: 1);
   check-false("one element range is not empty", empty?(test-range)); 


### PR DESCRIPTION
This is a small change to make sure that removing the element from a one-element range results in a valid empty range (instance of `<empty-range>` in this implementation)
A test is also provided.
Fixes #1091 