### PR TITLE
Fix testworks registry entries after move from sources/qa to sources/lib

### DIFF
--- a/sources/registry/generic/testworks-gui
+++ b/sources/registry/generic/testworks-gui
@@ -1,1 +1,1 @@
-abstract://dylan/qa/testworks/gui/testworks-gui.lid
+abstract://dylan/lib/testworks/gui/testworks-gui.lid

--- a/sources/registry/generic/testworks-report
+++ b/sources/registry/generic/testworks-report
@@ -1,1 +1,1 @@
-abstract://dylan/qa/testworks/report/testworks-report.lid
+abstract://dylan/lib/testworks/report/testworks-report.lid

--- a/sources/registry/generic/testworks-specs
+++ b/sources/registry/generic/testworks-specs
@@ -1,1 +1,1 @@
-abstract://dylan/qa/testworks/specs/testworks-specs.lid
+abstract://dylan/lib/testworks/specs/testworks-specs.lid

--- a/sources/registry/generic/testworks-test-suite
+++ b/sources/registry/generic/testworks-test-suite
@@ -1,1 +1,1 @@
-abstract://dylan/qa/testworks/tests/testworks-test-suite.lid
+abstract://dylan/lib/testworks/tests/testworks-test-suite.lid

--- a/sources/registry/generic/testworks-test-suite-app
+++ b/sources/registry/generic/testworks-test-suite-app
@@ -1,1 +1,1 @@
-abstract://dylan/qa/testworks/tests/testworks-test-suite-app.lid
+abstract://dylan/lib/testworks/tests/testworks-test-suite-app.lid


### PR DESCRIPTION
Untested because I don't have a Dylan compiler at hand. Seems pretty safe though.