### PR TITLE
LLVM library initialization changes

### DIFF
--- a/documentation/hacker-guide/source/runtime/startup.rst
+++ b/documentation/hacker-guide/source/runtime/startup.rst
@@ -54,11 +54,14 @@ in ``sources/dfmc/llvm-linker/llvm-gluefile.dylan``, does the following:
 #. Sets the initialization flag
 #. Calls the library startup glue functions of all libraries
    referenced by this one.
-#. Calls the for-user init functions for each compile-unit in the
+#. Calls the library's self-init function, named
+   ``_Init_``\ *mangled-library-name*\ ``_X``, which in turn calls each
+   of the for-user init functions for each compile-unit in the
    library. These contain the code generated for all of the top-level
    forms.
-#. Calls the ``%install-boot-symbols`` function defined in
-   ``sources/dylan/symbol-table.dylan``. (Dylan library only.)
+#. For the Dylan library only, the self-init function also calls the
+   ``%install-boot-symbols`` function defined in
+   ``sources/dylan/symbol-table.dylan``. ()
 
 For executables, execution begins at the usual ``main`` entry
 point. The ``main`` function, generated in ``_main.bc`` by

--- a/documentation/hacker-guide/source/runtime/startup.rst
+++ b/documentation/hacker-guide/source/runtime/startup.rst
@@ -53,7 +53,7 @@ in ``sources/dfmc/llvm-linker/llvm-gluefile.dylan``, does the following:
    done, and exits if it has
 #. Sets the initialization flag
 #. Calls the library startup glue functions of all libraries
-   referenced by this one.
+   (except for the Dylan library) referenced by this one.
 #. Calls the library's self-init function, named
    ``_Init_``\ *mangled-library-name*\ ``_X``, which in turn calls each
    of the for-user init functions for each compile-unit in the
@@ -62,6 +62,11 @@ in ``sources/dfmc/llvm-linker/llvm-gluefile.dylan``, does the following:
 #. For the Dylan library only, the self-init function also calls the
    ``%install-boot-symbols`` function defined in
    ``sources/dylan/symbol-table.dylan``. ()
+
+The startup glue function for the Dylan library is called from a
+global constructor at user priority. This ensures that the
+``%install-boot-symbols`` is performed before other libraries' symbol
+resolution begins.
 
 For executables, execution begins at the usual ``main`` entry
 point. The ``main`` function, generated in ``_main.bc`` by

--- a/sources/dfmc/llvm-linker/llvm-gluefile.dylan
+++ b/sources/dfmc/llvm-linker/llvm-gluefile.dylan
@@ -112,9 +112,8 @@ define sideways method emit-gluefile
     llvm-builder-declare-global(back-end,
                                 init-run-time-global.llvm-global-name,
                                 init-run-time-global);
-    emit-ctor-entry(back-end, m,
-                    $system-init-ctor-priority,
-                    init-run-time-global);
+    llvm-builder-add-ctor-entry(back-end, $system-init-ctor-priority,
+                                init-run-time-global);
   end if;
 
   // Add a flag to check whether the library has been initialized or not
@@ -245,6 +244,9 @@ define sideways method emit-gluefile
   cleanup
     back-end.llvm-builder-function := #f;
   end block;
+
+  // Add constructor definitions to the module
+  llvm-builder-finish-ctor(back-end);
 
   // Output LLVM bitcode
   llvm-save-bitcode-file(m, locator);

--- a/sources/dfmc/llvm-linker/llvm-linker.dylan
+++ b/sources/dfmc/llvm-linker/llvm-linker.dylan
@@ -252,7 +252,7 @@ define constant $system-init-code-tag = "for_system";
 define constant $user-init-code-tag = "for_user";
 
 define constant $system-init-ctor-priority = 0;
-//define constant $user-init-ctor-priority = 65535;
+define constant $user-init-ctor-priority = 65535;
 
 define constant $init-code-function-type
   = make(<llvm-function-type>,

--- a/sources/dfmc/llvm-linker/llvm-linker.dylan
+++ b/sources/dfmc/llvm-linker/llvm-linker.dylan
@@ -47,6 +47,9 @@ define sideways method emit-library-record
       
       link-all(back-end, m, cr);
 
+      // Add constructor definitions to the module
+      llvm-builder-finish-ctor(back-end);
+
       // Output LLVM bitcode
       llvm-save-bitcode-file(m, locator);
 
@@ -259,49 +262,6 @@ define constant $init-code-function-type
 define constant $init-code-function-ptr-type
   = make(<llvm-pointer-type>, pointee: $init-code-function-type);
 
-define constant $ctor-struct-type
-  = make(<llvm-struct-type>,
-         elements: vector($llvm-i32-type,
-                          $init-code-function-ptr-type,
-                          $llvm-i8*-type));
-
-define constant $null-data
-  = make(<llvm-null-constant>, type: $llvm-i8*-type);
-
-define method emit-ctor-entry
-    (back-end :: <llvm-back-end>, m :: <llvm-module>,
-     priority :: <integer>, init-function :: <llvm-value>)
- => ();
-  let priority-constant
-    = make(<llvm-integer-constant>,
-           type: $llvm-i32-type, integer: priority);
-
-  let ctor-element
-    = make(<llvm-aggregate-constant>,
-           type: $ctor-struct-type,
-           aggregate-values: vector(priority-constant,
-                                    init-function,
-                                    $null-data));
-
-  // Declare the constructors list
-  let ctor-type
-    = make(<llvm-array-type>,
-	   size: 1,
-	   element-type: $ctor-struct-type);
-  let ctor-global
-    = make(<llvm-global-variable>,
-	   name: "llvm.global_ctors",
-	   type: llvm-pointer-to(back-end, ctor-type),
-	   initializer: make(<llvm-aggregate-constant>,
-			     type: ctor-type,
-			     aggregate-values: vector(ctor-element)),
-           constant?: #f,
-	   linkage: #"appending");
-  llvm-builder-define-global(back-end,
-			     ctor-global.llvm-global-name,
-			     ctor-global);
-end method;
-
 define method emit-init-code-definition
     (back-end :: <llvm-back-end>, m :: <llvm-module>, heap, name :: <string>)
  => ();
@@ -373,7 +333,8 @@ define method emit-init-code-definition
                                               back-end.llvm-builder-function);
 
       // Add the init function to the constructor
-      emit-ctor-entry(back-end, m, $system-init-ctor-priority, global);
+      llvm-builder-add-ctor-entry(back-end, $system-init-ctor-priority,
+                                  global);
     end unless;
   cleanup
     back-end.llvm-builder-function := #f;

--- a/sources/lib/llvm/llvm-library.dylan
+++ b/sources/lib/llvm/llvm-library.dylan
@@ -292,6 +292,9 @@ define module llvm-builder
     llvm-builder-global,
     llvm-builder-global-defined?,
 
+    llvm-builder-add-ctor-entry,
+    llvm-builder-finish-ctor,
+
     <llvm-local-value>,
     ins--local,
     llvm-builder-local,


### PR DESCRIPTION
These changes shuffle the initialization of the Dylan library to ensure that the symbol table is booted before  attempting symbol resolution for other libraries.