### PR TITLE
release-notes: Clearly distinguish the upcoming release

### DIFF
--- a/documentation/release-notes/source/2019.1.rst
+++ b/documentation/release-notes/source/2019.1.rst
@@ -1,5 +1,5 @@
 *******************************
-Open Dylan 2019.1 Release Notes
+Open Dylan 2019.1 (coming soon)
 *******************************
 
 Introduction

--- a/documentation/release-notes/source/index.rst
+++ b/documentation/release-notes/source/index.rst
@@ -3,14 +3,9 @@ Open Dylan Release Notes
 
 .. toctree::
 
+   2019.1
    2014.1
    2013.2
    2013.1
    2012.1
    2011.1
-
-Upcoming releases:
-
-.. toctree::
-
-   2019.1


### PR DESCRIPTION
I don't know why the "Upcoming Releases" text in index.rst doesn't show up in the left nav. An alternative to the solution in this PR would be to figure out how to put some arbitrary text in the toctree, but I couldn't find a way.