### PR TITLE
Building Applications with DUIM: Fix links #94.

### DIFF
--- a/documentation/building-with-duim/source/callbacks.rst
+++ b/documentation/building-with-duim/source/callbacks.rst
@@ -4,7 +4,7 @@ Adding Callbacks to the Application
 
 At this point, the task list manager still does very little. If you try
 running the code (as described in `Starting the
-application <improve.htm#17910>`_), and interacting with any of the
+application <improve.html#17910>`_), and interacting with any of the
 elements in the GUI (clicking on a button, choosing a menu command, and
 so on), then only the "not yet implemented" message is displayed. This
 section shows you how to remedy this situation, by adding callback
@@ -142,7 +142,7 @@ ensure that information about tasks is passed to the ``task-list`` pane
 correctly. Make these changes to the existing definition in the file
 ``frame.dylan``.
 
-In `Gluing the final design together <menus.htm#70705>`_, the
+In `Gluing the final design together <menus.html#70705>`_, the
 definition of ``task-list`` was given as:
 
 .. code-block:: dylan
@@ -938,7 +938,7 @@ specified using known slot values about the gadget supplied to
 ``frame-add-task``, and the frame that contains the gadget. The ``name``
 and ``priority`` values are specified by calling the ``prompt-for-task``
 method defined in `Creating a dialog for adding new
-items <improve.htm#89811>`_. This method displays a dialog into which
+items <improve.html#89811>`_. This method displays a dialog into which
 the user types the text for the new task and chooses the priority, both
 of which values are returned from ``prompt-for-task``.
 
@@ -1254,7 +1254,7 @@ be refreshed for whatever reason. This happens most commonly after
 adding or removing a task from the list, or loading in a new task list
 from a file on disk. The method refresh-task-frame takes an instance of
 <task-frame> as an argument and returns no values. For the Task List 1
-project the definition is: <callbacks.htm#52283>`_. For the Task List 1
+project the definition is: <callbacks.html#52283>`_. For the Task List 1
 project, the ``note-task-selection-change`` method is defined:
 
 .. code-block:: dylan

--- a/documentation/building-with-duim/source/commands.rst
+++ b/documentation/building-with-duim/source/commands.rst
@@ -222,7 +222,7 @@ Changes to button definitions
 
 The definition of each button in the definition of ``<task-frame>`` needs
 to be modified compared to their definition in the Task List 1 project,
-as described in `Gluing the new design together <improve.htm#70170>`_.
+as described in `Gluing the new design together <improve.html#70170>`_.
 
 Broadly speaking, you need to update the ``command:`` keyword/argument
 pair for each button gadget, and you need to redefine the activate
@@ -376,8 +376,8 @@ instance of ``<gadget>``. This change results in these new definitions:
     end method note-task-selection-change;
 
 For details about ``note-task-selection-change``, see `Enabling and
-disabling buttons in the interface <callbacks.htm#42654>`_. See `A
-task list manager using command tables <source.htm#52969>`_ for the
+disabling buttons in the interface <callbacks.html#42654>`_. See `A
+task list manager using command tables <source.html#52969>`_ for the
 complete source code for the Task List 2 project.
 
 

--- a/documentation/building-with-duim/source/improve.rst
+++ b/documentation/building-with-duim/source/improve.rst
@@ -3,7 +3,7 @@ Improving The Design
 ********************
 
 The simple layout hierarchy described in `Creating the basic sheet
-hierarchy <design.htm#23252>`_ has a number of problems associated with
+hierarchy <design.html#23252>`_ has a number of problems associated with
 it, all of which revolve around the fact that the task list manager does
 not yet look very much like a standard Windows application. Although it
 is a simple design that does not warrant a complicated user interface,
@@ -232,7 +232,7 @@ radio box, and the list box from the initial design:
 
 Note that the definition of each element is identical to the definitions
 included in the original layout described in `Creating the basic
-sheet hierarchy <design.htm#23252>`_ (except that activate callbacks
+sheet hierarchy <design.html#23252>`_ (except that activate callbacks
 have been added to the code). Adding ``(frame)`` immediately after the
 name of each pane lets you refer to the frame itself within the frame
 definition using a local variable. This means that you can refer to any
@@ -244,7 +244,7 @@ to layout each pane in the frame itself.
 In addition, you need to define the layout in which to place these
 panes. This is itself just another pane, and its definition is again
 identical to the original layout described in `Creating the basic
-sheet hierarchy <design.htm#23252>`_, with one exception; rather than
+sheet hierarchy <design.html#23252>`_, with one exception; rather than
 defining each element explicitly, you just include a reference to the
 relevant pane that you have already defined using normal slot syntax,
 thus:
@@ -577,7 +577,7 @@ has reduced to a single column layout whose children are ``task-list`` and
 
 The definition for the new design of the frame class now looks as
 follows (button definitions vary slightly for the Task List 2 project,
-see `A task list manager using command tables <source.htm#52969>`_):
+see `A task list manager using command tables <source.html#52969>`_):
 
 .. code-block:: dylan
 
@@ -677,9 +677,9 @@ Add this method to ``frame.dylan``.
 
 .. note: The definition of the ``prompt-for-task`` method uses the
    ``<priority>`` type. Note that this type is defined in `Defining the
-   underlying data structures for tasks <callbacks.htm#71186>`_. Until the
+   underlying data structures for tasks <callbacks.html#71186>`_. Until the
    relevant code in `Defining the underlying data structures for
-   tasks <callbacks.htm#71186>`_ is added to your project, any attempt to
+   tasks <callbacks.html#71186>`_ is added to your project, any attempt to
    build it will generate a serious warning.
 
 .. code-block:: dylan

--- a/documentation/building-with-duim/source/menus.rst
+++ b/documentation/building-with-duim/source/menus.rst
@@ -249,10 +249,10 @@ of a slot: ``frame-task-list``. This takes an instance of the class
 Although it has not been referred to so far, this class will be used
 as the basic data structure in which task lists are stored, and a more
 complete description of these data structures is given in `Defining
-the underlying data structures for tasks <callbacks.htm#71186>`_. It
+the underlying data structures for tasks <callbacks.html#71186>`_. It
 transpires that defining the ``frame-task-list`` slot is essential for
 some of the file handling routines that are described in `Handling
-files in the task list manager <callbacks.htm#78540>`_.
+files in the task list manager <callbacks.html#78540>`_.
 
 .. code-block:: dylan
 

--- a/documentation/building-with-duim/source/tour.rst
+++ b/documentation/building-with-duim/source/tour.rst
@@ -54,7 +54,7 @@ these elements.
 You can use the Dylan Playground to run the examples in this chapter.
 *Reminder:* to interactively run the segments of example code presented
 in this chapter, you must pass them to ``contain`` (see `Using contain
-to run examples interactively <design.htm#73778>`_ for details).
+to run examples interactively <design.html#73778>`_ for details).
 
 A tour of gadgets
 -----------------
@@ -1430,7 +1430,7 @@ both the width and height of a frame.
 Defining new classes of frame
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As described in `Defining a new frame class <improve.htm#66956>`_,
+As described in `Defining a new frame class <improve.html#66956>`_,
 the ``define frame`` macro is used to create new classes of frame. The
 bulk of the definition of any new frame is split into several parts:
 
@@ -1637,7 +1637,7 @@ so you need only specify these titles if you want to supply a
 non-standard title to the dialog.
 
 Further examples of this function can be found in `Handling files in
-the task list manager <callbacks.htm#78540>`_.
+the task list manager <callbacks.html#78540>`_.
 
 The convenience functions ``choose-color`` and ``choose-text-style``
 generate the common dialogs for choosing a color and a font


### PR DESCRIPTION
Fix broken links finished in '.htm' to '.html'.