### PR TITLE
A few minor comment improvments

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,3 +1,5 @@
+# Changes made here may also need to be made in admin/builds/build-release.bat.
+
 prefix          = $(DESTDIR)@prefix@
 srcdir          = @abs_srcdir@
 abs_srcdir      = @abs_srcdir@
@@ -84,6 +86,12 @@ endif
 # instead. Note that the stage 1 dylan-compiler loads a mix of existing and
 # stage 1 libraries.
 
+###
+# These are "primitive" in the sense that most of them make use of the
+# primitive-* functions.
+#
+# TODO: the DUIM libraries and some other high-level libs probably don't
+#       belong in this list.
 BOOTSTRAP_1_PRIMITIVE_LIBS = \
 	dylan common-dylan c-ffi collections io system \
 	generic-arithmetic big-integers duim-utilities \
@@ -121,6 +129,9 @@ $(abs_builddir)/Bootstrap.1:
 	mkdir $(abs_builddir)/Bootstrap.1/build
 	mkdir $(abs_builddir)/Bootstrap.1/build/logs
 
+# BOOTSTRAP_1_PRIMITIVE_LIBS registry files are removed so those
+# libraries are taken from the bootstrap compiler's system registries.
+# The main point of stage 1 is to compile any changed compiler sources.
 $(BOOTSTRAP_1_REGISTRY):
 	mkdir $(BOOTSTRAP_1_REGISTRY)
 	cp -r $(srcdir)/sources/registry/generic $(BOOTSTRAP_1_REGISTRY)
@@ -272,6 +283,9 @@ rtg:
 	  llvm-dis $$target-runtime.bc && \
 	  clang -O3 -S $$target-runtime.bc; \
 	done
+
+###
+# 4 stage bootstrap is for LLVM testing.
 
 BOOTSTRAP_4_ENV = \
 	OPEN_DYLAN_TARGET_PLATFORM=$(OPEN_DYLAN_TARGET_PLATFORM) \

--- a/sources/environment/console/README.txt
+++ b/sources/environment/console/README.txt
@@ -24,23 +24,22 @@ The Dylan files in this directory used by each library are:
 
 File___________________________DC DE___DCT ___________________________________
 
-compiler-library               dc
-tools-compiler-library                 dct
-compiler-command-line          dc      dct
-compiler-module                dc      dct
+compiler-library               x
+tools-compiler-library                  x
+compiler-command-line          x        x
+compiler-module                x        x
 
-environment-library               de
-environment-command-line          de       det
-environment-module                de       det
+environment-library               x
+environment-command-line          x
+environment-module                x
 
-command-line                   all
-start                          all
+command-line                   x  x     x
+start                          x  x     x
 ______________________________________________________________________________
 
-All four libraries export a single module called console-environment. This
+All three libraries export a single module called console-environment. This
 module is defined in compiler-module.dylan for the DC and DCT libraries and in
-environment-module.dylan for the DE library. It does not export any
-bindings.
+environment-module.dylan for the DE library. It does not export any bindings.
 
 The command-line options are DEFINED in compiler-command-line.dylan or
 environment-command-line.dylan:

--- a/sources/environment/dfmc/exe-projects.dylan
+++ b/sources/environment/dfmc/exe-projects.dylan
@@ -1,4 +1,6 @@
 Module:    dfmc-environment
+Synopsis:  Project based on an existing executable. This type of
+           project cannot be built but may be run and debugged.
 Author:    Jason Trenouth, Andy Armstrong
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.


### PR DESCRIPTION
If you object to the use of 'x' in environment/console/README.txt I'm fine with changing it back. It just seemed a bit cleaner.