### PR TITLE
doc: Fix 'redirect permanent' warnings in 'Getting started with CLI' 

### DIFF
--- a/documentation/getting-started-cli/source/cross-compilation.rst
+++ b/documentation/getting-started-cli/source/cross-compilation.rst
@@ -3,5 +3,5 @@ Cross Compilation
 
 For now, see the `porting section`_ of the `Hacker's Guide`_.
 
-.. _porting section: http://opendylan.org/documentation/hacker-guide/topics/porting.html
-.. _Hacker's Guide: http://opendylan.org/documentation/hacker-guide/
+.. _porting section: https://opendylan.org/documentation/hacker-guide/topics/porting.html
+.. _Hacker's Guide: https://opendylan.org/documentation/hacker-guide/

--- a/documentation/getting-started-cli/source/editor-support.rst
+++ b/documentation/getting-started-cli/source/editor-support.rst
@@ -49,7 +49,7 @@ Support for Dylan is available out of the box.
 However, enhanced support is available in
 `dylan-vim`_.
 
-.. _language-dylan: http://atom.io/packages/language-dylan
-.. _DeftIDEA: http://plugins.jetbrains.com/plugin/7325
+.. _language-dylan: https://atom.io/packages/language-dylan
+.. _DeftIDEA: http://plugins.jetbrains.com/plugin/7325-deftidea
 .. _dylan.tmbundle: https://github.com/textmate/dylan.tmbundle
 .. _dylan-vim: https://github.com/dylan-lang/dylan-vim

--- a/documentation/getting-started-cli/source/index.rst
+++ b/documentation/getting-started-cli/source/index.rst
@@ -13,7 +13,7 @@ document describes these command-line tools.
 
 For help getting started with the IDE on Windows, see
 the `Getting Started with the Open Dylan IDE
-<http://opendylan.org/documentation/getting-started-ide/>`_
+<https://opendylan.org/documentation/getting-started-ide/>`_
 guide.
 
 .. toctree::

--- a/documentation/getting-started-cli/source/platform-specific.rst
+++ b/documentation/getting-started-cli/source/platform-specific.rst
@@ -15,7 +15,7 @@ LID File
 
 For further details of the LID file format, see `LID file`_.
 
-.. _LID file: http://opendylan.org/documentation/library-reference/lid.html
+.. _LID file: https://opendylan.org/documentation/library-reference/lid.html
 
 1) Library
 

--- a/documentation/getting-started-cli/source/windows.rst
+++ b/documentation/getting-started-cli/source/windows.rst
@@ -34,7 +34,7 @@ Setting Environment Variables
 
 Environment variables are managed differently on Windows.
 For modifying environment variables permanently, see
-`this guide <http://www.computerhope.com/issues/ch000549.htm>`_.
+`this guide <https://www.computerhope.com/issues/ch000549.htm>`_.
 
 For modifying an environment variable from the command line,
 use this syntax::


### PR DESCRIPTION
Fix 'redirect permanent' warnings in 'Getting started with CLI' when using 'make linkcheck' changing 'http' to 'https'.