### PR TITLE
Changes to reporting of invalid class precedence list

### DIFF
--- a/sources/dfmc/conversion/define-class-mop.dylan
+++ b/sources/dfmc/conversion/define-class-mop.dylan
@@ -950,6 +950,7 @@ define function ^compute-class-precedence-list (c :: <&class>)
                     map-into(remaining-lists, remove-next, remaining-lists))
       else
         // We are trying to build a class with an inconsistent CPL.
+        let heads = concatenate(c-direct-superclasses, list(c));
         // Find two classes, and two witnesses, such that
         // witness 1 < witness 2 in CPL of class 1 and reverse in class 2
         let (witness1, witness2, index-of-class1, index-of-class2) =
@@ -971,12 +972,8 @@ define function ^compute-class-precedence-list (c :: <&class>)
           end block;
 
         // Signal an error explaining what has gone wrong.
-        let class1 = if (index-of-class1 = 0)
-                       c
-                     else
-                       c-direct-superclasses[index-of-class1 - 1]
-                     end;
-        let class2 = c-direct-superclasses[index-of-class2 - 1];
+        let class1 = heads[index-of-class1];
+        let class2 = heads[index-of-class2];
         note-CPL-inconsistency(
           c,
           class1,

--- a/sources/dfmc/conversion/define-class-mop.dylan
+++ b/sources/dfmc/conversion/define-class-mop.dylan
@@ -985,8 +985,8 @@ define function ^compute-class-precedence-list (c :: <&class>)
 
   let c3 = merge-lists(list(c),
                        concatenate(map(^all-superclasses, c-direct-superclasses),
-                                   list(c-direct-superclasses)));
-  let old = ^compute-class-precedence-list-old(c);
+                                   list(c-direct-superclasses))) | #();
+  let old = ^compute-class-precedence-list-old(c) | #();
   unless (every?(\=, c3, old))
     let name = compose(fragment-identifier, model-variable-name);
     note(<cpl-differ>,

--- a/sources/dfmc/conversion/define-class-mop.dylan
+++ b/sources/dfmc/conversion/define-class-mop.dylan
@@ -1157,7 +1157,7 @@ define program-note <subclass-explanation-1>(<precedes-explanation>)
 end;
 
 define program-note <subclass-explanation-2>(<precedes-explanation>)
-  slot class-4-name,  init-keyword: class-3:;
+  slot class-4-name,  init-keyword: class-4:;
   format-string "%s precedes %s in the CPL of %s "
                 "because %s is a direct subclass of %s "
                 "and %s precedes %s in %s";
@@ -1207,7 +1207,7 @@ define method explain-precedes(c1, c2, in)
       if (precedes?(c1, c2, s))
         return(make(<subclass-explanation-2>,
                     class-1: c1.name, class-2: c2.name,
-                    class-2: in.name, class-4: s.name,
+                    class-3: in.name, class-4: s.name,
                     subnotes: list(explain-precedes(c1, c2, s))))
       end
     end;


### PR DESCRIPTION
This PR includes three things:
* Fixing the internal error noted in #1040 that occurs when the CPL is invalid 
* Fixing the code that explains why the CPL is invalid. In some cases it was mentioning the wrong classes.
* Removing code which cross-checked the C3 algorithm with the original Dylan algorithm

Note: if a class has an invalid CPL it will be reported but, because the compiler always tries to carry on, will cause subsequent errors when it is used as it will have no superclasses.  This maybe could be improved.

If a program has no invalid classes, the compiler output will be the same before and after this PR.

Fixes #1040 