### PR TITLE
llvm-as: New standalone tool with llvm-builder output

### DIFF
--- a/sources/app/llvm-as/library.dylan
+++ b/sources/app/llvm-as/library.dylan
@@ -1,0 +1,47 @@
+Module:    dylan-user
+Author:    Peter S. Housel
+Copyright:    Original Code is Copyright 2009-2018 Gwydion Dylan Maintainers
+              All rights reserved.
+License:      See License.txt in this distribution for details.
+Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
+
+define library llvm-as
+  use common-dylan;
+  use io;
+  use system;
+  use llvm;
+  use llvm-asm-parser;
+  use command-line-parser;
+end library llvm-as;
+
+define module llvm-write-builder
+  use common-dylan, exclude: { format-to-string };
+  use streams;
+  use print;
+  use pprint;
+  use format;
+  use standard-io;
+  use file-system;
+  use operating-system;
+
+  use llvm;
+
+  export llvm-write-builder;
+end module;
+
+define module llvm-as
+  use common-dylan, exclude: { format-to-string };
+  use streams;
+  use pprint;
+  use format;
+  use standard-io;
+  use locators;
+  use file-system;
+  use operating-system;
+  use command-line-parser;
+
+  use llvm;
+  use llvm-asm-parser;
+  use llvm-write-builder;
+end module llvm-as;
+

--- a/sources/app/llvm-as/llvm-as.dylan
+++ b/sources/app/llvm-as/llvm-as.dylan
@@ -1,0 +1,58 @@
+Module:    llvm-as
+Author:    Peter S. Housel
+Copyright:    Original Code is Copyright 2009-2018 Gwydion Dylan Maintainers
+              All rights reserved.
+License:      See License.txt in this distribution for details.
+Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
+
+define method main () => ()
+  let parser = make(<command-line-parser>,
+                    min-positional-options: 1,
+                    max-positional-options: 1);
+  add-option(parser,
+             make(<flag-option>,
+                  names: #("b", "output-builder"),
+                  default: #f,
+                  variable: "WHAT",
+                  help: "Output builder code to standard output"));
+  add-option(parser,
+             make(<parameter-option>,
+                  names: #("o"),
+                  variable: "FILE",
+                  help: "Override bitcode output filename"));
+
+  block ()
+    parse-command-line(parser, application-arguments(),
+                       description: "assemble LLVM assembly language");
+    let filename = parser.positional-options[0];
+    let module = make(<llvm-module>, name: filename);
+    with-open-file(stream = filename)
+      llvm-asm-parse(module, stream);
+    end;
+    let outfilename = get-option-value(parser, "o");
+    if (outfilename)
+      llvm-save-bitcode-file(module, outfilename);
+    else
+      let locator = as(<file-locator>, filename);
+      let output-locator
+        = make(<file-locator>,
+               directory: locator.locator-directory,
+               base: locator.locator-base,
+               extension: "bc");
+      llvm-save-bitcode-file(module, output-locator)
+    end if;
+    if (get-option-value(parser, "output-builder"))
+      llvm-write-builder(module, *standard-output*);
+    end if;
+
+    exit-application(0);
+  exception (e :: <simple-error>)
+    format(*standard-error*, "%s\n", e);
+    force-output(*standard-output*);
+    exit-application(1);
+  end;
+end method main;
+
+begin
+  main();
+end;

--- a/sources/app/llvm-as/llvm-as.lid
+++ b/sources/app/llvm-as/llvm-as.lid
@@ -1,0 +1,10 @@
+Library:      llvm-as
+Files:        library
+              llvm-as
+              llvm-write-builder
+Start-Function: main
+Target-Type:  executable
+Copyright:    Original Code is Copyright 2009-2018 Gwydion Dylan Maintainers
+              All rights reserved.
+License:      See License.txt in this distribution for details.
+Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND

--- a/sources/app/llvm-as/llvm-write-builder.dylan
+++ b/sources/app/llvm-as/llvm-write-builder.dylan
@@ -1,0 +1,294 @@
+Module: llvm-write-builder
+Copyright:    Original Code is Copyright 2014-2018 Gwydion Dylan Maintainers
+              All rights reserved.
+License:      See License.txt in this distribution for details.
+Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
+
+define function llvm-write-builder
+    (module :: <llvm-module>, stream :: <stream>)
+  => ();
+  let type-names = make(<object-table>);
+  type-names[$llvm-label-type] := "$llvm-label-type";
+  type-names[$llvm-void-type] := "$llvm-void-type";
+  type-names[$llvm-metadata-type] := "$llvm-metadata-type";
+  type-names[$llvm-float-type] := "$llvm-float-type";
+  type-names[$llvm-double-type] := "$llvm-double-type";
+  type-names[$llvm-i1-type] := "$llvm-i1-type";
+  type-names[$llvm-i8-type] := "$llvm-i8-type";
+  type-names[$llvm-i8*-type] := "$llvm-i8*-type";
+  type-names[$llvm-i16-type] := "$llvm-i16-type";
+  type-names[$llvm-i32-type] := "$llvm-i32-type";
+  type-names[$llvm-i64-type] := "$llvm-i64-type";
+
+  let global-value-names = make(<object-table>);
+  global-value-names[$llvm-false] := "$llvm-false";
+  global-value-names[$llvm-true] := "$llvm-true";
+  for (global :: <llvm-global-value> keyed-by name in module.llvm-global-table)
+    global-value-names[global] := name;
+  end for;
+
+  for (func :: <llvm-function> in module.llvm-module-functions)
+    let local-value-names = shallow-copy(global-value-names);
+    for (value :: <llvm-value> keyed-by name in func.llvm-function-value-table)
+      local-value-names[value] := name;
+      if (instance?(value, <llvm-placeholder-value>))
+        local-value-names[value.llvm-value-forward] := name;
+      end if;
+    end for;
+
+    format(stream, "// %s\n", func.llvm-global-name);
+    format(stream, "begin\n");
+
+    let v = 0;
+    for (bb :: <llvm-basic-block> in func.llvm-function-basic-blocks,
+         index from 1)
+      local-value-names[bb] := format-to-string("bb%d", index);
+
+      format(stream, "  let b%d = make(<llvm-basic-block>);\n", index);
+
+
+      for (instruction :: <llvm-instruction>
+             in bb.llvm-basic-block-instructions)
+        let instruction-name
+          = element(local-value-names, instruction, default: #f);
+        unless (instruction-name
+                  | llvm-void-type?(instruction.llvm-value-type))
+          local-value-names[instruction] := format-to-string("v%d", v);
+          v := v + 1;
+        end unless;
+      end for;
+    end for;
+    format(stream, "\n");
+
+    for (bb :: <llvm-basic-block> in func.llvm-function-basic-blocks)
+      format(stream, "  ins--block(be, %s);\n", local-value-names[bb]);
+
+      for (instruction :: <llvm-instruction>
+             in bb.llvm-basic-block-instructions)
+        let instruction-name
+          = element(local-value-names, instruction, default: #f);
+        if (instruction-name)
+          format(stream, "  let %s = ", instruction-name)
+        else
+          format(stream, "  ");
+        end if;
+        print-builder-instruction(instruction,
+                                  local-value-names, type-names,
+                                  stream);
+        format(stream, ";\n");
+      end for;
+
+      format(stream, "\n");
+    end for;
+    format(stream, "end;\n\n");
+  end for;
+end function;
+
+define method print-builder-instruction
+    (instruction :: <llvm-binop-instruction>, value-names, type-names,
+     stream)
+  => ();
+  format(stream, "ins--%s(be", instruction.llvm-binop-instruction-operator);
+  print-builder-operands(instruction.llvm-instruction-operands,
+                         value-names, type-names, stream);
+  format(stream, ")");
+end method;
+
+define method print-builder-instruction
+    (instruction :: <llvm-cast-instruction>, value-names, type-names,
+     stream)
+  => ();
+  format(stream, "ins--%s(be",
+         instruction.llvm-cast-instruction-operator);
+  print-builder-operands(instruction.llvm-instruction-operands,
+                         value-names, type-names, stream);
+  format(stream, ", ");
+  print-builder-type(instruction.llvm-value-type, type-names, stream);
+  format(stream, ")");
+end method;
+
+define method print-builder-instruction
+    (instruction :: <llvm-icmp-instruction>, value-names, type-names,
+     stream)
+  => ();
+  format(stream, "ins--icmp-%s(be",
+         instruction.llvm-cmp-predicate);
+  print-builder-operands(instruction.llvm-instruction-operands,
+                         value-names, type-names, stream);
+  format(stream, ")");
+end method;
+
+define method print-builder-instruction
+    (instruction :: <llvm-gep-instruction>, value-names, type-names,
+     stream)
+  => ();
+  format(stream, "ins--gep%s(be",
+         if (instruction.llvm-gep-instruction-in-bounds?)
+           "-inbounds"
+         else
+           ""
+         end);
+  print-builder-operands(instruction.llvm-instruction-operands,
+                         value-names, type-names, stream);
+  format(stream, ")");
+end method;
+
+define method print-builder-instruction
+    (instruction :: <llvm-load-instruction>, value-names, type-names,
+     stream)
+  => ();
+  format(stream, "ins--load(be");
+  print-builder-operands(instruction.llvm-instruction-operands,
+                         value-names, type-names, stream);
+  format(stream, ")");
+end method;
+
+define method print-builder-instruction
+    (instruction :: <llvm-store-instruction>, value-names, type-names,
+     stream)
+  => ();
+  format(stream, "ins--store(be");
+  print-builder-operands(instruction.llvm-instruction-operands,
+                         value-names, type-names, stream);
+  format(stream, ")");
+end method;
+
+define method print-builder-instruction
+    (instruction :: <llvm-phi-node>, value-names, type-names,
+     stream)
+  => ();
+  format(stream, "ins--phi*(be");
+  print-builder-operands(instruction.llvm-instruction-operands,
+                         value-names, type-names, stream);
+  format(stream, ")");
+end method;
+
+define method print-builder-instruction
+    (instruction :: <llvm-select-instruction>, value-names, type-names,
+     stream)
+  => ();
+  format(stream, "ins--select(be");
+  print-builder-operands(instruction.llvm-instruction-operands,
+                         value-names, type-names, stream);
+  format(stream, ")");
+end method;
+
+define method print-builder-instruction
+    (instruction :: <llvm-call-instruction>, value-names, type-names,
+     stream)
+  => ();
+  format(stream, "ins--call(be");
+  print-builder-operands(instruction.llvm-instruction-operands,
+                         value-names, type-names, stream);
+  format(stream, ")");
+end method;
+
+define method print-builder-instruction
+    (instruction :: <llvm-branch-instruction>, value-names, type-names,
+     stream)
+  => ();
+  format(stream, "ins--br(be");
+  print-builder-operands(instruction.llvm-instruction-operands,
+                         value-names, type-names, stream);
+  format(stream, ")");
+end method;
+
+define method print-builder-instruction
+    (instruction :: <llvm-return-instruction>, value-names, type-names,
+     stream)
+  => ();
+  format(stream, "ins--return(be");
+  print-builder-operands(instruction.llvm-instruction-operands,
+                         value-names, type-names, stream);
+  format(stream, ")");
+end method;
+
+define method print-builder-instruction
+    (instruction :: <llvm-instruction>, value-names, type-names,
+     stream)
+  => ();
+  format(stream, "ins--?(be");
+  print-builder-operands(instruction.llvm-instruction-operands,
+                         value-names, type-names, stream);
+  format(stream, ") /* %s */", instruction);
+end method;
+
+define function print-builder-operands
+    (operands :: <sequence>, value-names, type-names,
+     stream :: <stream>)
+  for (operand in operands)
+    format(stream, ", ");
+    print-builder-operand(operand, value-names, type-names, stream);
+  end for;
+end function;
+
+define method print-builder-operand
+    (operand :: <llvm-value>, value-names, type-names,
+     stream :: <stream>)
+ => ()
+  let name = element(value-names, operand, default: #f);
+  if (name)
+    print-message(name, stream);
+  else
+    print-message(operand, stream);
+  end if;
+end method;
+
+define method print-builder-operand
+    (operand :: <llvm-placeholder-value>, value-names, type-names,
+     stream :: <stream>)
+ => ()
+  print-builder-operand(operand.llvm-value-forward,
+                        value-names, type-names, stream);
+end method;
+
+define method print-builder-operand
+    (operand :: <llvm-argument>, value-names, type-names,
+     stream :: <stream>)
+ => ()
+  print-message(operand.llvm-argument-name, stream);
+end method;
+
+define method print-builder-operand
+    (operand :: <llvm-integer-constant>, value-names, type-names,
+     stream :: <stream>)
+ => ()
+  let type = operand.llvm-value-type.llvm-type-forward;
+  if (type.llvm-integer-type-width = 32)
+    format(stream, "%d", operand.llvm-integer-constant-integer);
+  else
+    next-method();
+  end;
+end method;
+
+define method print-builder-operand
+    (operand :: <llvm-null-constant>, value-names, type-names,
+     stream :: <stream>)
+ => ()
+  format(stream, "make(<llvm-null-constant>, type: ");
+  print-builder-type(operand.llvm-value-type, type-names, stream);
+  format(stream, ")");
+end method;
+
+define method print-builder-type
+    (type :: <llvm-type>, type-names, stream :: <stream>)
+ => ()
+  let name = element(type-names, type, default: #f);
+  if (name)
+    print-message(name, stream);
+  else
+    print-object(type, stream);
+  end if;
+end method;
+
+define method print-builder-type
+    (type :: <llvm-placeholder-type>, type-names, stream :: <stream>)
+ => ()
+  print-builder-type(type.llvm-type-forward, type-names, stream);
+end method;
+
+define method print-builder-type
+    (type :: <llvm-integer-type>, type-names, stream :: <stream>)
+  => ()
+  format(stream, "$llvm-i%d-type", type.llvm-integer-type-width);
+end method;

--- a/sources/lib/llvm/llvm-library.dylan
+++ b/sources/lib/llvm/llvm-library.dylan
@@ -1,6 +1,6 @@
 Module:       Dylan-User
 Author:       Peter S. Housel
-Copyright:    Original Code is Copyright 2009-2010 Gwydion Dylan Maintainers
+Copyright:    Original Code is Copyright 2009-2018 Gwydion Dylan Maintainers
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
@@ -148,7 +148,7 @@ define module llvm
     $llvm-calling-convention-x86-thiscall,
     $llvm-calling-convention-ptx-kernel,
     $llvm-calling-convention-ptx-device,
-    
+
     <llvm-function>,
     llvm-function-arguments,
     llvm-function-basic-blocks,
@@ -165,14 +165,19 @@ define module llvm
     llvm-basic-block-instructions,
 
     <llvm-instruction>,
+    llvm-instruction-operands,
     <llvm-binop-instruction>,
+    llvm-binop-instruction-operator,
     <llvm-cast-instruction>,
+    llvm-cast-instruction-operator,
     <llvm-gep-instruction>,
+    llvm-gep-instruction-in-bounds?,
     <llvm-select-instruction>,
     <llvm-extractelement-instruction>,
     <llvm-insertelement-instruction>,
     <llvm-shufflevector-instruction>,
     <llvm-cmp-instruction>,
+    llvm-cmp-predicate,
     <llvm-icmp-instruction>,
     <llvm-fcmp-instruction>,
     <llvm-terminator-instruction>,
@@ -197,7 +202,7 @@ define module llvm
     <llvm-va-arg-instruction>,
     <llvm-extract-value-instruction>,
     <llvm-insert-value-instruction>,
-    
+
     <llvm-module>,
     llvm-module-name,
     llvm-module-target-triple,
@@ -319,11 +324,11 @@ define module llvm-builder
     ins--extractelement,
     ins--insertelement,
     ins--shufflevector,
-    
+
     ins--phi,
     ins--phi*,
     ins--landingpad,
-    
+
     ins--call,
     ins--tail-call,
     ins--call-intrinsic,
@@ -346,7 +351,7 @@ define module llvm-builder
 
     ins--insertvalue,
     ins--extractvalue,
-    
+
     ins--ret,
     ins--br,
     ins--switch,

--- a/sources/registry/generic/llvm-as
+++ b/sources/registry/generic/llvm-as
@@ -1,0 +1,1 @@
+abstract://dylan/app/llvm-as/llvm-as.lid


### PR DESCRIPTION
This commit adds a Dylan version of the LLVM assembler tool,
llvm-as. In addition to being useful for testing the Dylan llvm
library's bitcode output, it can also be used to generate (an
approximation of) Dylan builder code which can be adapted for use in
compiler and runtime support code generators.

* sources/registry/generic/llvm-as: New registry entry.

* sources/app/llvm-as/llvm-as.lid: New library interchange file.

* sources/app/llvm-as/library.dylan: New library/module definition source.

* sources/app/llvm-as/llvm-as.dylan: New main program for llvm-as.

* sources/app/llvm-as/llvm-write-builder.dylan: New source (builder
  output).

* sources/lib/llvm/llvm-library.dylan
  (module llvm): Export instruction slot getter functions needed to
   inspect instructions for builder call generation.