### PR TITLE
Fix for segfault when using map-into with deque

### DIFF
--- a/sources/dylan/collection.dylan
+++ b/sources/dylan/collection.dylan
@@ -485,8 +485,10 @@ define method map-into-stretchy-one
           with-fip-of target with prefix t-
             for (key from 0 below key,
                  t-state = t-initial-state then t-next-state(target, t-state))
-            finally // Process the remaining keys
-              for (t-state = t-state then t-next-state(target, t-state))
+            finally // Process the remaining keys. We know the target and coll
+              // have the same size so only check the former.
+              for (t-state = t-state then t-next-state(target, t-state),
+                 until: t-finished-state?(target, t-state, t-limit))
                 t-current-element-setter
                   (fun(c-current-element(coll, c-state)), target, t-state);
                 c-state := c-next-state(coll, c-state);

--- a/sources/dylan/tests/regressions.dylan
+++ b/sources/dylan/tests/regressions.dylan
@@ -250,6 +250,14 @@ define test issue-1091 ()
   check-equal("empty range has size 0", 0, size(test-range));
 end;
 
+// Issue 1095: Bus error when using map-into with <deque> (https://github.com/dylan-lang/opendylan/issues/1095)
+define test issue-1095 ()
+  let col = as(<deque>, #(0, 0, 0));
+  check-equal("map-into stretches a <deque> correctly",
+              as(<deque>, #(1, 2, 3, 4)),
+              map-into(col, identity, #(1, 2, 3, 4)));
+end;
+
 define suite dylan-regressions ()
   test bug-2766;
   test bug-5800;
@@ -270,6 +278,7 @@ define suite dylan-regressions ()
   test issue-189;
   test issue-203;
   test issue-440;
-  test issue-1091
+  test issue-1091;
+  test issue-1095;
 end suite dylan-regressions;
 


### PR DESCRIPTION
When using `map-into` with a target collection which is a stretchy, mutable sequence but not an array (I think `<deque>` may be the only collection this applies to) and the target needs to be stretched, the copying loop doesn't have an end condition. Therefore the iterator state just runs on past the end of the collection until it eventually causes a segmentation fault/bus error.

Side question: should the functions in forward-iteration-protocol test if the iterator state is valid?

Tested on macos and Linux. Fixes #1095  