### PR TITLE
system: Implement machine-concurrent-thread-count

### DIFF
--- a/documentation/library-reference/source/system/operating-system.rst
+++ b/documentation/library-reference/source/system/operating-system.rst
@@ -36,6 +36,10 @@ These constants contain information about the hardware and software
 resident on the host machine. The constants let you programmatically
 check the current system conditions before executing a piece of code.
 
+The following function also returns information about the machine:
+
+- :func:`machine-concurrent-thread-count`
+
 The following two functions let you manipulate the values of any
 environment variables in the system.
 
@@ -473,6 +477,21 @@ System library's operating-system module.
 
      - :const:`$machine-name`
      - :const:`$os-name`
+
+.. function:: machine-concurrent-thread-count
+
+   Return the number of concurrent execution threads available.
+
+   :signature: machine-concurrent-thread-count => *count*
+
+   :value count: An instance of :drm:`<integer>`.
+
+   :description:
+
+      Returns the number of execution threads currently
+      available. This normally corresponds to the number of logical
+      processor cores currently online, and may vary over the lifetime
+      of the program.
 
 .. function:: register-application-exit-function
 

--- a/documentation/release-notes/source/2019.1.rst
+++ b/documentation/release-notes/source/2019.1.rst
@@ -262,6 +262,10 @@ Runtime
 system
 ======
 
+* A new ``machine-concurrent-thread-count`` function, which returns
+  the number of active CPU cores or execution threads, has been added
+  to the ``operating-system`` module.
+
 * New specializations on :drm:`as` have been added for creating locators
   from strings for the ``<file-system-directory-locator>`` and
   ``<file-system-file-locator>`` classes. These aren't typically used but

--- a/sources/system/library.dylan
+++ b/sources/system/library.dylan
@@ -68,7 +68,8 @@ define module operating-system
          signal-application-event,
          load-library,
          current-process-id,
-         parent-process-id;
+         parent-process-id,
+         machine-concurrent-thread-count;
 
   create command-line-option-prefix;
 end module operating-system;

--- a/sources/system/tests/operating-system.dylan
+++ b/sources/system/tests/operating-system.dylan
@@ -343,6 +343,11 @@ define operating-system function-test parent-process-id ()
   check-true("parent-process-id is an integer", instance?(pid, <integer>));
 end;
 
+define operating-system function-test machine-concurrent-thread-count ()
+  let thread-count = machine-concurrent-thread-count();
+  check-true("There is at least one core", thread-count >= 1);
+end;
+
 
 // Application startup handling
 

--- a/sources/system/tests/specification.dylan
+++ b/sources/system/tests/specification.dylan
@@ -205,6 +205,7 @@ define module-spec operating-system ()
   function load-library (<string>) => (<object>);
   function current-process-id () => (<integer>);
   function parent-process-id () => (<integer>);
+  function machine-concurrent-thread-count () => (<integer>);
 
   // Application startup handling
   function application-name () => (false-or(<string>));

--- a/sources/system/unix-operating-system.dylan
+++ b/sources/system/unix-operating-system.dylan
@@ -577,3 +577,12 @@ define function parent-process-id
                      ()
                  end);
 end;
+
+define function machine-concurrent-thread-count
+    () => (count :: <integer>)
+  raw-as-integer(%call-c-function("system_concurrent_thread_count")
+                     () => (count :: <raw-c-signed-int>)
+                     ()
+                 end);
+end;
+

--- a/sources/system/unix-portability.c
+++ b/sources/system/unix-portability.c
@@ -1,3 +1,7 @@
+#ifdef __APPLE__
+#define _DARWIN_C_SOURCE
+#endif
+
 #include <unistd.h>
 #include <signal.h>
 #include <errno.h>
@@ -124,4 +128,13 @@ const char* unix_tmpdir(void)
 #endif
   }
   return tmpdir;
+}
+
+int system_concurrent_thread_count(void)
+{
+  long count = sysconf(_SC_NPROCESSORS_ONLN);
+  if (count < 0) {
+    return 0;
+  }
+  return (int) count;
 }

--- a/sources/system/win32-shim.c
+++ b/sources/system/win32-shim.c
@@ -1,0 +1,8 @@
+#include <windows.h>
+
+int system_concurrent_thread_count(void)
+{
+  SYSTEM_INFO sysinfo;
+  GetSystemInfo(&sysinfo);
+  return (int) sysinfo.dwNumberOfProcessors;
+}

--- a/sources/system/x86-win32-operating-system.dylan
+++ b/sources/system/x86-win32-operating-system.dylan
@@ -1283,3 +1283,11 @@ define function parent-process-id
     () => (pid :: <integer>)
   0
 end;
+
+define function machine-concurrent-thread-count
+    () => (pid :: <integer>)
+  raw-as-integer(%call-c-function("system_concurrent_thread_count")
+                     () => (count :: <raw-c-signed-int>)
+                     ()
+                 end);
+end;

--- a/sources/system/x86-win32-system.lid
+++ b/sources/system/x86-win32-system.lid
@@ -27,6 +27,7 @@ Files: library
        xml
        settings/settings
        settings/win32-settings
+C-Source-Files: win32-shim.c
 C-Libraries: advapi32.lib
              shell32.lib
 Library-Pack: Core


### PR DESCRIPTION
This change adds machine-concurrent-thread-count, a function returning
the number of concurrent execution threads currently available, to the
operating-system module.

* sources/system/library.dylan
  (module operating-system): Export machine-concurrent-thread-count.

* sources/system/unix-operating-system.dylan
  (machine-concurrent-thread-count): New function.

* sources/system/unix-portability.c: Define _DARWIN_C_SOURCE on macOS.
  (system_concurrent_thread_count): Implement using POSIX sysconf.

* sources/system/x86-win32-operating-system.dylan
  (machine-concurrent-thread-count): New function.

* sources/system/win32-shim.c: New source.
  (system_concurrent_thread_count): Implement using GetSystemInfo.

* sources/system/tests/specification.dylan
  (module-spec operating-system): Add machine-concurrent-thread-count
   specification.

* sources/system/tests/operating-system.dylan
  (function-test machine-concurrent-thread-count): New test.

* sources/system/x86-win32-system.lid: Reference win32-shim.c.

* documentation/library-reference/source/system/operating-system.rst:
  Document machine-concurrent-thread-count.

* documentation/release-notes/source/2019.1.rst: Update release notes.