### PR TITLE
common-dylan: Fix hypot on Win32

### DIFF
--- a/sources/common-dylan/darwin-common-dylan.lid
+++ b/sources/common-dylan/darwin-common-dylan.lid
@@ -17,6 +17,7 @@ Files: library
        timers
        profiling
        transcendentals
+       transcendentals-unix
        machine-words/utilities
        machine-words/machine-word
        machine-words/logicals

--- a/sources/common-dylan/freebsd-common-dylan.lid
+++ b/sources/common-dylan/freebsd-common-dylan.lid
@@ -17,6 +17,7 @@ Files: library
        timers
        profiling
        transcendentals
+       transcendentals-unix
        machine-words/utilities
        machine-words/machine-word
        machine-words/logicals

--- a/sources/common-dylan/linux-common-dylan.lid
+++ b/sources/common-dylan/linux-common-dylan.lid
@@ -17,6 +17,7 @@ Files: library
        timers
        profiling
        transcendentals
+       transcendentals-unix
        machine-words/utilities
        machine-words/machine-word
        machine-words/logicals

--- a/sources/common-dylan/netbsd-common-dylan.lid
+++ b/sources/common-dylan/netbsd-common-dylan.lid
@@ -17,6 +17,7 @@ Files: library
        timers
        profiling
        transcendentals
+       transcendentals-unix
        machine-words/utilities
        machine-words/machine-word
        machine-words/logicals

--- a/sources/common-dylan/transcendentals-unix.dylan
+++ b/sources/common-dylan/transcendentals-unix.dylan
@@ -1,0 +1,30 @@
+Module:       common-dylan-internals
+Synopsis:     Transcendentals
+Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
+              All rights reserved.
+License:      See License.txt in this distribution for details.
+Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
+
+define binary-transcendental hypot (x, y);
+
+define sealed may-inline method hypot (x :: <single-float>, y :: <single-float>)
+ => (z :: <single-float>)
+  primitive-raw-as-single-float
+    (%call-c-function("hypotf")
+         (x :: <raw-single-float>, y :: <raw-single-float>)
+      => (z :: <raw-single-float>)
+         (primitive-single-float-as-raw(x),
+          primitive-single-float-as-raw(y))
+     end)
+end method hypot;
+
+define sealed may-inline method hypot (x :: <double-float>, y :: <double-float>)
+ => (z :: <double-float>)
+  primitive-raw-as-double-float
+    (%call-c-function("hypot")
+         (x :: <raw-double-float>, y :: <raw-double-float>)
+      => (z :: <raw-double-float>)
+         (primitive-double-float-as-raw(x),
+          primitive-double-float-as-raw(y))
+     end)
+end method hypot;

--- a/sources/common-dylan/transcendentals-windows.dylan
+++ b/sources/common-dylan/transcendentals-windows.dylan
@@ -1,0 +1,31 @@
+Module:       common-dylan-internals
+Synopsis:     Transcendentals
+Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
+              All rights reserved.
+License:      See License.txt in this distribution for details.
+Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
+
+define binary-transcendental hypot (x, y);
+
+define macro hypot-method-definer
+  { define hypot-method (?type:name, ?one:expression) end }
+    => { define method hypot (y :: ?type, x :: ?type) => (result :: ?type)
+           let x = abs(x);
+           let y = abs(y);
+           let (a, b)
+             = if (y > x)
+                 values(y, x)
+               else
+                 values(x, y)
+               end if;
+           if (zero?(a))
+             b
+           else
+             let t = b / a;
+             a * sqrt(?one + t * t)
+           end if
+         end method }
+end macro;
+
+define hypot-method (<single-float>, 1.0s0) end;
+define hypot-method (<double-float>, 1.0d0) end;

--- a/sources/common-dylan/transcendentals.dylan
+++ b/sources/common-dylan/transcendentals.dylan
@@ -233,27 +233,3 @@ end macro atan2-method-definer;
 
 define atan2-method (<single-float>, $single-pi, 0.0s0) end;
 define atan2-method (<double-float>, $double-pi, 0.0d0) end;
-
-define binary-transcendental hypot (x, y);
-
-define sealed may-inline method hypot (x :: <single-float>, y :: <single-float>)
- => (z :: <single-float>)
-  primitive-raw-as-single-float
-    (%call-c-function("hypotf")
-         (x :: <raw-single-float>, y :: <raw-single-float>)
-      => (z :: <raw-single-float>)
-         (primitive-single-float-as-raw(x),
-          primitive-single-float-as-raw(y))
-     end)
-end method hypot;
-
-define sealed may-inline method hypot (x :: <double-float>, y :: <double-float>)
- => (z :: <double-float>)
-  primitive-raw-as-double-float
-    (%call-c-function("hypot")
-         (x :: <raw-double-float>, y :: <raw-double-float>)
-      => (z :: <raw-double-float>)
-         (primitive-double-float-as-raw(x),
-          primitive-double-float-as-raw(y))
-     end)
-end method hypot;

--- a/sources/common-dylan/win32-common-dylan.lid
+++ b/sources/common-dylan/win32-common-dylan.lid
@@ -19,6 +19,7 @@ Files: library
        timers
        profiling
        transcendentals
+       transcendentals-windows
        machine-words/utilities
        machine-words/machine-word
        machine-words/logicals


### PR DESCRIPTION
The MSVCRT.dll runtime library does not provide hypot() and hypotf()
functions, and so it is necessary to provide an alternative
implementation on Win32.

* sources/common-dylan/transcendentals.dylan (hypot): Move from here.

* sources/common-dylan/transcendentals-unix.dylan (hypot): Move
  original FFI-based implementation here.

* sources/common-dylan/transcendentals-windows.dylan
  (hypot, hypot-method-definer): New Dylan-based implementation.

* sources/common-dylan/win32-common-dylan.lid: Reference
  transcendentals-windows.dylan.

* sources/common-dylan/darwin-common-dylan.lid: Reference
  transcendentals-unix.dylan.

* sources/common-dylan/freebsd-common-dylan.lid: Reference
  transcendentals-unix.dylan.

* sources/common-dylan/linux-common-dylan.lid: Reference
  transcendentals-unix.dylan.

* sources/common-dylan/netbsd-common-dylan.lid: Reference
  transcendentals-unix.dylan.