### PR TITLE
Work on automated tests for the 'io' library

### DIFF
--- a/documentation/library-reference/source/io/streams.rst
+++ b/documentation/library-reference/source/io/streams.rst
@@ -426,9 +426,7 @@ then an :class:`<invalid-file-permissions-error>`
 condition is signalled at the time the file stream is created.
 
 The *element-type:* init-keyword controls how the elements of the
-underlying file are accessed. This allows file elements to be
-represented abstractly; for instance, contiguous elements could be
-treated as a single database record. The three possible element types
+underlying file are accessed. The three possible element types
 are:
 
 - :type:`<byte-character>`

--- a/sources/common-dylan/format.dylan
+++ b/sources/common-dylan/format.dylan
@@ -713,7 +713,6 @@ define function print-method
   print-string(buffer, object-class-name(object));
   print-string(buffer, ": ");
   print-string(buffer, primitive-name(object));
-  print-string(buffer, " ");
   print-signature(buffer, object);
   print-string(buffer, "}");
 end function print-method;

--- a/sources/common-dylan/library.dylan
+++ b/sources/common-dylan/library.dylan
@@ -211,6 +211,9 @@ define module streams-protocol
          stream-position,
          stream-position-setter,
          adjust-stream-position;
+  // Wrapper streams
+  create outer-stream,
+         outer-stream-setter;
 end module streams-protocol;
 
 define module transcendentals

--- a/sources/common-dylan/streams-protocol.dylan
+++ b/sources/common-dylan/streams-protocol.dylan
@@ -80,6 +80,11 @@ define method stream-size (stream :: <stream>) => (size :: singleton(#f))
   #f
 end method stream-size;
 
+define open generic outer-stream
+  (stream :: <stream>) => (wrapper :: <stream>);
+
+define open generic outer-stream-setter
+  (wrapper :: <stream>, stream :: <stream>) => (wrapper :: <stream>);
 
 define open abstract class <positionable-stream> (<stream>) end;
 
@@ -91,7 +96,6 @@ define open generic stream-position-setter
 
 define open generic adjust-stream-position
     (stream :: <stream>, delta, #key from) => (position);
-
 
 define open generic read-element
     (stream :: <stream>, #key on-end-of-stream) => (element);

--- a/sources/common-dylan/streams-protocol.dylan
+++ b/sources/common-dylan/streams-protocol.dylan
@@ -10,6 +10,10 @@ define open abstract class <stream-error> (<error>, <format-string-condition>)
     required-init-keyword: stream:;
 end;
 
+define generic stream-error-stream
+  (error :: <stream-error>)
+  => (stream :: <stream>);
+
 // TODO: yuck.  Would be nicer to just have a condition-to-string method..
 // andrewa: note that then you need to update the runtime manager to
 // know about the new class too, it is simpler to rely on subclassing
@@ -50,6 +54,14 @@ define class <incomplete-read-error> (<end-of-stream-error>)
     required-init-keyword: count:;
 end class <incomplete-read-error>;
 
+define generic stream-error-sequence
+  (error :: <incomplete-read-error>)
+  => (sequence);
+
+define generic stream-error-count
+  (error :: <end-of-stream-error>)
+  => (count);
+
 define class <incomplete-write-error> (<end-of-stream-error>)
   constant slot stream-error-count,
     required-init-keyword: count:;
@@ -89,13 +101,13 @@ define open generic outer-stream-setter
 define open abstract class <positionable-stream> (<stream>) end;
 
 define open generic stream-position
-    (stream :: <stream>) => (position);
+    (stream :: <positionable-stream>) => (position);
 
 define open generic stream-position-setter
-    (position, stream :: <stream>) => (position :: <object>);
+    (position, stream :: <positionable-stream>) => (position :: <object>);
 
 define open generic adjust-stream-position
-    (stream :: <stream>, delta, #key from) => (position);
+    (stream :: <positionable-stream>, delta :: <integer>, #key from) => (position);
 
 define open generic read-element
     (stream :: <stream>, #key on-end-of-stream) => (element);

--- a/sources/common-dylan/streams-protocol.dylan
+++ b/sources/common-dylan/streams-protocol.dylan
@@ -5,7 +5,7 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
-define open class <stream-error> (<error>, <format-string-condition>)
+define open abstract class <stream-error> (<error>, <format-string-condition>)
   constant slot stream-error-stream :: <stream>,
     required-init-keyword: stream:;
 end;

--- a/sources/common-dylan/tests/library.dylan
+++ b/sources/common-dylan/tests/library.dylan
@@ -19,7 +19,9 @@ end library common-dylan-test-suite;
 define module common-dylan-test-suite
   use dylan;
   use dylan-extensions,
-    import: { encode-single-float, encode-double-float };
+    import: { encode-single-float,
+              encode-double-float,
+              <abstract-integer> };
   use common-extensions;
   use streams-protocol;
   use locators-protocol;

--- a/sources/common-dylan/tests/specification.dylan
+++ b/sources/common-dylan/tests/specification.dylan
@@ -172,7 +172,7 @@ define module-spec streams-protocol ()
     (<object>, #"key", #"all-keys") => (<stream>);
   open generic-function wait-for-io-completion (<stream>) => ();
   open generic-function close
-    (<stream>, #"rest", #"key", #"all-keys") => ();
+    (<closable-object>, #"rest", #"key", #"all-keys") => ();
 end module-spec streams-protocol;
 
 define module-spec locators-protocol ()

--- a/sources/common-dylan/tests/specification.dylan
+++ b/sources/common-dylan/tests/specification.dylan
@@ -154,7 +154,7 @@ define module-spec streams-protocol ()
   open generic-function stream-open? (<stream>) => (<boolean>);
   open generic-function stream-element-type (<stream>) => (<type>);
   open generic-function stream-at-end? (<stream>) => (<boolean>);
-  open generic-function stream-size (<stream>) => (false-or(<integer>));
+  open generic-function stream-size (<stream>) => (false-or(<abstract-integer>));
 
   // Positioning streams
   open abstract class <positionable-stream> (<stream>);

--- a/sources/common-dylan/tests/streams.dylan
+++ b/sources/common-dylan/tests/streams.dylan
@@ -205,7 +205,15 @@ end method test-stream;
 define abstract class <test-stream> (<positionable-stream>)
   slot stream-closed? :: <boolean> = #f;
   slot stream-test-position :: <integer> = 0;
+  slot outer-stream :: <stream>;
 end class <test-stream>;
+
+define method initialize(test-stream :: <test-stream>, #key)
+  next-method();
+  unless(slot-initialized?(test-stream, outer-stream))
+    test-stream.outer-stream := test-stream
+  end;
+end method initialize;
 
 define method close
     (stream :: <test-stream>, #key) => ()

--- a/sources/common-dylan/tests/streams.dylan
+++ b/sources/common-dylan/tests/streams.dylan
@@ -609,23 +609,29 @@ end method test-stream-input-available?;
 define method test-stream-contents
     (info :: <stream-test-info>, stream :: <stream>) => ()
   let name = info.info-test-name;
+  let prior-position = stream-position(stream);
   check-equal(format-to-string("%s: stream-contents correct", name),
               info.info-contents,
               stream-contents(stream));
-  check-at-end-of-stream(name, "stream-contents", stream)
+  check-equal(format-to-string("%s: stream-position is unchanged", name),
+	      prior-position,
+	      stream-position(stream));
 end method test-stream-contents;
 
 define method test-stream-contents-as
     (info :: <stream-test-info>, stream :: <stream>) => ()
   let name = info.info-test-name;
   let contents = #f;
+  let prior-position = stream-position(stream);
   check-equal(format-to-string("%s: stream-contents-as correct", name),
               info.info-contents,
               contents := stream-contents-as(<list>, stream));
   check-instance?(format-to-string("%s: stream-contents-as returns sequence of specified type", name),
                   <list>,
                   contents);
-  check-at-end-of-stream(name, "stream-contents-as", stream)
+  check-equal(format-to-string("%s: stream-position is unchanged", name),
+	      prior-position,
+	      stream-position(stream));
 end method test-stream-contents-as;
 
 define function check-at-end-of-stream

--- a/sources/io/library.dylan
+++ b/sources/io/library.dylan
@@ -113,8 +113,7 @@ define module streams
 
   // Wrapper streams
   create <wrapper-stream>,
-         inner-stream, inner-stream-setter,
-         outer-stream, outer-stream-setter;
+         inner-stream, inner-stream-setter;
 
   // Indenting streams
   create

--- a/sources/io/streams/buffered-stream.dylan
+++ b/sources/io/streams/buffered-stream.dylan
@@ -101,9 +101,9 @@ define inline function get-input-buffer
 end function get-input-buffer;
 
 // No default method for this.  Look for interesting methods under
-// <console-stream> and <file-stream> and <multi-buffered-stream>
+// <file-stream> and <multi-buffered-stream>
 define open generic do-get-input-buffer
-    (stream :: <stream>, #key wait?, bytes)
+    (stream :: <buffered-stream>, #key wait?, bytes)
  => (buffer :: false-or(<buffer>));
 
 define inline function next-input-buffer

--- a/sources/io/streams/buffered-stream.dylan
+++ b/sources/io/streams/buffered-stream.dylan
@@ -423,8 +423,12 @@ define method read
      #key on-end-of-stream = unsupplied())
  => (elements)
   let elements = make(stream-sequence-class(stream), size: n);
-  read-into!(stream, n, elements, on-end-of-stream: on-end-of-stream);
-  elements
+  let count-or-eof = read-into!(stream, n, elements, on-end-of-stream: on-end-of-stream);
+  if (count-or-eof == on-end-of-stream)
+    on-end-of-stream
+  else
+    elements
+  end
 end method read;
 
 //---*** andrewa: this is a bad name, since this isn't meant to know about
@@ -434,7 +438,8 @@ define variable *multi-buffer-bytes* :: <integer> = 0;
 define method read-into!
     (stream :: <buffered-stream>, n :: <integer>, seq :: <mutable-sequence>,
      #key start :: <integer> = 0, on-end-of-stream = unsupplied())
- => (n-read)
+  => (n-read)
+  let n-read = n;
   if (n > 0)
     with-input-buffer (sb = stream)
       let e :: <integer> = start + n;
@@ -457,17 +462,20 @@ define method read-into!
           // Signal error if we didn't get enough data
           if (n > i - start)
             n := i - start;
-            unless (supplied?(on-end-of-stream))
+            if (supplied?(on-end-of-stream))
+              n-read := on-end-of-stream;
+            else
+              n-read := i - start;
               signal(make(<incomplete-read-error>,
                           stream: stream,
-                          count: n, sequence: seq))
+                          count: n-read, sequence: seq))
             end
           end
         end
       end iterate
     end;
   end;
-  n
+  n-read
 end method read-into!;
 
 

--- a/sources/io/streams/file-stream.dylan
+++ b/sources/io/streams/file-stream.dylan
@@ -78,9 +78,9 @@ define method initialize
     //--** This may leave closed <external-stream>s hanging around,
     //-- See $open-external-streams.
     let handler <condition> = method(condition, next-handler)
-				stream.stream-direction := #"closed";
-				next-handler();
-				end;
+                                stream.stream-direction := #"closed";
+                                next-handler();
+                              end;
     stream.accessor := apply(new-accessor, #"file", initargs);
   end;
   if (requested-buffer-size)

--- a/sources/io/streams/native-buffer.dylan
+++ b/sources/io/streams/native-buffer.dylan
@@ -56,6 +56,19 @@ define inline sealed method buffer-size
 end method buffer-size;
 
 //
+// Definitions for the specification tests
+//
+define generic buffer-next
+  (buffer :: <buffer>) => (index :: <buffer-index>);
+define generic buffer-next-setter
+  (index :: <buffer-index>, buffer :: <buffer>) => (index :: <buffer-index>);
+define generic buffer-end
+  (buffer :: <buffer>) => (index :: <buffer-index>);
+define generic buffer-end-setter
+  (index :: <buffer-index>, buffer :: <buffer>) => (index :: <buffer-index>);
+
+
+//
 // ELEMENT
 //
 

--- a/sources/io/streams/sequence-stream.dylan
+++ b/sources/io/streams/sequence-stream.dylan
@@ -188,16 +188,23 @@ define method read
   let src-n :: <integer>  = (stream-limit(stream) | stream.final-position) - pos;
   if (n > src-n)
     if (unsupplied?(on-end-of-stream))
-      signal(make(<incomplete-read-error>,
-                  stream: stream,
-                  count: src-n,
-                  sequence: copy-sequence(seq, start: pos, end: pos + src-n)));
+      if (zero?(src-n))
+        signal(make(<end-of-stream-error>, stream: stream))
+      else
+        stream.current-position := pos + src-n;
+        signal(make(<incomplete-read-error>,
+                    stream: stream,
+                    count: src-n,
+                    sequence: copy-sequence(seq, start: pos, end: pos + src-n)));
+      end;
+    else
+      on-end-of-stream
     end;
-    n := src-n
+  else
+    let elements = copy-sequence(seq, start: pos, end: pos + n);
+    stream.current-position := pos + n;
+    elements
   end;
-  let elements = copy-sequence(seq, start: pos, end: pos + n);
-  stream.current-position := pos + n;
-  elements
 end method read;
 
 define method read-into!

--- a/sources/io/streams/sequence-stream.dylan
+++ b/sources/io/streams/sequence-stream.dylan
@@ -95,7 +95,8 @@ define method initialize
     stream.final-position := _start
   else
     stream.final-position := size(stream-sequence(stream))
-  end
+  end;
+  stream.stream-element-type := element-type(stream-sequence(stream));
 end method initialize;
 
 define open generic type-for-sequence-stream

--- a/sources/io/streams/stream.dylan
+++ b/sources/io/streams/stream.dylan
@@ -17,7 +17,7 @@ define constant $closed       = 4;
 /// The basic stream class
 
 define open abstract primary class <basic-stream> (<stream>)
-  slot outer-stream :: false-or(<stream>),
+  slot outer-stream :: <stream>,
     init-keyword: outer-stream:;
   slot private-stream-element-type-value :: <type> = <object>,
     init-keyword: element-type:;
@@ -153,7 +153,7 @@ define method close
      wait? :: <boolean>,
      synchronize? :: <boolean>) => ()
   ignore(keys, abort?, wait?, synchronize?);
-  stream.outer-stream := #f;
+  stream.outer-stream := stream;
   stream.private-stream-direction-value := $closed;
   next-method ();
 end method close;

--- a/sources/io/streams/wrapper-stream.dylan
+++ b/sources/io/streams/wrapper-stream.dylan
@@ -8,7 +8,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 /// Wrapper streams
 
-define open abstract primary class <wrapper-stream> (<basic-stream>)
+define open abstract primary class <wrapper-stream> (<basic-stream>, <positionable-stream>)
   slot %inner-stream :: <stream>,
     required-init-keyword: inner-stream:;
 end class <wrapper-stream>;

--- a/sources/io/streams/wrapper-stream.dylan
+++ b/sources/io/streams/wrapper-stream.dylan
@@ -87,7 +87,6 @@ end method peek;
 define method read
     (stream :: <wrapper-stream>, n :: <integer>, #rest keys, #key on-end-of-stream)
  => (elements-or-eof :: <object>)
-  ignore(on-end-of-stream);
   apply(read, stream.inner-stream, n, keys)
 end method read;
 
@@ -95,7 +94,6 @@ define method read-into!
     (stream :: <wrapper-stream>, n :: <integer>, seq :: <mutable-sequence>,
      #rest keys, #key start, on-end-of-stream)
  => (n-read-or-eof :: <object>)
-  ignore(start, on-end-of-stream);
   apply(read-into!, stream.inner-stream, n, seq, keys)
 end method read-into!;
 

--- a/sources/io/tests/specification.dylan
+++ b/sources/io/tests/specification.dylan
@@ -67,10 +67,10 @@ define module-spec streams ()
     => (<stream>);
   open generic-function inner-stream-setter (<stream>, <wrapper-stream>)
     => (<stream>);
-  open generic-function outer-stream (<stream>) => (<wrapper-stream>);
+  open generic-function outer-stream (<stream>) => (<stream>);
   open generic-function outer-stream-setter
-       (<wrapper-stream>, <stream>)
-    => (<wrapper-stream>);
+       (<stream>, <stream>)
+    => (<stream>);
 
   // Stream buffers
   sealed instantiable class <buffer> (<vector>);

--- a/sources/io/tests/streams.dylan
+++ b/sources/io/tests/streams.dylan
@@ -423,6 +423,29 @@ define method read-element
   as-uppercase(char)
 end method read-element;
 
+define method read
+  (stream :: <test-wrapper-stream>, n :: <integer>, #key on-end-of-stream)
+  => (sequence)
+  let sequence = next-method();
+  map(as-uppercase, sequence);
+end;
+
+define method stream-contents
+  (stream :: <test-wrapper-stream>, #key clear-contents?)
+  => (sequence :: <sequence>)
+  let sequence = next-method();
+  map(as-uppercase, sequence)
+end;
+
+define method stream-contents-as
+  (type :: <class>, stream :: <test-wrapper-stream>, #key clear-contents?)
+  => (sequence :: <sequence>)
+  let sequence = next-method();
+  sequence := map(as-uppercase, sequence);
+  as(type, sequence);
+end;
+
+
 define method write-element
     (stream :: <test-wrapper-stream>, elt :: <character>) => ()
   write-element(stream.inner-stream, as-uppercase(elt))

--- a/sources/io/tests/streams.dylan
+++ b/sources/io/tests/streams.dylan
@@ -10,6 +10,10 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define constant $default-string  = "abcdefghijklmnopqrstuvwxyz";
 
+define sideways method make-test-instance(cls == <buffer>) => (object)
+  make(<buffer>)
+end;
+
 
 /// Stream convenience function tests
 
@@ -388,7 +392,7 @@ define sideways method make-stream-tests-of-size
        make(<stream-test-info>,
             test-name: "<test-wrapper-stream> for <test-input-stream>",
             class-info: stream-class-info(<test-wrapper-stream>),
-            contents: $default-string,
+            contents: as-uppercase($default-string),
             direction: #"input",
             make-function: method ()
                              let stream
@@ -401,6 +405,8 @@ end method make-stream-tests-of-size;
 
 
 /// Test wrapper stream subclass
+// This subclass always converts characters read from the inner stream
+// to upper case.
 
 define class <test-wrapper-stream> (<wrapper-stream>)
 end class <test-wrapper-stream>;

--- a/sources/io/tests/streams.dylan
+++ b/sources/io/tests/streams.dylan
@@ -417,18 +417,42 @@ register-stream-class-info("<test-wrapper-stream>", <test-wrapper-stream>,
                            element-type: <object>);
 
 define method read-element
-    (stream :: <test-wrapper-stream>, #rest keys, #key on-end-of-stream)
+    (stream :: <test-wrapper-stream>, #rest keys, #key on-end-of-stream = unsupplied())
  => (element :: <object>)
-  let char :: <character> = next-method();
-  as-uppercase(char)
+  let char = next-method();
+  if (char == on-end-of-stream)
+    on-end-of-stream
+  else
+    as-uppercase(char);
+  end if
 end method read-element;
 
 define method read
-  (stream :: <test-wrapper-stream>, n :: <integer>, #key on-end-of-stream)
+  (stream :: <test-wrapper-stream>, n :: <integer>, #key on-end-of-stream = unsupplied())
   => (sequence)
   let sequence = next-method();
-  map(as-uppercase, sequence);
+  if (sequence == on-end-of-stream)
+    on-end-of-stream
+  else
+    map(as-uppercase, sequence);
+  end if
 end;
+
+define method read-into!
+  (stream :: <test-wrapper-stream>, n :: <integer>, sequence :: <mutable-sequence>,
+   #key start :: <integer> = 0, on-end-of-stream = unsupplied())
+  => (count-or-eof)
+  let count-or-eof = next-method();
+  if (count-or-eof == on-end-of-stream)
+    on-end-of-stream
+  else
+    let count :: <integer> = count-or-eof;
+    for (i from 0 below count)
+      sequence[i] := as-uppercase(sequence[i]);
+    end;
+    count
+  end
+end method read-into!;
 
 define method stream-contents
   (stream :: <test-wrapper-stream>, #key clear-contents?)
@@ -445,6 +469,15 @@ define method stream-contents-as
   as(type, sequence);
 end;
 
+define method peek
+  (stream :: <test-wrapper-stream>, #key on-end-of-stream = unsupplied()) => (element-or-eof)
+  let element-or-eof = next-method();
+  if (on-end-of-stream == element-or-eof)
+    on-end-of-stream
+  else
+    as-uppercase(element-or-eof)
+  end
+end method peek;
 
 define method write-element
     (stream :: <test-wrapper-stream>, elt :: <character>) => ()

--- a/sources/io/tests/streams.dylan
+++ b/sources/io/tests/streams.dylan
@@ -104,10 +104,10 @@ end method test-new-line;
 
 /// Positionable stream convenience function tests
 
-register-stream-test(<stream>, test-current-position);
-register-stream-test(<stream>, test-current-position-setter);
-register-stream-test(<stream>, test-initial-position);
-register-stream-test(<stream>, test-final-position);
+register-stream-test(<positionable-stream>, test-current-position);
+register-stream-test(<positionable-stream>, test-current-position-setter);
+register-stream-test(<positionable-stream>, test-initial-position);
+register-stream-test(<positionable-stream>, test-final-position);
 
 // Don't test the functions we're already testing... there must be a better way!
 define streams function-test current-position () end;


### PR DESCRIPTION
This fixes Testworks fails for the io library. In some cases the test was changed, in some the library.
Note that there are still a lot of tests not implemented.