### PR TITLE
Implement run-time backtraces and other improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,11 @@ Get MPS or boehm-gc, depending on your platform:
 * macOS and all 64 bit (C back-end) -> `boehm-gc
   <https://github.com/ivmai/bdwgc>`_
 
+The ``libunwind`` library is an optional dependency on Linux and
+FreeBSD. If available, it is used to display stack traces for
+unhandled error conditions. (The ``libunwind`` API is built-in on
+macOS.)
+
 On macOS, you may find it easiest to install Homebrew and install
 the following::
 
@@ -68,7 +73,7 @@ with the ``--universal`` flag.
 On Ubuntu, Debian, etc, you can install the necessary dependencies
 with::
 
-    apt-get install autoconf automake gcc libgc-dev
+    apt-get install autoconf automake gcc libgc-dev libunwind-dev
 
 Building
 --------

--- a/configure.ac
+++ b/configure.ac
@@ -239,6 +239,31 @@ AS_IF([echo "$CFLAGS" | grep -q -- "-W" 2> /dev/null],
 )
 AC_SUBST(DISABLE_WARNINGS_CFLAGS)
 
+AC_CHECK_FUNC(sigaction,
+              AC_CHECK_TYPE(siginfo_t,
+                            AC_DEFINE(HAVE_SIGINFO_T, 1,
+                                      [Define if you have 'siginfo_t']),
+              [],
+              [#include <signal.h>]))
+
+# libm
+AC_SEARCH_LIBS([atan], [m])
+
+# libunwind
+AC_CHECK_HEADERS([libunwind.h])
+
+AC_MSG_CHECKING(for libunwind library)
+AC_LANG_CONFTEST([AC_LANG_PROGRAM([#define UNW_LOCAL_ONLY
+                                   #include <stddef.h>
+                                   #include <libunwind.h>],
+                                  [unw_step(NULL)])])
+AC_LINK_IFELSE([], [AC_MSG_RESULT(none needed)],
+               [save_LIBS="$LIBS"
+                LIBS="$LIBS -lunwind"
+                AC_LINK_IFELSE([], [AC_MSG_RESULT(-lunwind)],
+                               [AC_MSG_RESULT(not found)
+                                LIBS="$save_LIBS"])])
+
 AC_CONFIG_FILES(Makefile
                 sources/jamfiles/Makefile
                 sources/jamfiles/config.jam

--- a/sources/dfmc/llvm-back-end/llvm-entry-points.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-entry-points.dylan
@@ -1786,7 +1786,8 @@ define single-method outer entry-point-descriptor single-method
   // Chain to the method's IEP
   op--call-iep(be, iep, arguments,
                next: data,
-               function: meth)
+               function: meth,
+               tail-call?: #t)
 end entry-point-descriptor;
 
 define constant $null-object-pointer

--- a/sources/dfmc/llvm-linker/llvm-linker.dylan
+++ b/sources/dfmc/llvm-linker/llvm-linker.dylan
@@ -277,7 +277,7 @@ define method emit-init-code-definition
               name: system-init-name,
               type: $init-code-function-ptr-type,
               arguments: #(),
-              linkage: #"internal",
+              linkage: #"external",
               section: llvm-section-name(back-end, #"init-code"),
               calling-convention: $llvm-calling-convention-c);
     ins--block(back-end, make(<llvm-basic-block>, name: "bb.entry"));
@@ -325,17 +325,11 @@ define method emit-init-code-definition
                 vector(undef, undef),
                 calling-convention: $llvm-calling-convention-fast);
     end for;
-    
+
     ins--ret(back-end);
 
-    unless (empty?(fixups-elements) & empty?(heap.heap-root-system-init-code))
-      let global = llvm-builder-define-global(back-end, system-init-name,
-                                              back-end.llvm-builder-function);
-
-      // Add the init function to the constructor
-      llvm-builder-add-ctor-entry(back-end, $system-init-ctor-priority,
-                                  global);
-    end unless;
+    llvm-builder-define-global(back-end, system-init-name,
+                               back-end.llvm-builder-function);
   cleanup
     back-end.llvm-builder-function := #f;
   end block;

--- a/sources/jamfiles/config.jam.in
+++ b/sources/jamfiles/config.jam.in
@@ -8,6 +8,8 @@ CCFLAGS           ?= @DISABLE_WARNINGS_CFLAGS@ @CFLAGS@ ;
 C++               ?= @CXX@ ;
 C++FLAGS          ?= $(CCFLAGS) ;
 
+LIBS              ?= @LIBS@ ;
+
 MPS_CFLAGS        ?= @MPS_CFLAGS@ -DGC_USE_MPS ;
 MPS_LIBS          ?= @MPS_LIBS@ ;
 BDW_GC_CFLAGS     ?= @BDW_GC_CFLAGS@ -DGC_THREADS -DGC_USE_BOEHM ;

--- a/sources/jamfiles/posix-build.jam
+++ b/sources/jamfiles/posix-build.jam
@@ -91,7 +91,7 @@ LINKFLAGS += -L$(SYSTEM_LIBDIR)/runtime/$(RUNTIMEDIR)/ ;
 
 # These are passed to the link rules by way of the dylan.lid file
 rtlibs  ?= $(RTOBJS_$(COMPILER_BACK_END)) ;
-rtclibs ?= $(RTCLIBS_$(COMPILER_BACK_END)) -lm ;
+rtclibs ?= $(RTCLIBS_$(COMPILER_BACK_END)) $(LIBS) ;
 
 guilflags ?= ;
 

--- a/sources/lib/run-time/Makefile.in
+++ b/sources/lib/run-time/Makefile.in
@@ -100,7 +100,7 @@ endif
 CC = @CC@
 AR = ar -rcs
 
-CFLAGS		= $(PLATFORM_CFLAGS) -Wall -O -g -I$(srcdir)
+CFLAGS		= $(PLATFORM_CFLAGS) -Wall -O -g -I$(srcdir) @DEFS@
 LFLAGS		= $(PLATFORM_LFLAGS)
 
 HARP_CFLAGS     = -DOPEN_DYLAN_BACKEND_HARP
@@ -119,6 +119,7 @@ HARP_RUNTIME_OBJS = \
 		  $(OBJDIR_HARP)/collector.o \
 		  $(OBJDIR_HARP)/debug-print.o \
 		  $(OBJDIR_HARP)/stack-walker.o \
+		  $(OBJDIR_HARP)/demangle.o \
 		  $(OBJDIR_HARP)/thread-utils.o \
 		  $(OBJDIR_HARP)/trace.o \
 		  $(OBJDIR_HARP)/unix-harp-support.o \
@@ -145,6 +146,7 @@ LLVM_RUNTIME_OBJS = \
 		  $(OBJDIR_LLVM)/break.o \
 		  $(OBJDIR_LLVM)/collector.o \
 		  $(OBJDIR_LLVM)/stack-walker.o \
+		  $(OBJDIR_LLVM)/demangle.o \
 		  $(OBJDIR_LLVM)/thread-utils.o \
 		  $(OBJDIR_LLVM)/unix-spy-interfaces.o \
 		  $(OBJDIR_LLVM)/llvm-runtime-init.o \
@@ -178,6 +180,7 @@ C_RUNTIME_OBJS	= $(OBJDIR_C)/break.o \
 		  $(OBJDIR_C)/collector.o \
 		  $(OBJDIR_C)/debug-print.o \
 		  $(OBJDIR_C)/stack-walker.o \
+		  $(OBJDIR_C)/demangle.o \
 		  $(OBJDIR_C)/thread-utils.o \
 		  $(OBJDIR_C)/trace.o \
 		  $(OBJDIR_C)/unix-spy-interfaces.o \

--- a/sources/lib/run-time/Makefile.in
+++ b/sources/lib/run-time/Makefile.in
@@ -108,7 +108,7 @@ HARP_CFLAGS     = -DOPEN_DYLAN_BACKEND_HARP
 LLVM_CFLAGS     = -DOPEN_DYLAN_BACKEND_LLVM \
 	          -DOPEN_DYLAN_RUNTIME_HEADER=\"llvm-$(OPEN_DYLAN_TARGET_PLATFORM)-runtime.h\" \
 		  -I. \
-		  -fexceptions
+		  -fexceptions -Og -g
 LLVM_LFLAGS     = -fexceptions
 
 C_CFLAGS        = -DOPEN_DYLAN_BACKEND_C

--- a/sources/lib/run-time/demangle.c
+++ b/sources/lib/run-time/demangle.c
@@ -1,0 +1,136 @@
+#include "demangle.h"
+
+#include <limits.h>
+#include <stdbool.h>
+
+#define CONSTANT_PREFIX         'K'
+#define DYLAN_MODULE_SEP        'K'
+#define MODULE_SEP              'Y'
+#define LIBRARY_SEP             'V'
+#define ESCAPE_SEP              'Z'
+#define METHOD_MARK             'M'
+#define IEP_MARK                'I'
+
+#define ARRAY_LEN(x)            (sizeof(x)/sizeof((x)[0]))
+
+// This is adequate for IEPs, but could be improved for other things
+// See documentation/hacker-guide/source/runtime/mangling.rst
+int dylan_demangle(char *dest, size_t destsize, char *src)
+{
+  if (destsize == 0) {
+    return -1;
+  }
+  char *limit = dest + destsize - 1;
+
+  static const char * const dylan_abbrev_map[] = {
+    ['d'] = "dylan",
+    ['i'] = "internal",
+    ['p'] = "dylan-primitives",
+    ['e'] = "dylan-extensions",
+    ['c'] = "dylan-c-ffi",
+    ['n'] = "dylan-incremental",
+    ['t'] = "dylan-threads",
+    ['g'] = "dispatch-engine",
+    ['m'] = "machine-word-lowlevel",
+  };
+  static char demangle_map[1 << CHAR_BIT];
+  if (demangle_map['_'] == '\0') {
+    char *mapping = "-_!X$D%P*T/S<L>G?Q+A&B^C_U@O=E~N";
+    while (*mapping) {
+      demangle_map[(unsigned) mapping[1]] = mapping[0];
+      mapping += 2;
+    }
+    for (int c = 'a'; c <= 'z'; ++c) {
+      demangle_map[c] = c;
+    }
+    for (int c = '0'; c <= '9'; ++c) {
+      demangle_map[c] = c;
+    }
+  }
+
+  if (*src == CONSTANT_PREFIX) {
+    ++src;
+  }
+
+  bool module_seen = false;
+  const char *library = NULL;
+  while (*src && dest < limit) {
+    char c = *src++;
+    if (demangle_map[(unsigned) c] != '\0') {
+      *dest++ = demangle_map[(unsigned) c];
+    }
+    else {
+      switch (c) {
+      case ESCAPE_SEP:
+        {
+          unsigned value = 0;
+          while ('0' <= *src && *src <= '9') {
+            value = value * 10 + (*src++ - '0');
+          }
+          if (*src == ESCAPE_SEP) {
+            ++src;
+            *dest++ = value;
+          }
+          else {
+            return -1;
+          }
+        }
+        break;
+
+      case DYLAN_MODULE_SEP:
+        {
+          char abbrev = *src++;
+          if (0 <= abbrev && abbrev < ARRAY_LEN(dylan_abbrev_map)) {
+            const char *module = dylan_abbrev_map[(unsigned) abbrev];
+            if (module != NULL) {
+              while (*module && dest < limit) {
+                *dest++ = *module++;
+              }
+              const char *library = ":dylan";
+              while (*library && dest < limit) {
+                *dest++ = *library++;
+              }
+            }
+          }
+          else {
+            return -1;
+          }
+          module_seen = true;
+        }
+        break;
+
+      case MODULE_SEP:
+        module_seen = true;
+        *dest++ = ':';
+        break;
+
+      case LIBRARY_SEP:
+        library = dest;
+        *dest++ = ':';
+        break;
+
+      case METHOD_MARK:
+      case IEP_MARK:
+        if (!module_seen && library != NULL) {
+          // No module seen implies the module name is the same as the
+          // library name
+          char *library_end = dest;
+          while (library < library_end && dest < limit) {
+            *dest++ = *library++;
+          }
+          module_seen = true;
+        }
+        if (c == METHOD_MARK) {
+          *dest++ = '#';
+        }
+        break;
+
+      default:
+        return -1;
+      }
+    }
+  }
+
+  *dest++ = '\0';
+  return 0;
+}

--- a/sources/lib/run-time/demangle.h
+++ b/sources/lib/run-time/demangle.h
@@ -1,0 +1,9 @@
+#ifndef DEMANGLE_H_
+#define DEMANGLE_H_
+
+#include <stddef.h>
+
+extern int dylan_demangle(char *dest, size_t destsize, char *src);
+
+#endif // DEMANGLE_H_
+

--- a/sources/lib/run-time/stack-walker.c
+++ b/sources/lib/run-time/stack-walker.c
@@ -1,71 +1,299 @@
-#include <dlfcn.h>
 #include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
 
-void print_frame(void *ip)
+#define ARRAY_LEN(x)            (sizeof(x)/sizeof((x)[0]))
+
+#ifdef HAVE_LIBUNWIND_H
+#define UNW_LOCAL_ONLY
+#include <libunwind.h>
+
+#include "demangle.h"
+
+// The dispatch engine is not interesting
+static int interesting_iep(const char *demangled)
 {
-#ifdef OPEN_DYLAN_PLATFORM_UNIX
-  Dl_info info;
-  int rc;
+  const char suffix[] = ":dispatch-engine:dylan";
+  size_t suffix_len = strlen(suffix);
+  size_t demangled_len = strlen(demangled);
+  return
+    demangled_len < suffix_len
+      || strcmp(demangled + demangled_len - suffix_len, suffix) != 0;
+}
 
-  rc = dladdr(ip, &info);
-  if (!rc||(!info.dli_sname && !info.dli_fname)) {
-    printf("0x%lx (unknown)\n", (long)ip);
-  } else {
-    if (!info.dli_sname) {
-      printf("0x%lx (%s)\n", (long)ip, info.dli_fname);
-    } else {
-      printf("%s+%ld (%s)\n",
-             info.dli_sname,
-             (long)ip - (long)info.dli_saddr,
-             info.dli_fname);
+// Keep sorted!
+const char * const uninteresting[] = {
+  "apply_mep_1",
+  "apply_mep_10",
+  "apply_mep_11",
+  "apply_mep_12",
+  "apply_mep_13",
+  "apply_mep_14",
+  "apply_mep_15",
+  "apply_mep_16",
+  "apply_mep_17",
+  "apply_mep_18",
+  "apply_mep_19",
+  "apply_mep_2",
+  "apply_mep_20",
+  "apply_mep_3",
+  "apply_mep_4",
+  "apply_mep_5",
+  "apply_mep_6",
+  "apply_mep_7",
+  "apply_mep_8",
+  "apply_mep_9",
+  "apply_xep_1",
+  "apply_xep_10",
+  "apply_xep_11",
+  "apply_xep_12",
+  "apply_xep_13",
+  "apply_xep_14",
+  "apply_xep_15",
+  "apply_xep_16",
+  "apply_xep_17",
+  "apply_xep_18",
+  "apply_xep_19",
+  "apply_xep_2",
+  "apply_xep_20",
+  "apply_xep_3",
+  "apply_xep_4",
+  "apply_xep_5",
+  "apply_xep_6",
+  "apply_xep_7",
+  "apply_xep_8",
+  "apply_xep_9",
+  "general_engine_node_n",
+  "general_engine_node_n_engine",
+  "general_engine_node_n_optionals",
+  "general_engine_node_spread",
+  "general_engine_node_spread_engine",
+  "gf_optional_xep_0",
+  "gf_optional_xep_1",
+  "gf_optional_xep_10",
+  "gf_optional_xep_11",
+  "gf_optional_xep_12",
+  "gf_optional_xep_13",
+  "gf_optional_xep_14",
+  "gf_optional_xep_15",
+  "gf_optional_xep_16",
+  "gf_optional_xep_17",
+  "gf_optional_xep_18",
+  "gf_optional_xep_19",
+  "gf_optional_xep_2",
+  "gf_optional_xep_20",
+  "gf_optional_xep_3",
+  "gf_optional_xep_4",
+  "gf_optional_xep_5",
+  "gf_optional_xep_6",
+  "gf_optional_xep_7",
+  "gf_optional_xep_8",
+  "gf_optional_xep_9",
+  "gf_xep_0",
+  "gf_xep_1",
+  "gf_xep_10",
+  "gf_xep_11",
+  "gf_xep_12",
+  "gf_xep_13",
+  "gf_xep_14",
+  "gf_xep_15",
+  "gf_xep_16",
+  "gf_xep_17",
+  "gf_xep_18",
+  "gf_xep_19",
+  "gf_xep_2",
+  "gf_xep_20",
+  "gf_xep_3",
+  "gf_xep_4",
+  "gf_xep_5",
+  "gf_xep_6",
+  "gf_xep_7",
+  "gf_xep_8",
+  "gf_xep_9",
+  "iep_apply",
+  "implicit_keyed_single_method_1",
+  "implicit_keyed_single_method_10",
+  "implicit_keyed_single_method_11",
+  "implicit_keyed_single_method_12",
+  "implicit_keyed_single_method_13",
+  "implicit_keyed_single_method_14",
+  "implicit_keyed_single_method_15",
+  "implicit_keyed_single_method_16",
+  "implicit_keyed_single_method_17",
+  "implicit_keyed_single_method_18",
+  "implicit_keyed_single_method_19",
+  "implicit_keyed_single_method_2",
+  "implicit_keyed_single_method_20",
+  "implicit_keyed_single_method_3",
+  "implicit_keyed_single_method_4",
+  "implicit_keyed_single_method_5",
+  "implicit_keyed_single_method_6",
+  "implicit_keyed_single_method_7",
+  "implicit_keyed_single_method_8",
+  "implicit_keyed_single_method_9",
+  "key_mep_0",
+  "key_mep_1",
+  "key_mep_2",
+  "key_mep_3",
+  "key_mep_4",
+  "key_mep_5",
+  "key_mep_6",
+  "key_mep_7",
+  "key_mep_8",
+  "key_mep_9",
+  "primitive_apply_spread",
+  "primitive_engine_node_apply_with_optionals",
+  "primitive_invoke_debugger",
+  "primitive_mep_apply_with_optionals",
+  "primitive_xep_apply",
+  "rest_key_mep_1",
+  "rest_key_mep_10",
+  "rest_key_mep_11",
+  "rest_key_mep_12",
+  "rest_key_mep_13",
+  "rest_key_mep_14",
+  "rest_key_mep_15",
+  "rest_key_mep_16",
+  "rest_key_mep_17",
+  "rest_key_mep_18",
+  "rest_key_mep_19",
+  "rest_key_mep_2",
+  "rest_key_mep_20",
+  "rest_key_mep_3",
+  "rest_key_mep_4",
+  "rest_key_mep_5",
+  "rest_key_mep_6",
+  "rest_key_mep_7",
+  "rest_key_mep_8",
+  "rest_key_mep_9",
+  "rest_key_mep_n",
+  "rest_key_xep",
+  "rest_key_xep_0",
+  "rest_key_xep_1",
+  "rest_key_xep_10",
+  "rest_key_xep_11",
+  "rest_key_xep_12",
+  "rest_key_xep_13",
+  "rest_key_xep_14",
+  "rest_key_xep_15",
+  "rest_key_xep_16",
+  "rest_key_xep_17",
+  "rest_key_xep_18",
+  "rest_key_xep_19",
+  "rest_key_xep_2",
+  "rest_key_xep_20",
+  "rest_key_xep_3",
+  "rest_key_xep_4",
+  "rest_key_xep_5",
+  "rest_key_xep_6",
+  "rest_key_xep_7",
+  "rest_key_xep_8",
+  "rest_key_xep_9",
+  "rest_key_xep_n",
+  "rest_xep_0",
+  "rest_xep_1",
+  "rest_xep_10",
+  "rest_xep_11",
+  "rest_xep_12",
+  "rest_xep_13",
+  "rest_xep_14",
+  "rest_xep_15",
+  "rest_xep_16",
+  "rest_xep_17",
+  "rest_xep_18",
+  "rest_xep_19",
+  "rest_xep_2",
+  "rest_xep_20",
+  "rest_xep_3",
+  "rest_xep_4",
+  "rest_xep_5",
+  "rest_xep_6",
+  "rest_xep_7",
+  "rest_xep_8",
+  "rest_xep_9",
+  "single_method_0",
+  "single_method_1",
+  "single_method_10",
+  "single_method_11",
+  "single_method_12",
+  "single_method_13",
+  "single_method_14",
+  "single_method_15",
+  "single_method_16",
+  "single_method_17",
+  "single_method_18",
+  "single_method_19",
+  "single_method_2",
+  "single_method_20",
+  "single_method_3",
+  "single_method_4",
+  "single_method_5",
+  "single_method_6",
+  "single_method_7",
+  "single_method_8",
+  "single_method_9",
+};
+
+int entrycmp(const void *a, const void *b)
+{
+  const char **ap = (const char **) a;
+  const char **bp = (const char **) b;
+  return strcmp(*ap, *bp);
+}
+
+static int interesting_function(const char *name)
+{
+  return bsearch(&name, uninteresting, ARRAY_LEN(uninteresting),
+                 sizeof(uninteresting[0]), entrycmp) == NULL;
+}
+
+void dylan_dump_callstack(void *ctxt)
+{
+  unw_context_t context;
+  if (ctxt == NULL) {
+    // If no explicit context was passed in, start "here"
+    unw_getcontext(&context);
+    ctxt = &context;
+  }
+
+  fprintf(stderr, "Backtrace:\n");
+  unw_cursor_t cursor;
+  int rc = unw_init_local(&cursor, ctxt);
+  do {
+    // Find a symbol for the current frame
+    unw_word_t offset;
+    char buf[256];
+    if (unw_get_proc_name(&cursor, buf, sizeof buf, &offset) == 0) {
+      // Is this an IEP?
+      size_t namelen = strlen(buf);
+      char demangled[256];
+      if (namelen > 0
+          && buf[namelen - 1] == 'I'
+          && dylan_demangle(demangled, sizeof demangled, buf) == 0) {
+        if (interesting_iep(demangled)) {
+          fprintf(stderr, "  %s + %#jx\n", demangled, (uintmax_t) offset);
+        }
+      }
+      else if (interesting_function(buf)) {
+        fprintf(stderr, "  %s + %#jx\n", buf, (uintmax_t) offset);
+      }
     }
-  }
-#endif
+    else {
+      // Read the raw instruction pointer address
+      unw_word_t ip;
+      unw_get_reg(&cursor, UNW_REG_IP, &ip);
+
+      fprintf(stderr, "  %#jx\n", (uintmax_t) ip);
+    }
+
+    // On to the next enclosing frame
+    rc = unw_step(&cursor);
+  } while (rc > 0);
 }
 
-// this is our stack walker, used in SIGTRAP
-#if defined(OPEN_DYLAN_PLATFORM_DARWIN)
+#else  // !HAVE_LIBUNWIND_H
 
-#include <unwind.h>
-
-static _Unwind_Reason_Code frame_func(struct _Unwind_Context *context, void *arg)
-{
-  void *ip = (void*)_Unwind_GetIP(context);
-  print_frame(ip);
-  return(_URC_NO_REASON);
-}
-
-void dylan_dump_callstack(void)
-{
-  _Unwind_Backtrace(frame_func, NULL);
-}
-
-#elif defined(OPEN_DYLAN_ARCH_X86) && \
-      (defined(OPEN_DYLAN_PLATFORM_LINUX) || \
-       defined(OPEN_DYLAN_PLATFORM_FREEBSD))
-
-static long getebp (void)
-{
-    long ebp;
-    asm("mov (%%ebp), %0"
-        :"=r"(ebp));
-    return ebp;
-    return 0;
-}
-
-void dylan_dump_callstack(void)
-{
-  long ebp = getebp();
-  while (ebp) {
-    long eip = *((long *)ebp + 1);
-    print_frame((void*)eip);
-    ebp = *((long*)ebp);
-  }
-}
-
-#else
-
-void dylan_dump_callstack(void)
+void dylan_dump_callstack(void *ctxt)
 {
 }
 

--- a/sources/lib/run-time/stack-walker.h
+++ b/sources/lib/run-time/stack-walker.h
@@ -1,0 +1,6 @@
+#ifndef STACK_WALKER_H_
+#define STACK_WALKER_H_
+
+extern void dylan_dump_callstack(void *ctxt);
+
+#endif // STACK_WALKER_H_

--- a/sources/lib/run-time/x86-freebsd-exceptions.c
+++ b/sources/lib/run-time/x86-freebsd-exceptions.c
@@ -10,8 +10,6 @@ extern void dylan_float_invalid_handler();
 extern void dylan_float_overflow_handler();
 extern void dylan_float_underflow_handler();
 
-extern void dylan_dump_callstack(void);
-
 /* FreeBSD exception handling:  Setup a signal handler for SIGFPE (floating point exceptions).
    We rely on the fact that FreeBSD passes a second argument containing the error context. */
 
@@ -21,6 +19,8 @@ extern void dylan_dump_callstack(void);
 #include <ucontext.h>
 #include <ieeefp.h>
 #include <fenv.h>
+
+#include "stack-walker.h"
 
 #define EXCEPTION_PREAMBLE() \
   struct sigaction oldFPEHandler; \
@@ -115,5 +115,6 @@ static void DylanFPEHandler (int sig, siginfo_t *info, void *uap)
 
 static void DylanTRAPHandler (int sig, siginfo_t *info, void *sc)
 {
-  dylan_dump_callstack();
+  dylan_dump_callstack(sc);
+  _exit(127);
 }

--- a/sources/lib/run-time/x86-linux-exceptions.c
+++ b/sources/lib/run-time/x86-linux-exceptions.c
@@ -12,6 +12,8 @@
 #include <ucontext.h>
 #include <fpu_control.h>
 
+#include "stack-walker.h"
+
 extern int inside_dylan_ffi_barrier();
 extern void dylan_stack_overflow_handler(void *base_address, int size, unsigned long protection);
 extern void dylan_integer_overflow_handler();
@@ -20,8 +22,6 @@ extern void dylan_float_divide_0_handler();
 extern void dylan_float_invalid_handler();
 extern void dylan_float_overflow_handler();
 extern void dylan_float_underflow_handler();
-
-extern void dylan_dump_callstack(void);
 
 /* Linux exception handling: Setup signal handlers for SIGFPE
  * (floating point exceptions), SIGSEGV (segmentation violation), and
@@ -251,6 +251,6 @@ static void DylanSEGVHandler (int sig, siginfo_t *info, void *uap)
 
 static void DylanTRAPHandler (int sig, siginfo_t *info, void *sc)
 {
-  dylan_dump_callstack();
+  dylan_dump_callstack(sc);
   chain_sigaction(&outer_TRAPHandler, sig, info, sc);
 }

--- a/sources/lib/variable-search/unix-variable-value.dylan
+++ b/sources/lib/variable-search/unix-variable-value.dylan
@@ -10,6 +10,9 @@ define thread variable *mangler* = make(<mangler>);
 
 define variable *dl-handle* = #f;
 
+// From <dlfcn.h>
+define constant $RTLD-LAZY = 1;
+
 define method variable-value
     (variable-name, module-name, library-name, #key default)
  => (object)
@@ -26,9 +29,10 @@ define method variable-value
     *dl-handle*
        := primitive-wrap-machine-word
             (%call-c-function ("dlopen")
-                  (name :: <raw-byte-string>)
+                  (name :: <raw-byte-string>, mode :: <raw-integer>)
                => (object :: <raw-machine-word>)
-                (primitive-cast-raw-as-pointer(integer-as-raw(0)))
+                (primitive-cast-raw-as-pointer(integer-as-raw(0)),
+                 integer-as-raw($RTLD-LAZY))
               end);
   end unless;
   let val =


### PR DESCRIPTION
These changes implement printing a backtrace when a Dylan program is terminated with an error condition, and make other improvements that improve platform support.