### PR TITLE
Add a platforms: keyword to each non-generic .lid file.

### DIFF
--- a/sources/app/create-id/create-id.lid
+++ b/sources/app/create-id/create-id.lid
@@ -6,4 +6,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/app/dll-wrap/dll-wrap.lid
+++ b/sources/app/dll-wrap/dll-wrap.lid
@@ -9,4 +9,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/app/flying-squares/flying-squares.lid
+++ b/sources/app/flying-squares/flying-squares.lid
@@ -14,4 +14,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/app/plonker/plonker.lid
+++ b/sources/app/plonker/plonker.lid
@@ -17,4 +17,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/app/with-splash-screen/with-splash-screen.lid
+++ b/sources/app/with-splash-screen/with-splash-screen.lid
@@ -15,4 +15,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/collections/collections-win32.lid
+++ b/sources/collections/collections-win32.lid
@@ -10,4 +10,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/common-dylan/darwin-common-dylan.lid
+++ b/sources/common-dylan/darwin-common-dylan.lid
@@ -33,4 +33,5 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-darwin
+           x86_64-darwin

--- a/sources/common-dylan/freebsd-common-dylan.lid
+++ b/sources/common-dylan/freebsd-common-dylan.lid
@@ -33,4 +33,5 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-freebsd
+           x86_64-freebsd

--- a/sources/common-dylan/linux-common-dylan.lid
+++ b/sources/common-dylan/linux-common-dylan.lid
@@ -32,4 +32,6 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: arm-linux
+           x86-linux
+           x86_64-linux

--- a/sources/common-dylan/netbsd-common-dylan.lid
+++ b/sources/common-dylan/netbsd-common-dylan.lid
@@ -33,4 +33,5 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-netbsd
+           x86_64-netbsd

--- a/sources/common-dylan/win32-common-dylan.lid
+++ b/sources/common-dylan/win32-common-dylan.lid
@@ -35,4 +35,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/corba/orb/orb/win32-orb.hdp
+++ b/sources/corba/orb/orb/win32-orb.hdp
@@ -22,3 +22,4 @@ subprojects:	../iop-protocol/iop-protocol.hdp
 	../ir/orb-ir.hdp
 	../utilities/orb-utilities.hdp
 executable:	DxORB
+Platforms: x86-win32

--- a/sources/corba/services/naming/client/win32-naming-client.lid
+++ b/sources/corba/services/naming/client/win32-naming-client.lid
@@ -9,4 +9,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/databases/odbc-ffi/unix-odbc.lid
+++ b/sources/databases/odbc-ffi/unix-odbc.lid
@@ -13,4 +13,5 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-darwin
+           x86_64-darwin

--- a/sources/databases/odbc-ffi/win32-odbc.lid
+++ b/sources/databases/odbc-ffi/win32-odbc.lid
@@ -13,4 +13,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/deuce/duim/win32-duim-deuce.lid
+++ b/sources/deuce/duim/win32-duim-deuce.lid
@@ -10,4 +10,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/deuce/standalone/win32-standalone-deuce.lid
+++ b/sources/deuce/standalone/win32-standalone-deuce.lid
@@ -41,4 +41,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/deuce/win32-deuce.lid
+++ b/sources/deuce/win32-deuce.lid
@@ -10,4 +10,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/dfmc/back-end-implementations/back-end-implementations-harp.lid
+++ b/sources/dfmc/back-end-implementations/back-end-implementations-harp.lid
@@ -1,3 +1,7 @@
 library: dfmc-back-end-implementations
 Target-Type: dll
 files: library-harp
+Platforms: x86-freebsd
+           x86-linux
+           x86-netbsd
+           x86-win32

--- a/sources/dfmc/mangling/mangling-win32.lid
+++ b/sources/dfmc/mangling/mangling-win32.lid
@@ -7,4 +7,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/duim/core/win32-duim-core.lid
+++ b/sources/duim/core/win32-duim-core.lid
@@ -10,4 +10,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/duim/dcs/win32-duim-dcs.lid
+++ b/sources/duim/dcs/win32-duim-dcs.lid
@@ -7,4 +7,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/duim/examples/cookbook/win32-duim-examples.lid
+++ b/sources/duim/examples/cookbook/win32-duim-examples.lid
@@ -17,4 +17,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/duim/examples/life/win32-life.lid
+++ b/sources/duim/examples/life/win32-life.lid
@@ -26,3 +26,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 Other-files: README.html
+Platforms: x86-win32

--- a/sources/duim/examples/pente/win32-pente.lid
+++ b/sources/duim/examples/pente/win32-pente.lid
@@ -11,4 +11,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/duim/examples/resources/duim-resource-example.lid
+++ b/sources/duim/examples/resources/duim-resource-example.lid
@@ -12,4 +12,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/duim/examples/reversi/win32-reversi.lid
+++ b/sources/duim/examples/reversi/win32-reversi.lid
@@ -15,4 +15,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/duim/examples/scribble/win32-scribble.lid
+++ b/sources/duim/examples/scribble/win32-scribble.lid
@@ -11,5 +11,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 Other-files: README.html
-
-
+Platforms: x86-win32

--- a/sources/duim/examples/tetris/win32-tetris.lid
+++ b/sources/duim/examples/tetris/win32-tetris.lid
@@ -13,4 +13,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/duim/examples/tic-tac-toe/win32-tic-tac-toe.lid
+++ b/sources/duim/examples/tic-tac-toe/win32-tic-tac-toe.lid
@@ -12,4 +12,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/duim/examples/windows-viewer/windows-hook.hdp
+++ b/sources/duim/examples/windows-viewer/windows-hook.hdp
@@ -11,3 +11,4 @@ Major-Version: 2
 Minor-Version: 1
 Compilation-Mode: tight
 Target-Type: dll
+Platforms: x86-win32

--- a/sources/duim/examples/windows-viewer/windows-viewer.hdp
+++ b/sources/duim/examples/windows-viewer/windows-viewer.hdp
@@ -22,3 +22,4 @@ Major-Version: 2
 Minor-Version: 1
 Compilation-Mode: tight
 Target-Type: executable
+Platforms: x86-win32

--- a/sources/duim/extended-geometry/win32-duim-extended-geometry.lid
+++ b/sources/duim/extended-geometry/win32-duim-extended-geometry.lid
@@ -7,4 +7,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/duim/frames/win32-duim-frames.lid
+++ b/sources/duim/frames/win32-duim-frames.lid
@@ -7,4 +7,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/duim/gadgets/win32-duim-gadgets.lid
+++ b/sources/duim/gadgets/win32-duim-gadgets.lid
@@ -7,4 +7,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/duim/geometry/win32-duim-geometry.lid
+++ b/sources/duim/geometry/win32-duim-geometry.lid
@@ -7,4 +7,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/duim/graphics/win32-duim-graphics.lid
+++ b/sources/duim/graphics/win32-duim-graphics.lid
@@ -7,4 +7,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/duim/gtk/duim.lid
+++ b/sources/duim/gtk/duim.lid
@@ -10,4 +10,12 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: arm-linux
+           x86-darwin
+           x86-freebsd
+           x86-linux
+           x86-netbsd
+           x86_64-darwin
+           x86_64-freebsd
+           x86_64-linux
+           x86_64-netbsd

--- a/sources/duim/layouts/win32-duim-layouts.lid
+++ b/sources/duim/layouts/win32-duim-layouts.lid
@@ -7,4 +7,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/duim/panes/win32-duim-gadget-panes.lid
+++ b/sources/duim/panes/win32-duim-gadget-panes.lid
@@ -23,4 +23,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/duim/recording/win32-duim-recording.lid
+++ b/sources/duim/recording/win32-duim-recording.lid
@@ -7,4 +7,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/duim/sheets/win32-duim-sheets.lid
+++ b/sources/duim/sheets/win32-duim-sheets.lid
@@ -7,4 +7,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/duim/tests/gui/win32-duim-gui-test-suite.lid
+++ b/sources/duim/tests/gui/win32-duim-gui-test-suite.lid
@@ -32,4 +32,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 Other-files: README.html
-
+Platforms: x86-win32

--- a/sources/duim/tests/regression/win32-duim-regression-test-suite.lid
+++ b/sources/duim/tests/regression/win32-duim-regression-test-suite.lid
@@ -16,4 +16,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/duim/tests/win32/win32-duim-gui-test-suite.lid
+++ b/sources/duim/tests/win32/win32-duim-gui-test-suite.lid
@@ -22,4 +22,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/duim/user/win32-duim-user.lid
+++ b/sources/duim/user/win32-duim-user.lid
@@ -6,4 +6,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/duim/utilities/win32-duim-utilities.lid
+++ b/sources/duim/utilities/win32-duim-utilities.lid
@@ -7,4 +7,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/duim/win32/duim.lid
+++ b/sources/duim/win32/duim.lid
@@ -15,4 +15,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/duim/win32/win32-duim.lid
+++ b/sources/duim/win32/win32-duim.lid
@@ -44,4 +44,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/dylan/dylan-win32.lid
+++ b/sources/dylan/dylan-win32.lid
@@ -9,4 +9,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/environment/debugger/tests/checkmate/checkmate-win32.lid
+++ b/sources/environment/debugger/tests/checkmate/checkmate-win32.lid
@@ -9,4 +9,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/environment/editor/editor-manager.lid
+++ b/sources/environment/editor/editor-manager.lid
@@ -11,4 +11,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/environment/server/dde/dde-server.lid
+++ b/sources/environment/server/dde/dde-server.lid
@@ -5,4 +5,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/environment/server/win32/environment-server.lid
+++ b/sources/environment/server/win32/environment-server.lid
@@ -6,4 +6,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/environment/source-control/backends/vss/SourceSafeTypeLib/SourceSafeTypeLib.lid
+++ b/sources/environment/source-control/backends/vss/SourceSafeTypeLib/SourceSafeTypeLib.lid
@@ -14,4 +14,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 Other-Files:  type-library.spec
-
+Platforms: x86-win32

--- a/sources/environment/source-control/backends/vss/vss-backend.lid
+++ b/sources/environment/source-control/backends/vss/vss-backend.lid
@@ -10,4 +10,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/environment/splash-screen/win32-environment-splash-screen.lid
+++ b/sources/environment/splash-screen/win32-environment-splash-screen.lid
@@ -8,4 +8,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/environment/win32/win32-environment.lid
+++ b/sources/environment/win32/win32-environment.lid
@@ -119,4 +119,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/examples/gui/duim-gl-demo/duim-gl-demo.lid
+++ b/sources/examples/gui/duim-gl-demo/duim-gl-demo.lid
@@ -15,4 +15,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/examples/odbc/database-viewer/win32-database-viewer.lid
+++ b/sources/examples/odbc/database-viewer/win32-database-viewer.lid
@@ -14,4 +14,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 Other-files: README.html
-
+Platforms: x86-win32

--- a/sources/examples/windows/windows-ffi-example/windows-ffi-example.lid
+++ b/sources/examples/windows/windows-ffi-example/windows-ffi-example.lid
@@ -11,4 +11,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 Other-files: README.html
-
+Platforms: x86-win32

--- a/sources/examples/windows/windows-gadgets-example/windows-gadgets-example.lid
+++ b/sources/examples/windows/windows-gadgets-example/windows-gadgets-example.lid
@@ -14,4 +14,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/examples/windows/windows-resource-example/windows-resource-example.lid
+++ b/sources/examples/windows/windows-resource-example/windows-resource-example.lid
@@ -12,4 +12,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/io/unix-io.lid
+++ b/sources/io/unix-io.lid
@@ -36,3 +36,12 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
+Platforms: arm-linux
+           x86-darwin
+           x86-freebsd
+           x86-linux
+           x86-netbsd
+           x86_64-darwin
+           x86_64-freebsd
+           x86_64-linux
+           x86_64-netbsd

--- a/sources/io/win32-io.lid
+++ b/sources/io/win32-io.lid
@@ -39,4 +39,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/lib/big-integers/big-integers-win32.lid
+++ b/sources/lib/big-integers/big-integers-win32.lid
@@ -10,4 +10,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/lib/c-ffi/win32-c-ffi.lid
+++ b/sources/lib/c-ffi/win32-c-ffi.lid
@@ -21,4 +21,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/lib/channels/channels-win32.lid
+++ b/sources/lib/channels/channels-win32.lid
@@ -10,4 +10,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/lib/coloring-stream/windows-coloring-stream.lid
+++ b/sources/lib/coloring-stream/windows-coloring-stream.lid
@@ -10,4 +10,4 @@ Copyright:    Original Code is Copyright 2015 Dylan Hackers.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/lib/commands/commands-win32.lid
+++ b/sources/lib/commands/commands-win32.lid
@@ -10,4 +10,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/lib/dood/dood-64.lid
+++ b/sources/lib/dood/dood-64.lid
@@ -25,5 +25,7 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
-// eof
+Platforms: x86_64-darwin
+           x86_64-freebsd
+           x86_64-linux
+           x86_64-netbsd

--- a/sources/lib/dood/dood.lid
+++ b/sources/lib/dood/dood.lid
@@ -27,5 +27,8 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
-// eof
+Platforms: arm-linux
+           x86-darwin
+           x86-freebsd
+           x86-linux
+           x86-netbsd

--- a/sources/lib/dood/win32-dood.lid
+++ b/sources/lib/dood/win32-dood.lid
@@ -10,4 +10,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/lib/generic-arithmetic/generic-arithmetic-win32.lid
+++ b/sources/lib/generic-arithmetic/generic-arithmetic-win32.lid
@@ -10,4 +10,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/lib/jam/unix-jam.lid
+++ b/sources/lib/jam/unix-jam.lid
@@ -20,3 +20,12 @@ Copyright:    Original Code is Copyright 2004 Gwydion Dylan Maintainers
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
+Platforms: arm-linux
+           x86-darwin
+           x86-freebsd
+           x86-linux
+           x86-netbsd
+           x86_64-darwin
+           x86_64-freebsd
+           x86_64-linux
+           x86_64-netbsd

--- a/sources/lib/jam/win32-jam.lid
+++ b/sources/lib/jam/win32-jam.lid
@@ -20,3 +20,4 @@ Copyright:    Original Code is Copyright 2004 Gwydion Dylan Maintainers
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
+Platforms: x86-win32

--- a/sources/lib/midi/win32-midi.lid
+++ b/sources/lib/midi/win32-midi.lid
@@ -15,4 +15,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/lib/motley/motley.lid
+++ b/sources/lib/motley/motley.lid
@@ -12,4 +12,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/lib/ssl/ssl.lid
+++ b/sources/lib/ssl/ssl.lid
@@ -5,3 +5,12 @@ Files:	 library
 	 openssl-wrapper
 C-libraries: -lssl -lcrypto
 C-source-files: support.c
+Platforms: arm-linux
+           x86-darwin
+           x86-freebsd
+           x86-linux
+           x86-netbsd
+           x86_64-darwin
+           x86_64-freebsd
+           x86_64-linux
+           x86_64-netbsd

--- a/sources/lib/stack-walker/stack-walker.lid
+++ b/sources/lib/stack-walker/stack-walker.lid
@@ -2,3 +2,8 @@ library: stack-walker
 c-source-files: getebp.c
 files: library
        stack-walker
+Platforms: arm-linux
+           x86-freebsd
+           x86-linux
+           x86-netbsd
+           x86_64-linux

--- a/sources/lib/variable-search/darwin-variable-search.lid
+++ b/sources/lib/variable-search/darwin-variable-search.lid
@@ -8,4 +8,5 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-darwin
+           x86_64-darwin

--- a/sources/lib/variable-search/win32-variable-search.lid
+++ b/sources/lib/variable-search/win32-variable-search.lid
@@ -11,4 +11,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/lib/walker/walker-win32.lid
+++ b/sources/lib/walker/walker-win32.lid
@@ -7,4 +7,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/network/win32-network.lid
+++ b/sources/network/win32-network.lid
@@ -31,4 +31,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/network/x64-darwin-network.lid
+++ b/sources/network/x64-darwin-network.lid
@@ -27,4 +27,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86_64-darwin

--- a/sources/network/x86-bsd-network.lid
+++ b/sources/network/x86-bsd-network.lid
@@ -27,4 +27,8 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-darwin
+           x86-freebsd
+           x86-netbsd
+           x86_64-freebsd
+           x86_64-netbsd

--- a/sources/network/x86-linux-network.lid
+++ b/sources/network/x86-linux-network.lid
@@ -27,4 +27,6 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: arm-linux
+           x86-linux
+           x86_64-linux

--- a/sources/ole/com/com.lid
+++ b/sources/ole/com/com.lid
@@ -27,4 +27,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/ole/duim-ole-container/duim-ole-container.lid
+++ b/sources/ole/duim-ole-container/duim-ole-container.lid
@@ -19,4 +19,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/ole/duim-ole-control/duim-ole-control.lid
+++ b/sources/ole/duim-ole-control/duim-ole-control.lid
@@ -17,4 +17,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/ole/duim-ole-server/duim-ole-server.lid
+++ b/sources/ole/duim-ole-server/duim-ole-server.lid
@@ -17,4 +17,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/ole/examples/ocx-scribble/ocx-scribble.lid
+++ b/sources/ole/examples/ocx-scribble/ocx-scribble.lid
@@ -11,4 +11,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 Other-files: README.html
-
+Platforms: x86-win32

--- a/sources/ole/examples/ole-scribble/ole-scribble.lid
+++ b/sources/ole/examples/ole-scribble/ole-scribble.lid
@@ -13,4 +13,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 Other-files: README.html
-
+Platforms: x86-win32

--- a/sources/ole/examples/sample-automation-controller/sample-automation-controller.lid
+++ b/sources/ole/examples/sample-automation-controller/sample-automation-controller.lid
@@ -12,4 +12,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 Other-files: README.html
-
+Platforms: x86-win32

--- a/sources/ole/examples/sample-automation-server/sample-automation-server.lid
+++ b/sources/ole/examples/sample-automation-server/sample-automation-server.lid
@@ -13,4 +13,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 Other-files: README.html
-
+Platforms: x86-win32

--- a/sources/ole/examples/sample-duim-container/sample-duim-container.lid
+++ b/sources/ole/examples/sample-duim-container/sample-duim-container.lid
@@ -16,4 +16,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 Other-Files: README.html
-
+Platforms: x86-win32

--- a/sources/ole/examples/sample-ole-container/sample-ole-container.lid
+++ b/sources/ole/examples/sample-ole-container/sample-ole-container.lid
@@ -24,4 +24,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 Other-files: README.html
-
+Platforms: x86-win32

--- a/sources/ole/examples/sample-ole-server/sample-ole-server.lid
+++ b/sources/ole/examples/sample-ole-server/sample-ole-server.lid
@@ -32,4 +32,4 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 Other-Files: README.html
              sample.reg
-
+Platforms: x86-win32

--- a/sources/ole/examples/win32-invisible-control/win32-invisible-control.lid
+++ b/sources/ole/examples/win32-invisible-control/win32-invisible-control.lid
@@ -11,4 +11,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 Other-files:     README.html
-
+Platforms: x86-win32

--- a/sources/ole/examples/win32-ole-container/win32-ole-container.lid
+++ b/sources/ole/examples/win32-ole-container/win32-ole-container.lid
@@ -17,4 +17,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 Other-Files: README.html
-
+Platforms: x86-win32

--- a/sources/ole/examples/win32-ole-server/win32-ole-server.lid
+++ b/sources/ole/examples/win32-ole-server/win32-ole-server.lid
@@ -17,4 +17,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 Other-files: README.html
-
+Platforms: x86-win32

--- a/sources/ole/ole-automation/ole-automation.lid
+++ b/sources/ole/ole-automation/ole-automation.lid
@@ -24,4 +24,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/ole/ole-automation/tests/custom-interface-test/custom-interface-test.lid
+++ b/sources/ole/ole-automation/tests/custom-interface-test/custom-interface-test.lid
@@ -13,4 +13,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/ole/ole-automation/tests/inproc-dual/inproc-dual.lid
+++ b/sources/ole/ole-automation/tests/inproc-dual/inproc-dual.lid
@@ -13,4 +13,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 Other-files: README.txt
-
+Platforms: x86-win32

--- a/sources/ole/ole-automation/tests/ole-coclass-test/ole-coclass-test.lid
+++ b/sources/ole/ole-automation/tests/ole-coclass-test/ole-coclass-test.lid
@@ -9,4 +9,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/ole/ole-automation/tests/ole-macro-test/ole-macro-test.lid
+++ b/sources/ole/ole-automation/tests/ole-macro-test/ole-macro-test.lid
@@ -9,4 +9,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/ole/ole-automation/tests/ole-test/ole-test.lid
+++ b/sources/ole/ole-automation/tests/ole-test/ole-test.lid
@@ -13,4 +13,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/ole/ole-container/ole-container.lid
+++ b/sources/ole/ole-container/ole-container.lid
@@ -24,4 +24,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/ole/ole-control-framework/ole-control-framework.lid
+++ b/sources/ole/ole-control-framework/ole-control-framework.lid
@@ -18,4 +18,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/ole/ole-controls/ole-controls.lid
+++ b/sources/ole/ole-controls/ole-controls.lid
@@ -21,4 +21,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/ole/ole-dialogs/ole-dialogs.lid
+++ b/sources/ole/ole-dialogs/ole-dialogs.lid
@@ -15,4 +15,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/ole/ole-server/ole-server.lid
+++ b/sources/ole/ole-server/ole-server.lid
@@ -28,4 +28,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/ole/ole/ole.lid
+++ b/sources/ole/ole/ole.lid
@@ -20,4 +20,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/ole/win32-automation/win32-automation.lid
+++ b/sources/ole/win32-automation/win32-automation.lid
@@ -22,4 +22,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/runtime-manager/local-access-path/win32-local-access-path.lid
+++ b/sources/runtime-manager/local-access-path/win32-local-access-path.lid
@@ -7,3 +7,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
+Platforms: x86-win32

--- a/sources/system/arm-linux-system.lid
+++ b/sources/system/arm-linux-system.lid
@@ -34,4 +34,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: arm-linux

--- a/sources/system/x86-darwin-system.lid
+++ b/sources/system/x86-darwin-system.lid
@@ -35,4 +35,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-darwin

--- a/sources/system/x86-freebsd-system.lid
+++ b/sources/system/x86-freebsd-system.lid
@@ -34,4 +34,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-freebsd

--- a/sources/system/x86-linux-system.lid
+++ b/sources/system/x86-linux-system.lid
@@ -35,4 +35,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-linux

--- a/sources/system/x86-netbsd-system.lid
+++ b/sources/system/x86-netbsd-system.lid
@@ -34,4 +34,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-netbsd

--- a/sources/system/x86-win32-system.lid
+++ b/sources/system/x86-win32-system.lid
@@ -37,4 +37,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/system/x86_64-darwin-system.lid
+++ b/sources/system/x86_64-darwin-system.lid
@@ -35,4 +35,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86_64-darwin

--- a/sources/system/x86_64-freebsd-system.lid
+++ b/sources/system/x86_64-freebsd-system.lid
@@ -34,4 +34,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86_64-freebsd

--- a/sources/system/x86_64-linux-system.lid
+++ b/sources/system/x86_64-linux-system.lid
@@ -35,4 +35,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86_64-linux

--- a/sources/system/x86_64-netbsd-system.lid
+++ b/sources/system/x86_64-netbsd-system.lid
@@ -34,4 +34,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86_64-netbsd

--- a/sources/testing/apps/pentium-test-suite/pentium-test-suite-app.lid
+++ b/sources/testing/apps/pentium-test-suite/pentium-test-suite-app.lid
@@ -7,4 +7,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/testing/apps/win32-test-suite/win32-test-suite-app.lid
+++ b/sources/testing/apps/win32-test-suite/win32-test-suite-app.lid
@@ -7,4 +7,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/testing/pentium-test-suite/pentium-test-suite.lid
+++ b/sources/testing/pentium-test-suite/pentium-test-suite.lid
@@ -7,4 +7,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/testing/win32-test-suite/win32-test-suite.lid
+++ b/sources/testing/win32-test-suite/win32-test-suite.lid
@@ -7,4 +7,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/win32/tests/win32-util-test/win32-util-test.lid
+++ b/sources/win32/tests/win32-util-test/win32-util-test.lid
@@ -9,4 +9,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/win32/win32-common/win32-common.lid
+++ b/sources/win32/win32-common/win32-common.lid
@@ -18,4 +18,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/win32/win32-controls/win32-controls.lid
+++ b/sources/win32/win32-controls/win32-controls.lid
@@ -17,4 +17,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/win32/win32-dde/win32-dde.lid
+++ b/sources/win32/win32-dde/win32-dde.lid
@@ -17,4 +17,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/win32/win32-dialog/win32-dialog.lid
+++ b/sources/win32/win32-dialog/win32-dialog.lid
@@ -18,4 +18,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/win32/win32-gdi/win32-gdi.lid
+++ b/sources/win32/win32-gdi/win32-gdi.lid
@@ -17,4 +17,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/win32/win32-gl/win32-gl.lid
+++ b/sources/win32/win32-gl/win32-gl.lid
@@ -17,4 +17,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/win32/win32-glu/win32-glu.lid
+++ b/sources/win32/win32-glu/win32-glu.lid
@@ -16,4 +16,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/win32/win32-html-help/win32-html-help.lid
+++ b/sources/win32/win32-html-help/win32-html-help.lid
@@ -13,4 +13,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/win32/win32-kernel/win32-kernel.lid
+++ b/sources/win32/win32-kernel/win32-kernel.lid
@@ -20,4 +20,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/win32/win32-multimedia/win32-multimedia.lid
+++ b/sources/win32/win32-multimedia/win32-multimedia.lid
@@ -15,4 +15,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/win32/win32-registry/win32-registry.lid
+++ b/sources/win32/win32-registry/win32-registry.lid
@@ -17,4 +17,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/win32/win32-resources/win32-resources.lid
+++ b/sources/win32/win32-resources/win32-resources.lid
@@ -23,4 +23,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/win32/win32-rich-edit/win32-rich-edit.lid
+++ b/sources/win32/win32-rich-edit/win32-rich-edit.lid
@@ -13,4 +13,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/win32/win32-shell/win32-shell.lid
+++ b/sources/win32/win32-shell/win32-shell.lid
@@ -16,4 +16,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/win32/win32-user/win32-user.lid
+++ b/sources/win32/win32-user/win32-user.lid
@@ -18,4 +18,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32

--- a/sources/win32/win32-version/win32-version.lid
+++ b/sources/win32/win32-version/win32-version.lid
@@ -14,4 +14,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: x86-win32


### PR DESCRIPTION
Generated from the contents of sources/registry. This makes it
possible for the `dylan-tool` library to correctly generate registry
entries only for .lid files that work on the current platform.

This isn't ideal, in that it redundantly stores platform information
and we will need to remember to add this keyword to new, non-generic
.lid files as they're created. Any other solution I can think of
requires a change in the LID spec, which is a bigger job than I want
to take on right now.