### PR TITLE
Issue #949. 2015.2: Remove find-value from common-extensions

### DIFF
--- a/sources/common-dylan/common-extensions.dylan
+++ b/sources/common-dylan/common-extensions.dylan
@@ -403,16 +403,6 @@ define method find-element
   end;
 end method find-element;
 
-//---*** This should be removed at some point
-define method find-value
-    (collection :: <collection>, predicate :: <function>,
-     #key skip :: <integer> = 0,
-          failure = #f)
- => (value)
-  find-element(collection, predicate, skip: skip, failure: failure)
-end method find-value;
-
-
 define function fill-table!
     (table :: <table>, keys-and-elements :: <sequence>)
  => (table :: <table>)

--- a/sources/common-dylan/library.dylan
+++ b/sources/common-dylan/library.dylan
@@ -124,7 +124,6 @@ define module common-extensions
          join,
          fill-table!,
          find-element,
-         find-value,
          float-to-string,
          integer-to-string,
          number-to-string,


### PR DESCRIPTION
Remove 'find-value' as not needed.