### PR TITLE
Add more thorough tests for bit-vectors

### DIFF
--- a/sources/collections/bit-vector.dylan
+++ b/sources/collections/bit-vector.dylan
@@ -141,7 +141,7 @@ end function;
 //
 /*
 define method check-start-compute-end
-  (vector :: <bit-vector>, start :: <integer>, last) 
+  (vector :: <bit-vector>, start :: <integer>, last)
       => (real-last :: <integer>);
   let vector-size = vector.size;
   let last :: <integer> = if (unsupplied?(last)) vector-size else last end;
@@ -202,7 +202,7 @@ define inline-only function bit-vector-and-internal!
 
     if (result.word-size > v1.word-size)
       for (i :: <integer> from v1.word-size below result.word-size)
-        bit-vector-word(result, i) := 
+        bit-vector-word(result, i) :=
           if (p1 = 0)
             primitive-unwrap-machine-word($machine-word-zero);
           else
@@ -263,12 +263,12 @@ define inline-only function bit-vector-andc2-internal!
     if (v1.word-size < result.word-size)
       if (p1 = 0)
         for (i :: <integer> from v1.word-size below result.word-size)
-          bit-vector-word(result, i) := 
+          bit-vector-word(result, i) :=
             primitive-unwrap-machine-word($machine-word-zero);
         end for;
       else
         for (i :: <integer> from v1.word-size below result.word-size)
-          bit-vector-word(result, i) := 
+          bit-vector-word(result, i) :=
             primitive-machine-word-lognot(bit-vector-word(v2, i));
         end for;
       end if;
@@ -972,7 +972,7 @@ define function bit-vector-andc2
      #key pad1 :: <bit> = 0, pad2 :: <bit> = 0)
  => (result :: <bit-vector>, pad :: <bit>)
 
-  let result-size = 
+  let result-size =
   if (pad1 = 0)
     if (pad2 = 0)
       vector1.size
@@ -1035,7 +1035,7 @@ define function bit-vector-or
      #key pad1 :: <bit> = 0, pad2 :: <bit> = 0)
  => (result :: <bit-vector>, pad :: <bit>)
 
-  let result-size = 
+  let result-size =
   if (pad1 = 0)
     if (pad2 = 0)
       max(vector1.size, vector2.size);
@@ -1156,7 +1156,7 @@ define function bit-vector-not
  => (result :: <bit-vector>, result-pad :: <bit>)
   let result :: <bit-vector> = make(<bit-vector>, size: vector.size);
   for (i :: <integer> from 0 below vector.word-size)
-    bit-vector-word(result, i) := 
+    bit-vector-word(result, i) :=
         primitive-machine-word-lognot(bit-vector-word(vector, i));
   end for;
   values(result, if (pad = 0) 1 else 0 end);

--- a/sources/collections/tests/bit-count.dylan
+++ b/sources/collections/tests/bit-count.dylan
@@ -19,7 +19,7 @@ end test;
 
 define test bit-count-tiny-vector ()
   let vector = make(<bit-vector>, size: $tiny-size);
-  let bits = list(1, 4, 6, 7, 9, 11, 13);
+  let bits = list(1);
   set-bits(vector, bits);
   check-equal("Count bits in tiny vector", bit-count(vector), size(bits));
   check-equal("Count zero bits in tiny vector",
@@ -28,6 +28,16 @@ define test bit-count-tiny-vector ()
     bit-count(vector, bit-value: 1), size(bits));
 end test;
 
+define test bit-count-small-vector ()
+  let vector = make(<bit-vector>, size: $small-size);
+  let bits = list(1, 4, 6, 7, 9, 11, 13);
+  set-bits(vector, bits);
+  check-equal("Count bits in small vector", bit-count(vector), size(bits));
+  check-equal("Count zero bits in small vector",
+    bit-count(vector, bit-value: 0), $small-size - size(bits));
+  check-equal("Count one bits in small vector",
+    bit-count(vector, bit-value: 1), size(bits));
+end test;
 
 define test bit-count-huge-vector ()
   let vector = make(<bit-vector>, size: $huge-size);
@@ -55,6 +65,7 @@ end test;
 define suite bit-count-suite (description: "Test bit-count")
   test bit-count-empty-vector;
   test bit-count-tiny-vector;
+  test bit-count-small-vector;
   test bit-count-huge-vector;
   test bit-count-multiple-word-sized-vector;
 end suite;

--- a/sources/collections/tests/bit-count.dylan
+++ b/sources/collections/tests/bit-count.dylan
@@ -62,7 +62,7 @@ define test bit-count-multiple-word-sized-vector ()
     bit-count(vector, bit-value: 1), size(bits));
 end test;
 
-define suite bit-count-suite (description: "Test bit-count")
+define suite bit-count-suite ()
   test bit-count-empty-vector;
   test bit-count-tiny-vector;
   test bit-count-small-vector;

--- a/sources/collections/tests/bit-vector-and.dylan
+++ b/sources/collections/tests/bit-vector-and.dylan
@@ -33,9 +33,7 @@ define method test-and-for-all-pad-values
 end method;
 
 
-define test bit-vector-and-tiny-vector
-    (description: "Test bit-vector-and with tiny sized bit-vectors")
-
+define test bit-vector-and-tiny-vector ()
   let vector1 = make(<bit-vector>, size: $tiny-size);
   let vector2 = make(<bit-vector>, size: $tiny-size);
   let vector3 = make(<bit-vector>, size: $tiny-size, fill: 1);
@@ -104,9 +102,7 @@ define test bit-vector-and-tiny-vector
 
 end test;
 
-define test bit-vector-and-small-vector
-    (description: "Test bit-vector-and with small sized bit-vectors")
-
+define test bit-vector-and-small-vector ()
   let vector1 = make(<bit-vector>, size: $small-size);
   let vector2 = make(<bit-vector>, size: $small-size);
   let vector3 = make(<bit-vector>, size: $small-size, fill: 1);
@@ -175,9 +171,7 @@ define test bit-vector-and-small-vector
 
 end test;
 
-define test bit-vector-and-huge-vector
-    (description: "Test bit-vector-and with huge sized bit-vectors")
-
+define test bit-vector-and-huge-vector ()
   let vector1 = make(<bit-vector>, size: $huge-size);
   let vector2 = make(<bit-vector>, size: $huge-size);
   let vector3 = make(<bit-vector>, size: $huge-size, fill: 1);
@@ -246,9 +240,7 @@ define test bit-vector-and-huge-vector
 
 end test;
 
-define test bit-vector-and-multiple-word-vector
-    (description: "Test bit-vector-and with multiple-word sized bit-vectors")
-
+define test bit-vector-and-multiple-word-vector ()
   let vector1 = make(<bit-vector>, size: $multiple-word-size);
   let vector2 = make(<bit-vector>, size: $multiple-word-size);
   let vector3 = make(<bit-vector>, size: $multiple-word-size, fill: 1);

--- a/sources/collections/tests/bit-vector-and.dylan
+++ b/sources/collections/tests/bit-vector-and.dylan
@@ -7,28 +7,29 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define method test-and-for-all-pad-values
-    (prefix :: <string>, vector1 :: <bit-vector>, vector2 :: <bit-vector>,
+  (prefix :: <string>, size :: <integer>,
+     vector1 :: <bit-vector>, vector2 :: <bit-vector>,
      bits00, bits01, bits10, bits11)
  => ()
   let (result, pad) = bit-vector-and(vector1, vector2);
   check-equal(concatenate(prefix, ", pad1=0, pad2=0: result pad"), pad, 0);
   bit-vector-consistency-checks(concatenate(prefix, ", pad1=0, pad2=0"),
-    result, $tiny-size, bits00);
+    result, size, bits00);
 
   let (result, pad) = bit-vector-and(vector1, vector2, pad1: 0, pad2: 1);
   check-equal(concatenate(prefix, ", pad1=0, pad2=0: result pad"), pad, 0);
   bit-vector-consistency-checks(concatenate(prefix, ", pad1=0, pad2=1"),
-    result, $tiny-size, bits01);
+    result, size, bits01);
 
   let (result, pad) = bit-vector-and(vector1, vector2, pad1: 1, pad2: 0);
   check-equal(concatenate(prefix, ", pad1=1, pad2=0: result pad"), pad, 0);
   bit-vector-consistency-checks(concatenate(prefix, ", pad1=1, pad2=0"),
-    result, $tiny-size, bits10);
+    result, size, bits10);
 
   let (result, pad) = bit-vector-and(vector1, vector2, pad1: 1, pad2: 1);
   check-equal(concatenate(prefix, ", pad1=1, pad2=1: result pad"), pad, 1);
   bit-vector-consistency-checks(concatenate(prefix, ", pad1=1, pad2=1"),
-    result, $tiny-size, bits11);
+    result, size, bits11);
 end method;
 
 
@@ -40,13 +41,13 @@ define test bit-vector-and-tiny-vector
   let vector3 = make(<bit-vector>, size: $tiny-size, fill: 1);
   let vector4 = make(<bit-vector>, size: $tiny-size, fill: 1);
 
-  let bits5 = list(2, 3, 5, 7, 11, 13);
-  let not-bits5 = list(0, 1, 4, 6, 8, 9, 10, 12);
+  let bits5 = list(2, 3);
+  let not-bits5 = list(0, 1);
   let vector5 = make(<bit-vector>, size: $tiny-size);
   set-bits(vector5, bits5);
 
-  let bits6 = list(1, 3, 6, 7, 9, 10, 12, 13);
-  let not-bits6 = list(0, 2, 4, 5, 8, 11);
+  let bits6 = list(1, 3);
+  let not-bits6 = list(0, 2);
   let vector6 = make(<bit-vector>, size: $tiny-size, fill: 1);
   unset-bits(vector6, not-bits6);
 
@@ -56,54 +57,269 @@ define test bit-vector-and-tiny-vector
   // And two all-zero vectors together with different pad values
   //
   test-and-for-all-pad-values("And two all-zero vectors",
-    vector1, vector2,
+    $tiny-size, vector1, vector2,
     #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
 
   // And two all-one vectors together with different pad values
   //
   test-and-for-all-pad-values("And two all-one vectors",
-    vector3, vector4,
+    $tiny-size, vector3, vector4,
     #"all-ones", #"all-ones", #"all-ones", #"all-ones");
 
   // And an all-zero and all-one vector together with different pad values
   //
   test-and-for-all-pad-values("And an all-one and all-zero vector",
-    vector1, vector3,
+    $tiny-size, vector1, vector3,
     #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
   test-and-for-all-pad-values("And an all-zero and all-one vector",
-    vector3, vector1,
+    $tiny-size, vector3, vector1,
     #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
 
   // And an all-zero vector with a mixed vector and different pad values
   //
   test-and-for-all-pad-values("And an all-zero and mixed vector",
-    vector1, vector5,
+    $tiny-size, vector1, vector5,
     #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
   test-and-for-all-pad-values("And a mixed and all-zero vector",
-    vector5, vector1,
+    $tiny-size, vector5, vector1,
     #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
 
   // And an all-one vector with a mixed vector and different pad values
   //
   test-and-for-all-pad-values("And an all-one and mixed vector",
-    vector3, vector5,
+    $tiny-size, vector3, vector5,
       bits5, bits5, bits5, bits5);
   test-and-for-all-pad-values("And a mixed and all-one vector",
-    vector5, vector3,
+    $tiny-size, vector5, vector3,
       bits5, bits5, bits5, bits5);
 
   // And two mixed vectors together with different pad values
   //
   test-and-for-all-pad-values("And two vectors",
-    vector5, vector6,
+    $tiny-size, vector5, vector6,
     bits5-and-bits6, bits5-and-bits6, bits5-and-bits6, bits5-and-bits6);
   test-and-for-all-pad-values("And two vectors again, arguments reversed",
-    vector6, vector5,
+    $tiny-size, vector6, vector5,
     bits6-and-bits5, bits6-and-bits5, bits6-and-bits5, bits6-and-bits5);
 
 end test;
 
+define test bit-vector-and-small-vector
+    (description: "Test bit-vector-and with small sized bit-vectors")
+
+  let vector1 = make(<bit-vector>, size: $small-size);
+  let vector2 = make(<bit-vector>, size: $small-size);
+  let vector3 = make(<bit-vector>, size: $small-size, fill: 1);
+  let vector4 = make(<bit-vector>, size: $small-size, fill: 1);
+
+  let bits5 = list(2, 3, 5, 7, 11, 13);
+  let not-bits5 = list(0, 1, 4, 6, 8, 9, 10, 12);
+  let vector5 = make(<bit-vector>, size: $small-size);
+  set-bits(vector5, bits5);
+
+  let bits6 = list(1, 3, 6, 7, 9, 10, 12, 13);
+  let not-bits6 = list(0, 2, 4, 5, 8, 11);
+  let vector6 = make(<bit-vector>, size: $small-size, fill: 1);
+  unset-bits(vector6, not-bits6);
+
+  let bits5-and-bits6 = intersection(bits5, bits6);
+  let bits6-and-bits5 = bits5-and-bits6;
+
+  // And two all-zero vectors together with different pad values
+  //
+  test-and-for-all-pad-values("And two all-zero vectors",
+    $small-size, vector1, vector2,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+
+  // And two all-one vectors together with different pad values
+  //
+  test-and-for-all-pad-values("And two all-one vectors",
+    $small-size, vector3, vector4,
+    #"all-ones", #"all-ones", #"all-ones", #"all-ones");
+
+  // And an all-zero and all-one vector together with different pad values
+  //
+  test-and-for-all-pad-values("And an all-one and all-zero vector",
+    $small-size, vector1, vector3,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+  test-and-for-all-pad-values("And an all-zero and all-one vector",
+    $small-size, vector3, vector1,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+
+  // And an all-zero vector with a mixed vector and different pad values
+  //
+  test-and-for-all-pad-values("And an all-zero and mixed vector",
+    $small-size, vector1, vector5,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+  test-and-for-all-pad-values("And a mixed and all-zero vector",
+    $small-size, vector5, vector1,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+
+  // And an all-one vector with a mixed vector and different pad values
+  //
+  test-and-for-all-pad-values("And an all-one and mixed vector",
+    $small-size, vector3, vector5,
+      bits5, bits5, bits5, bits5);
+  test-and-for-all-pad-values("And a mixed and all-one vector",
+    $small-size, vector5, vector3,
+      bits5, bits5, bits5, bits5);
+
+  // And two mixed vectors together with different pad values
+  //
+  test-and-for-all-pad-values("And two vectors",
+    $small-size, vector5, vector6,
+    bits5-and-bits6, bits5-and-bits6, bits5-and-bits6, bits5-and-bits6);
+  test-and-for-all-pad-values("And two vectors again, arguments reversed",
+    $small-size, vector6, vector5,
+    bits6-and-bits5, bits6-and-bits5, bits6-and-bits5, bits6-and-bits5);
+
+end test;
+
+define test bit-vector-and-huge-vector
+    (description: "Test bit-vector-and with huge sized bit-vectors")
+
+  let vector1 = make(<bit-vector>, size: $huge-size);
+  let vector2 = make(<bit-vector>, size: $huge-size);
+  let vector3 = make(<bit-vector>, size: $huge-size, fill: 1);
+  let vector4 = make(<bit-vector>, size: $huge-size, fill: 1);
+
+  let bits5 = random-elements($huge-size, seed: 186);
+  let not-bits5 = compute-not-bits(bits5, $huge-size);
+  let vector5 = make(<bit-vector>, size: $huge-size);
+  set-bits(vector5, bits5);
+
+  let bits6 = random-elements($huge-size, seed: 191);
+  let not-bits6 = compute-not-bits(bits6, $huge-size);
+  let vector6 = make(<bit-vector>, size: $huge-size, fill: 1);
+  unset-bits(vector6, not-bits6);
+
+  let bits5-and-bits6 = intersection(bits5, bits6);
+  let bits6-and-bits5 = bits5-and-bits6;
+
+  // And two all-zero vectors together with different pad values
+  //
+  test-and-for-all-pad-values("And two all-zero vectors",
+    $huge-size, vector1, vector2,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+
+  // And two all-one vectors together with different pad values
+  //
+  test-and-for-all-pad-values("And two all-one vectors",
+    $huge-size, vector3, vector4,
+    #"all-ones", #"all-ones", #"all-ones", #"all-ones");
+
+  // And an all-zero and all-one vector together with different pad values
+  //
+  test-and-for-all-pad-values("And an all-one and all-zero vector",
+    $huge-size, vector1, vector3,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+  test-and-for-all-pad-values("And an all-zero and all-one vector",
+    $huge-size, vector3, vector1,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+
+  // And an all-zero vector with a mixed vector and different pad values
+  //
+  test-and-for-all-pad-values("And an all-zero and mixed vector",
+    $huge-size, vector1, vector5,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+  test-and-for-all-pad-values("And a mixed and all-zero vector",
+    $huge-size, vector5, vector1,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+
+  // And an all-one vector with a mixed vector and different pad values
+  //
+  test-and-for-all-pad-values("And an all-one and mixed vector",
+    $huge-size, vector3, vector5,
+      bits5, bits5, bits5, bits5);
+  test-and-for-all-pad-values("And a mixed and all-one vector",
+    $huge-size, vector5, vector3,
+      bits5, bits5, bits5, bits5);
+
+  // And two mixed vectors together with different pad values
+  //
+  test-and-for-all-pad-values("And two vectors",
+    $huge-size, vector5, vector6,
+    bits5-and-bits6, bits5-and-bits6, bits5-and-bits6, bits5-and-bits6);
+  test-and-for-all-pad-values("And two vectors again, arguments reversed",
+    $huge-size, vector6, vector5,
+    bits6-and-bits5, bits6-and-bits5, bits6-and-bits5, bits6-and-bits5);
+
+end test;
+
+define test bit-vector-and-multiple-word-vector
+    (description: "Test bit-vector-and with multiple-word sized bit-vectors")
+
+  let vector1 = make(<bit-vector>, size: $multiple-word-size);
+  let vector2 = make(<bit-vector>, size: $multiple-word-size);
+  let vector3 = make(<bit-vector>, size: $multiple-word-size, fill: 1);
+  let vector4 = make(<bit-vector>, size: $multiple-word-size, fill: 1);
+
+  let bits5 = random-elements($multiple-word-size, seed: 257);
+  let not-bits5 = compute-not-bits(bits5, $multiple-word-size);
+  let vector5 = make(<bit-vector>, size: $multiple-word-size);
+  set-bits(vector5, bits5);
+
+  let bits6 = random-elements($multiple-word-size, seed: 262);
+  let not-bits6 = compute-not-bits(bits6, $multiple-word-size);
+  let vector6 = make(<bit-vector>, size: $multiple-word-size, fill: 1);
+  unset-bits(vector6, not-bits6);
+
+  let bits5-and-bits6 = intersection(bits5, bits6);
+  let bits6-and-bits5 = bits5-and-bits6;
+
+  // And two all-zero vectors together with different pad values
+  //
+  test-and-for-all-pad-values("And two all-zero vectors",
+    $multiple-word-size, vector1, vector2,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+
+  // And two all-one vectors together with different pad values
+  //
+  test-and-for-all-pad-values("And two all-one vectors",
+    $multiple-word-size, vector3, vector4,
+    #"all-ones", #"all-ones", #"all-ones", #"all-ones");
+
+  // And an all-zero and all-one vector together with different pad values
+  //
+  test-and-for-all-pad-values("And an all-one and all-zero vector",
+    $multiple-word-size, vector1, vector3,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+  test-and-for-all-pad-values("And an all-zero and all-one vector",
+    $multiple-word-size, vector3, vector1,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+
+  // And an all-zero vector with a mixed vector and different pad values
+  //
+  test-and-for-all-pad-values("And an all-zero and mixed vector",
+    $multiple-word-size, vector1, vector5,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+  test-and-for-all-pad-values("And a mixed and all-zero vector",
+    $multiple-word-size, vector5, vector1,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+
+  // And an all-one vector with a mixed vector and different pad values
+  //
+  test-and-for-all-pad-values("And an all-one and mixed vector",
+    $multiple-word-size, vector3, vector5,
+      bits5, bits5, bits5, bits5);
+  test-and-for-all-pad-values("And a mixed and all-one vector",
+    $multiple-word-size, vector5, vector3,
+      bits5, bits5, bits5, bits5);
+
+  // And two mixed vectors together with different pad values
+  //
+  test-and-for-all-pad-values("And two vectors",
+    $multiple-word-size, vector5, vector6,
+    bits5-and-bits6, bits5-and-bits6, bits5-and-bits6, bits5-and-bits6);
+  test-and-for-all-pad-values("And two vectors again, arguments reversed",
+    $multiple-word-size, vector6, vector5,
+    bits6-and-bits5, bits6-and-bits5, bits6-and-bits5, bits6-and-bits5);
+
+end test;
 
 define suite bit-vector-and-suite ()
   test bit-vector-and-tiny-vector;
+  test bit-vector-and-small-vector;
+  test bit-vector-and-huge-vector;
+  test bit-vector-and-multiple-word-vector;
 end suite;

--- a/sources/collections/tests/bit-vector-and.dylan
+++ b/sources/collections/tests/bit-vector-and.dylan
@@ -86,10 +86,10 @@ define test bit-vector-and-tiny-vector ()
   //
   test-and-for-all-pad-values("And an all-one and mixed vector",
     $tiny-size, vector3, vector5,
-      bits5, bits5, bits5, bits5);
+    bits5, bits5, bits5, bits5);
   test-and-for-all-pad-values("And a mixed and all-one vector",
     $tiny-size, vector5, vector3,
-      bits5, bits5, bits5, bits5);
+    bits5, bits5, bits5, bits5);
 
   // And two mixed vectors together with different pad values
   //
@@ -155,10 +155,10 @@ define test bit-vector-and-small-vector ()
   //
   test-and-for-all-pad-values("And an all-one and mixed vector",
     $small-size, vector3, vector5,
-      bits5, bits5, bits5, bits5);
+    bits5, bits5, bits5, bits5);
   test-and-for-all-pad-values("And a mixed and all-one vector",
     $small-size, vector5, vector3,
-      bits5, bits5, bits5, bits5);
+    bits5, bits5, bits5, bits5);
 
   // And two mixed vectors together with different pad values
   //
@@ -224,10 +224,10 @@ define test bit-vector-and-huge-vector ()
   //
   test-and-for-all-pad-values("And an all-one and mixed vector",
     $huge-size, vector3, vector5,
-      bits5, bits5, bits5, bits5);
+    bits5, bits5, bits5, bits5);
   test-and-for-all-pad-values("And a mixed and all-one vector",
     $huge-size, vector5, vector3,
-      bits5, bits5, bits5, bits5);
+    bits5, bits5, bits5, bits5);
 
   // And two mixed vectors together with different pad values
   //
@@ -293,10 +293,10 @@ define test bit-vector-and-multiple-word-vector ()
   //
   test-and-for-all-pad-values("And an all-one and mixed vector",
     $multiple-word-size, vector3, vector5,
-      bits5, bits5, bits5, bits5);
+    bits5, bits5, bits5, bits5);
   test-and-for-all-pad-values("And a mixed and all-one vector",
     $multiple-word-size, vector5, vector3,
-      bits5, bits5, bits5, bits5);
+    bits5, bits5, bits5, bits5);
 
   // And two mixed vectors together with different pad values
   //

--- a/sources/collections/tests/bit-vector-andc2.dylan
+++ b/sources/collections/tests/bit-vector-andc2.dylan
@@ -33,9 +33,7 @@ define method test-andc2-for-all-pad-values
 end method;
 
 
-define test bit-vector-andc2-tiny-vector
-    (description: "Test bit-vector-andc2 with tiny sized bit-vectors")
-
+define test bit-vector-andc2-tiny-vector ()
   let vector1 = make(<bit-vector>, size: $tiny-size);
   let vector2 = make(<bit-vector>, size: $tiny-size);
   let vector3 = make(<bit-vector>, size: $tiny-size, fill: 1);
@@ -106,9 +104,7 @@ define test bit-vector-andc2-tiny-vector
 
 end test;
 
-define test bit-vector-andc2-small-vector
-    (description: "Test bit-vector-andc2 with small sized bit-vectors")
-
+define test bit-vector-andc2-small-vector ()
   let vector1 = make(<bit-vector>, size: $small-size);
   let vector2 = make(<bit-vector>, size: $small-size);
   let vector3 = make(<bit-vector>, size: $small-size, fill: 1);
@@ -179,9 +175,7 @@ define test bit-vector-andc2-small-vector
 
 end test;
 
-define test bit-vector-andc2-huge-vector
-    (description: "Test bit-vector-andc2 with huge sized bit-vectors")
-
+define test bit-vector-andc2-huge-vector ()
   let vector1 = make(<bit-vector>, size: $huge-size);
   let vector2 = make(<bit-vector>, size: $huge-size);
   let vector3 = make(<bit-vector>, size: $huge-size, fill: 1);

--- a/sources/collections/tests/bit-vector-andc2.dylan
+++ b/sources/collections/tests/bit-vector-andc2.dylan
@@ -7,28 +7,29 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define method test-andc2-for-all-pad-values
-    (prefix :: <string>, vector1 :: <bit-vector>, vector2 :: <bit-vector>,
+    (prefix :: <string>,
+     size :: <integer>, vector1 :: <bit-vector>, vector2 :: <bit-vector>,
      bits00, bits01, bits10, bits11)
  => ()
   let (result, pad) = bit-vector-andc2(vector1, vector2);
   check-equal(concatenate(prefix, ", pad1=0, pad2=0: result pad"), pad, 0);
   bit-vector-consistency-checks(concatenate(prefix, ", pad1=0, pad2=0"),
-    result, $tiny-size, bits00);
+    result, size, bits00);
 
   let (result, pad) = bit-vector-andc2(vector1, vector2, pad1: 0, pad2: 1);
   check-equal(concatenate(prefix, ", pad1=0, pad2=0: result pad"), pad, 0);
   bit-vector-consistency-checks(concatenate(prefix, ", pad1=0, pad2=1"),
-    result, $tiny-size, bits01);
+    result, size, bits01);
 
   let (result, pad) = bit-vector-andc2(vector1, vector2, pad1: 1, pad2: 0);
   check-equal(concatenate(prefix, ", pad1=1, pad2=0: result pad"), pad, 1);
   bit-vector-consistency-checks(concatenate(prefix, ", pad1=1, pad2=0"),
-    result, $tiny-size, bits10);
+    result, size, bits10);
 
   let (result, pad) = bit-vector-andc2(vector1, vector2, pad1: 1, pad2: 1);
   check-equal(concatenate(prefix, ", pad1=1, pad2=1: result pad"), pad, 0);
   bit-vector-consistency-checks(concatenate(prefix, ", pad1=1, pad2=1"),
-    result, $tiny-size, bits11);
+    result, size, bits11);
 end method;
 
 
@@ -40,13 +41,13 @@ define test bit-vector-andc2-tiny-vector
   let vector3 = make(<bit-vector>, size: $tiny-size, fill: 1);
   let vector4 = make(<bit-vector>, size: $tiny-size, fill: 1);
 
-  let bits5 = list(2, 3, 5, 7, 11, 13);
-  let not-bits5 = list(0, 1, 4, 6, 8, 9, 10, 12);
+  let bits5 = list(2, 3);
+  let not-bits5 = list(0, 1);
   let vector5 = make(<bit-vector>, size: $tiny-size);
   set-bits(vector5, bits5);
 
-  let bits6 = list(1, 3, 6, 7, 9, 10, 12, 13);
-  let not-bits6 = list(0, 2, 4, 5, 8, 11);
+  let bits6 = list(1, 3);
+  let not-bits6 = list(0, 2);
   let vector6 = make(<bit-vector>, size: $tiny-size, fill: 1);
   unset-bits(vector6, not-bits6);
 
@@ -56,70 +57,142 @@ define test bit-vector-andc2-tiny-vector
   // Andc2 two all-zero vectors together with different pad values
   //
   test-andc2-for-all-pad-values("Andc2 two all-zero vectors",
-    vector1, vector2,
+    $tiny-size, vector1, vector2,
     #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
 
   // Andc2 two all-one vectors together with different pad values
   //
   test-andc2-for-all-pad-values("Andc2 two all-one vectors",
-    vector3, vector4,
+    $tiny-size, vector3, vector4,
     #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
 
   // Andc2 an all-zero and all-one vector together with different pad values
   //
   test-andc2-for-all-pad-values("Andc2 an all-one and all-zero vector",
-    vector1, vector3,
+    $tiny-size, vector1, vector3,
     #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
   test-andc2-for-all-pad-values("Andc2 an all-zero and all-one vector",
-    vector3, vector1,
+    $tiny-size, vector3, vector1,
     #"all-ones", #"all-ones", #"all-ones", #"all-ones");
 
   // Andc2 an all-zero vector with a mixed vector and different pad values
   //
   test-andc2-for-all-pad-values("Andc2 an all-zero and mixed vector",
-    vector1, vector5,
+    $tiny-size, vector1, vector5,
     #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
   test-andc2-for-all-pad-values("Andc2 a mixed and all-zero vector",
-    vector5, vector1,
+    $tiny-size, vector5, vector1,
     bits5, bits5, bits5, bits5);
 
   // Andc2 an all-one vector with a mixed vector and different pad values
   //
   test-andc2-for-all-pad-values("Andc2 an all-one and mixed vector",
-    vector3, vector5,
+    $tiny-size, vector3, vector5,
     not-bits5, not-bits5, not-bits5, not-bits5);
   test-andc2-for-all-pad-values("Andc2 a mixed and all-one vector",
-    vector5, vector3,
+    $tiny-size, vector5, vector3,
     #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
 
   // Andc2 two mixed vectors together with different pad values
   //
   test-andc2-for-all-pad-values("Andc2 two vectors",
-    vector5, vector6,
+    $tiny-size, vector5, vector6,
     bits5-andc2-bits6, bits5-andc2-bits6,
     bits5-andc2-bits6, bits5-andc2-bits6);
   test-andc2-for-all-pad-values("Andc2 two vectors again, arguments reversed",
-    vector6, vector5,
+    $tiny-size, vector6, vector5,
     bits6-andc2-bits5, bits6-andc2-bits5,
     bits6-andc2-bits5, bits6-andc2-bits5);
 
 end test;
 
-/*
-define test bit-vector-andc2-????-vector
-    (description: "Test bit-vector-andc2 with tiny sized bit-vectors")
+define test bit-vector-andc2-small-vector
+    (description: "Test bit-vector-andc2 with small sized bit-vectors")
 
-  let vector1 = make(<bit-vector>, size: $tiny-size);
-  let vector2 = make(<bit-vector>, size: $huge-size);
-  let vector3 = make(<bit-vector>, size: $tiny-size, fill: 1);
-  let vector4 = make(<bit-vector>, size: $huge-size, fill: 1);
+  let vector1 = make(<bit-vector>, size: $small-size);
+  let vector2 = make(<bit-vector>, size: $small-size);
+  let vector3 = make(<bit-vector>, size: $small-size, fill: 1);
+  let vector4 = make(<bit-vector>, size: $small-size, fill: 1);
 
   let bits5 = list(2, 3, 5, 7, 11, 13);
   let not-bits5 = list(0, 1, 4, 6, 8, 9, 10, 12);
-  let vector5 = make(<bit-vector>, size: $tiny-size);
+  let vector5 = make(<bit-vector>, size: $small-size);
   set-bits(vector5, bits5);
 
   let bits6 = list(1, 3, 6, 7, 9, 10, 12, 13);
+  let not-bits6 = list(0, 2, 4, 5, 8, 11);
+  let vector6 = make(<bit-vector>, size: $small-size, fill: 1);
+  unset-bits(vector6, not-bits6);
+
+  let bits5-andc2-bits6 = intersection(bits5, not-bits6);
+  let bits6-andc2-bits5 = intersection(bits6, not-bits5);
+
+  // Andc2 two all-zero vectors together with different pad values
+  //
+  test-andc2-for-all-pad-values("Andc2 two all-zero vectors",
+    $small-size, vector1, vector2,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+
+  // Andc2 two all-one vectors together with different pad values
+  //
+  test-andc2-for-all-pad-values("Andc2 two all-one vectors",
+    $small-size, vector3, vector4,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+
+  // Andc2 an all-zero and all-one vector together with different pad values
+  //
+  test-andc2-for-all-pad-values("Andc2 an all-one and all-zero vector",
+    $small-size, vector1, vector3,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+  test-andc2-for-all-pad-values("Andc2 an all-zero and all-one vector",
+    $small-size, vector3, vector1,
+    #"all-ones", #"all-ones", #"all-ones", #"all-ones");
+
+  // Andc2 an all-zero vector with a mixed vector and different pad values
+  //
+  test-andc2-for-all-pad-values("Andc2 an all-zero and mixed vector",
+    $small-size, vector1, vector5,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+  test-andc2-for-all-pad-values("Andc2 a mixed and all-zero vector",
+    $small-size, vector5, vector1,
+    bits5, bits5, bits5, bits5);
+
+  // Andc2 an all-one vector with a mixed vector and different pad values
+  //
+  test-andc2-for-all-pad-values("Andc2 an all-one and mixed vector",
+    $small-size, vector3, vector5,
+    not-bits5, not-bits5, not-bits5, not-bits5);
+  test-andc2-for-all-pad-values("Andc2 a mixed and all-one vector",
+    $small-size, vector5, vector3,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+
+  // Andc2 two mixed vectors together with different pad values
+  //
+  test-andc2-for-all-pad-values("Andc2 two vectors",
+    $small-size, vector5, vector6,
+    bits5-andc2-bits6, bits5-andc2-bits6,
+    bits5-andc2-bits6, bits5-andc2-bits6);
+  test-andc2-for-all-pad-values("Andc2 two vectors again, arguments reversed",
+    $small-size, vector6, vector5,
+    bits6-andc2-bits5, bits6-andc2-bits5,
+    bits6-andc2-bits5, bits6-andc2-bits5);
+
+end test;
+
+define test bit-vector-andc2-huge-vector
+    (description: "Test bit-vector-andc2 with huge sized bit-vectors")
+
+  let vector1 = make(<bit-vector>, size: $huge-size);
+  let vector2 = make(<bit-vector>, size: $huge-size);
+  let vector3 = make(<bit-vector>, size: $huge-size, fill: 1);
+  let vector4 = make(<bit-vector>, size: $huge-size, fill: 1);
+
+  let bits5 = random-elements($huge-size, seed: 190);
+  let not-bits5 = compute-not-bits(bits5, $huge-size);
+  let vector5 = make(<bit-vector>, size: $huge-size);
+  set-bits(vector5, bits5);
+
+  let bits6 = random-elements($huge-size, seed: 195);
   let not-bits6 = compute-not-bits(bits6, $huge-size);
   let vector6 = make(<bit-vector>, size: $huge-size, fill: 1);
   unset-bits(vector6, not-bits6);
@@ -130,63 +203,57 @@ define test bit-vector-andc2-????-vector
   // Andc2 two all-zero vectors together with different pad values
   //
   test-andc2-for-all-pad-values("Andc2 two all-zero vectors",
-    vector1, vector2,
-    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
-  test-andc2-for-all-pad-values("Andc2 two all-zero vectors",
-    vector2, vector1,
+    $huge-size, vector1, vector2,
     #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
 
   // Andc2 two all-one vectors together with different pad values
   //
   test-andc2-for-all-pad-values("Andc2 two all-one vectors",
-    vector3, vector4,
-    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
-  test-andc2-for-all-pad-values("Andc2 two all-one vectors",
-    vector4, vector3,
+    $huge-size, vector3, vector4,
     #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
 
   // Andc2 an all-zero and all-one vector together with different pad values
   //
   test-andc2-for-all-pad-values("Andc2 an all-one and all-zero vector",
-    vector1, vector3,
+    $huge-size, vector1, vector3,
     #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
   test-andc2-for-all-pad-values("Andc2 an all-zero and all-one vector",
-    vector3, vector1,
+    $huge-size, vector3, vector1,
     #"all-ones", #"all-ones", #"all-ones", #"all-ones");
 
   // Andc2 an all-zero vector with a mixed vector and different pad values
   //
   test-andc2-for-all-pad-values("Andc2 an all-zero and mixed vector",
-    vector1, vector5,
+    $huge-size, vector1, vector5,
     #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
   test-andc2-for-all-pad-values("Andc2 a mixed and all-zero vector",
-    vector5, vector1,
+    $huge-size, vector5, vector1,
     bits5, bits5, bits5, bits5);
 
   // Andc2 an all-one vector with a mixed vector and different pad values
   //
   test-andc2-for-all-pad-values("Andc2 an all-one and mixed vector",
-    vector3, vector5,
+    $huge-size, vector3, vector5,
     not-bits5, not-bits5, not-bits5, not-bits5);
   test-andc2-for-all-pad-values("Andc2 a mixed and all-one vector",
-    vector5, vector3,
+    $huge-size, vector5, vector3,
     #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
 
   // Andc2 two mixed vectors together with different pad values
   //
   test-andc2-for-all-pad-values("Andc2 two vectors",
-    vector5, vector6,
+    $huge-size, vector5, vector6,
     bits5-andc2-bits6, bits5-andc2-bits6,
     bits5-andc2-bits6, bits5-andc2-bits6);
   test-andc2-for-all-pad-values("Andc2 two vectors again, arguments reversed",
-    vector6, vector5,
+    $huge-size, vector6, vector5,
     bits6-andc2-bits5, bits6-andc2-bits5,
     bits6-andc2-bits5, bits6-andc2-bits5);
 
 end test;
-*/
-
 
 define suite bit-vector-andc2-suite ()
   test bit-vector-andc2-tiny-vector;
+  test bit-vector-andc2-small-vector;
+  test bit-vector-andc2-huge-vector;
 end suite;

--- a/sources/collections/tests/bit-vector-elements.dylan
+++ b/sources/collections/tests/bit-vector-elements.dylan
@@ -176,7 +176,6 @@ define test bit-vector-elements-huge-vector ()
   bit-vector-consistency-checks("Only bits 0, 20 and 99 set",
     vector1, $huge-size, list(0, 20, 99));
 
-
   check-equal("Bit 0 of vector1 to 1 again", (vector1[0] := 1), 1);
   bit-vector-consistency-checks("Only bits 0, 20 and 99 set",
     vector1, $huge-size, list(0, 20, 99));

--- a/sources/collections/tests/bit-vector-elements.dylan
+++ b/sources/collections/tests/bit-vector-elements.dylan
@@ -6,9 +6,7 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
-define test bit-vector-elements-tiny-vector
-    (description: "Tests for tiny bit-vectors")
-
+define test bit-vector-elements-tiny-vector ()
   let vector1 = make(<bit-vector>, size: $tiny-size);
   let vector2 = make(<bit-vector>, size: $tiny-size, fill: 0);
   let vector3 = make(<bit-vector>, size: $tiny-size, fill: 1);
@@ -81,9 +79,7 @@ define test bit-vector-elements-tiny-vector
 
 end test;
 
-define test bit-vector-elements-small-vector
-    (description: "Tests for small bit-vectors")
-
+define test bit-vector-elements-small-vector ()
   let vector1 = make(<bit-vector>, size: $small-size);
   let vector2 = make(<bit-vector>, size: $small-size, fill: 0);
   let vector3 = make(<bit-vector>, size: $small-size, fill: 1);
@@ -156,9 +152,7 @@ define test bit-vector-elements-small-vector
     vector3, $small-size, list(1, 2, 3, 5, 6, 7, 8, 9, 11, 12, 13));
 end test;
 
-define test bit-vector-elements-huge-vector
-    (description: "Tests for huge bit-vectors")
-
+define test bit-vector-elements-huge-vector ()
   let vector1 = make(<bit-vector>, size: $huge-size);
   let vector2 = make(<bit-vector>, size: $huge-size, fill: 0);
   let vector3 = make(<bit-vector>, size: $huge-size, fill: 1);
@@ -230,9 +224,7 @@ define test bit-vector-elements-huge-vector
     vector3, $huge-size, compute-not-bits(list(0, 99, 101), $huge-size));
 end test;
 
-define test bit-vector-elements-multiple-word-vector
-    (description: "Tests for multiple-word bit-vectors")
-
+define test bit-vector-elements-multiple-word-vector ()
   let vector1 = make(<bit-vector>, size: $multiple-word-size);
   let vector2 = make(<bit-vector>, size: $multiple-word-size, fill: 0);
   let vector3 = make(<bit-vector>, size: $multiple-word-size, fill: 1);
@@ -304,8 +296,7 @@ define test bit-vector-elements-multiple-word-vector
     vector3, $multiple-word-size, compute-not-bits(list(0, 57, 23), $multiple-word-size));
 end test;
 
-define suite bit-vector-elements-suite
-    (description: "Tests for element setters and getters")
+define suite bit-vector-elements-suite ()
   test bit-vector-elements-tiny-vector;
   test bit-vector-elements-small-vector;
   test bit-vector-elements-huge-vector;

--- a/sources/collections/tests/bit-vector-elements.dylan
+++ b/sources/collections/tests/bit-vector-elements.dylan
@@ -7,7 +7,7 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define test bit-vector-elements-tiny-vector
-    (description: "Tests for small bit-vectors")
+    (description: "Tests for tiny bit-vectors")
 
   let vector1 = make(<bit-vector>, size: $tiny-size);
   let vector2 = make(<bit-vector>, size: $tiny-size, fill: 0);
@@ -24,66 +24,290 @@ define test bit-vector-elements-tiny-vector
   bit-vector-consistency-checks("Only bit 0 set",
     vector1, $tiny-size, list(0));
 
+  check-equal("Bit 3 of vector1 to 1", (element(vector1, 3) := 1), 1);
+  bit-vector-consistency-checks("Only bits 0 and 3 set",
+    vector1, $tiny-size, list(0, 3));
+
+  check-equal("Bit 2 of vector1 to 1", (vector1[2] := 1), 1);
+  bit-vector-consistency-checks("Only bits 0, 2 and 3 set",
+    vector1, $tiny-size, list(0, 2, 3));
+
+  check-equal("Bit 0 of vector1 to 1 again", (vector1[0] := 1), 1);
+  bit-vector-consistency-checks("Only bits 0, 2 and 3 set",
+    vector1, $tiny-size, list(0, 2, 3));
+
+  check-equal("Bit 1 of vector1 to 0", (element(vector1, 1) := 0), 0);
+  bit-vector-consistency-checks("Only bits 0, 2 and 3 set",
+    vector1, $tiny-size, list(0, 2, 3));
+
+  check-equal("Bit 3 of vector1 to 1 again", (element(vector1, 3) := 1), 1);
+  bit-vector-consistency-checks("Only bits 0, 2 and 3 set",
+    vector1, $tiny-size, list(0, 2, 3));
+
+  check-equal("Bit 2 of vector1 to 1 again",
+    element-setter(1, vector1, 2), 1);
+  bit-vector-consistency-checks("Only bits 0, 2 and 3 set",
+    vector1, $tiny-size, list(0, 2, 3));
+
+  // vector3
+
+  check-equal("Bit 0 of vector3 to 0", element-setter(0, vector3, 0), 0);
+  bit-vector-consistency-checks("Only bit 0 unset",
+    vector3, $tiny-size, list(1, 2, 3));
+
+  check-equal("Bit 3 of vector3 to 0", (element(vector3, 3) := 0), 0);
+  bit-vector-consistency-checks("Only bits 0 and 3 unset",
+    vector3, $tiny-size, list(1, 2));
+
+  check-equal("Bit 2 of vector3 to 0", (vector3[2] := 0), 0);
+  bit-vector-consistency-checks("Only bits 0, 2 and 3 unset",
+    vector3, $tiny-size, list(1));
+
+  check-equal("Bit 0 of vector3 to 0 again", (element(vector3, 0) := 0), 0);
+  bit-vector-consistency-checks("Only bits 0, 2 and 3 unset",
+    vector3, $tiny-size, list(1));
+
+  check-equal("Bit 1 of vector3 to 0 again", element-setter(0, vector3, 1), 0);
+  bit-vector-consistency-checks("All bits unset",
+    vector3, $tiny-size, list());
+
+  check-equal("Bit 2 of vector3 to 1", element-setter(1, vector3, 2), 1);
+  bit-vector-consistency-checks("Only bits 0, 1, 3 unset",
+    vector3, $tiny-size, list(2));
+
+  check-equal("Bit 0 of vector3 to 0 again", (vector3[0] := 0), 0);
+  bit-vector-consistency-checks("Only bits 0, 1, 3 unset",
+    vector3, $tiny-size, list(2));
+
+end test;
+
+define test bit-vector-elements-small-vector
+    (description: "Tests for small bit-vectors")
+
+  let vector1 = make(<bit-vector>, size: $small-size);
+  let vector2 = make(<bit-vector>, size: $small-size, fill: 0);
+  let vector3 = make(<bit-vector>, size: $small-size, fill: 1);
+
+  bit-vector-consistency-checks("Make small vector1",
+    vector1, $small-size, #"all-zeros");
+  bit-vector-consistency-checks("Make small vector2",
+    vector2, $small-size, #"all-zeros");
+  bit-vector-consistency-checks("Make small vector3",
+    vector3, $small-size, #"all-ones");
+
+  check-equal("Bit 0 of vector1 to 1", element-setter(1, vector1, 0), 1);
+  bit-vector-consistency-checks("Only bit 0 set",
+    vector1, $small-size, list(0));
+
   check-equal("Bit 10 of vector1 to 1", (element(vector1, 10) := 1), 1);
   bit-vector-consistency-checks("Only bits 0 and 10 set",
-    vector1, $tiny-size, list(0, 10));
+    vector1, $small-size, list(0, 10));
 
   check-equal("Bit 7 of vector1 to 1", (vector1[7] := 1), 1);
   bit-vector-consistency-checks("Only bits 0, 10 and 7 set",
-    vector1, $tiny-size, list(0, 10, 7));
+    vector1, $small-size, list(0, 10, 7));
 
 
   check-equal("Bit 0 of vector1 to 1 again", (vector1[0] := 1), 1);
   bit-vector-consistency-checks("Only bits 0, 7 and 10 set",
-    vector1, $tiny-size, list(0, 7, 10));
+    vector1, $small-size, list(0, 7, 10));
 
   check-equal("Bit 2 of vector1 to 0", (element(vector1, 2) := 0), 0);
   bit-vector-consistency-checks("Only bits 0, 7 and 10 set",
-    vector1, $tiny-size, list(0, 7, 10));
+    vector1, $small-size, list(0, 7, 10));
 
   check-equal("Bit 7 of vector1 to 1 again", (element(vector1, 7) := 1), 1);
   bit-vector-consistency-checks("Only bits 0, 7 and 10 set",
-    vector1, $tiny-size, list(0, 7, 10));
+    vector1, $small-size, list(0, 7, 10));
 
   check-equal("Bit 10 of vector1 to 1 again",
     element-setter(1, vector1, 10), 1);
   bit-vector-consistency-checks("Only bits 0, 7 and 10 set",
-    vector1, $tiny-size, list(0, 7, 10));
+    vector1, $small-size, list(0, 7, 10));
 
 
   check-equal("Bit 0 of vector3 to 0", element-setter(0, vector3, 0), 0);
   bit-vector-consistency-checks("Only bit 0 unset",
-    vector3, $tiny-size, list(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13));
+    vector3, $small-size, list(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13));
 
   check-equal("Bit 10 of vector3 to 0", (element(vector3, 10) := 0), 0);
   bit-vector-consistency-checks("Only bits 0 and 10 unset",
-    vector3, $tiny-size, list(1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13));
+    vector3, $small-size, list(1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13));
 
   check-equal("Bit 4 of vector3 to 0", (vector3[4] := 0), 0);
   bit-vector-consistency-checks("Only bits 0, 4 and 10 unset",
-    vector3, $tiny-size, list(1, 2, 3, 5, 6, 7, 8, 9, 11, 12, 13));
+    vector3, $small-size, list(1, 2, 3, 5, 6, 7, 8, 9, 11, 12, 13));
 
 
   check-equal("Bit 0 of vector3 to 0 again", (element(vector3, 0) := 0), 0);
   bit-vector-consistency-checks("Only bits 0, 4 and 10 unset",
-    vector3, $tiny-size, list(1, 2, 3, 5, 6, 7, 8, 9, 11, 12, 13));
+    vector3, $small-size, list(1, 2, 3, 5, 6, 7, 8, 9, 11, 12, 13));
 
   check-equal("Bit 4 of vector3 to 0 again", element-setter(0, vector3, 4), 0);
   bit-vector-consistency-checks("Only bits 0, 4 and 10 unset",
-    vector3, $tiny-size, list(1, 2, 3, 5, 6, 7, 8, 9, 11, 12, 13));
+    vector3, $small-size, list(1, 2, 3, 5, 6, 7, 8, 9, 11, 12, 13));
 
   check-equal("Bit 5 of vector3 to 1", element-setter(1, vector3, 5), 1);
   bit-vector-consistency-checks("Only bits 0, 4 and 10 unset",
-    vector3, $tiny-size, list(1, 2, 3, 5, 6, 7, 8, 9, 11, 12, 13));
+    vector3, $small-size, list(1, 2, 3, 5, 6, 7, 8, 9, 11, 12, 13));
 
   check-equal("Bit 10 of vector1 to 0 again", (vector3[10] := 0), 0);
   bit-vector-consistency-checks("Only bits 0, 4 and 10 unset",
-    vector3, $tiny-size, list(1, 2, 3, 5, 6, 7, 8, 9, 11, 12, 13));
-
+    vector3, $small-size, list(1, 2, 3, 5, 6, 7, 8, 9, 11, 12, 13));
 end test;
 
+define test bit-vector-elements-huge-vector
+    (description: "Tests for huge bit-vectors")
+
+  let vector1 = make(<bit-vector>, size: $huge-size);
+  let vector2 = make(<bit-vector>, size: $huge-size, fill: 0);
+  let vector3 = make(<bit-vector>, size: $huge-size, fill: 1);
+
+  bit-vector-consistency-checks("Make huge vector1",
+    vector1, $huge-size, #"all-zeros");
+  bit-vector-consistency-checks("Make huge vector2",
+    vector2, $huge-size, #"all-zeros");
+  bit-vector-consistency-checks("Make huge vector3",
+    vector3, $huge-size, #"all-ones");
+
+  check-equal("Bit 0 of vector1 to 1", element-setter(1, vector1, 0), 1);
+  bit-vector-consistency-checks("Only bit 0 set",
+    vector1, $huge-size, list(0));
+
+  check-equal("Bit 99 of vector1 to 1", (element(vector1, 99) := 1), 1);
+  bit-vector-consistency-checks("Only bits 0 and 99 set",
+    vector1, $huge-size, list(0, 99));
+
+  check-equal("Bit 20 of vector1 to 1", (vector1[20] := 1), 1);
+  bit-vector-consistency-checks("Only bits 0, 20 and 99 set",
+    vector1, $huge-size, list(0, 20, 99));
+
+
+  check-equal("Bit 0 of vector1 to 1 again", (vector1[0] := 1), 1);
+  bit-vector-consistency-checks("Only bits 0, 20 and 99 set",
+    vector1, $huge-size, list(0, 20, 99));
+
+  check-equal("Bit 45 of vector1 to 0", (element(vector1, 45) := 0), 0);
+  bit-vector-consistency-checks("Only bits 0, 20 and 99 set",
+    vector1, $huge-size, list(0, 20, 99));
+
+  check-equal("Bit 20 of vector1 to 1 again", (element(vector1, 20) := 1), 1);
+  bit-vector-consistency-checks("Only bits 0, 20 and 99 set",
+    vector1, $huge-size, list(0, 20, 99));
+
+  check-equal("Bit 99 of vector1 to 1 again",
+    element-setter(1, vector1, 99), 1);
+  bit-vector-consistency-checks("Only bits 0, 20 and 99 set",
+    vector1, $huge-size, list(0, 20, 99));
+
+
+  check-equal("Bit 0 of vector3 to 0", element-setter(0, vector3, 0), 0);
+  bit-vector-consistency-checks("Only bit 0 unset",
+    vector3, $huge-size, compute-not-bits(list(0), $huge-size));
+
+  check-equal("Bit 99 of vector3 to 0", (element(vector3, 99) := 0), 0);
+  bit-vector-consistency-checks("Only bits 0 and 99 unset",
+    vector3, $huge-size, compute-not-bits(list(0, 99), $huge-size));
+
+  check-equal("Bit 101 of vector3 to 0", (vector3[101] := 0), 0);
+  bit-vector-consistency-checks("Only bits 0, 99 and 101 unset",
+    vector3, $huge-size, compute-not-bits(list(0, 99, 101), $huge-size));
+
+  check-equal("Bit 0 of vector3 to 0 again", (element(vector3, 0) := 0), 0);
+  bit-vector-consistency-checks("Only bits 0, 99 and 101 unset",
+    vector3, $huge-size, compute-not-bits(list(0, 99, 101), $huge-size));
+
+  check-equal("Bit 101 of vector3 to 0 again", element-setter(0, vector3, 101), 0);
+  bit-vector-consistency-checks("Only bits 0, 99 and 101 unset",
+    vector3, $huge-size, compute-not-bits(list(0, 99, 101), $huge-size));
+
+  check-equal("Bit 5 of vector3 to 1", element-setter(1, vector3, 5), 1);
+  bit-vector-consistency-checks("Only bits 0, 99 and 101 unset",
+    vector3, $huge-size, compute-not-bits(list(0, 99, 101), $huge-size));
+
+  check-equal("Bit 99 of vector1 to 0 again", (vector3[99] := 0), 0);
+  bit-vector-consistency-checks("Only bits 0, 99 and 101 unset",
+    vector3, $huge-size, compute-not-bits(list(0, 99, 101), $huge-size));
+end test;
+
+define test bit-vector-elements-multiple-word-vector
+    (description: "Tests for multiple-word bit-vectors")
+
+  let vector1 = make(<bit-vector>, size: $multiple-word-size);
+  let vector2 = make(<bit-vector>, size: $multiple-word-size, fill: 0);
+  let vector3 = make(<bit-vector>, size: $multiple-word-size, fill: 1);
+
+  bit-vector-consistency-checks("Make multiple-word vector1",
+    vector1, $multiple-word-size, #"all-zeros");
+  bit-vector-consistency-checks("Make multiple-word vector2",
+    vector2, $multiple-word-size, #"all-zeros");
+  bit-vector-consistency-checks("Make multiple-word vector3",
+    vector3, $multiple-word-size, #"all-ones");
+
+  check-equal("Bit 0 of vector1 to 1", element-setter(1, vector1, 0), 1);
+  bit-vector-consistency-checks("Only bit 0 set",
+    vector1, $multiple-word-size, list(0));
+
+  check-equal("Bit 57 of vector1 to 1", (element(vector1, 57) := 1), 1);
+  bit-vector-consistency-checks("Only bits 0 and 57 set",
+    vector1, $multiple-word-size, list(0, 57));
+
+  check-equal("Bit 20 of vector1 to 1", (vector1[20] := 1), 1);
+  bit-vector-consistency-checks("Only bits 0, 20 and 57 set",
+    vector1, $multiple-word-size, list(0, 20, 57));
+
+
+  check-equal("Bit 0 of vector1 to 1 again", (vector1[0] := 1), 1);
+  bit-vector-consistency-checks("Only bits 0, 20 and 57 set",
+    vector1, $multiple-word-size, list(0, 20, 57));
+
+  check-equal("Bit 45 of vector1 to 0", (element(vector1, 45) := 0), 0);
+  bit-vector-consistency-checks("Only bits 0, 20 and 57 set",
+    vector1, $multiple-word-size, list(0, 20, 57));
+
+  check-equal("Bit 20 of vector1 to 1 again", (element(vector1, 20) := 1), 1);
+  bit-vector-consistency-checks("Only bits 0, 20 and 57 set",
+    vector1, $multiple-word-size, list(0, 20, 57));
+
+  check-equal("Bit 57 of vector1 to 1 again",
+    element-setter(1, vector1, 57), 1);
+  bit-vector-consistency-checks("Only bits 0, 20 and 57 set",
+    vector1, $multiple-word-size, list(0, 20, 57));
+
+
+  check-equal("Bit 0 of vector3 to 0", element-setter(0, vector3, 0), 0);
+  bit-vector-consistency-checks("Only bit 0 unset",
+    vector3, $multiple-word-size, compute-not-bits(list(0), $multiple-word-size));
+
+  check-equal("Bit 57 of vector3 to 0", (element(vector3, 57) := 0), 0);
+  bit-vector-consistency-checks("Only bits 0 and 57 unset",
+    vector3, $multiple-word-size, compute-not-bits(list(0, 57), $multiple-word-size));
+
+  check-equal("Bit 23 of vector3 to 0", (vector3[23] := 0), 0);
+  bit-vector-consistency-checks("Only bits 0, 57 and 23 unset",
+    vector3, $multiple-word-size, compute-not-bits(list(0, 57, 23), $multiple-word-size));
+
+  check-equal("Bit 0 of vector3 to 0 again", (element(vector3, 0) := 0), 0);
+  bit-vector-consistency-checks("Only bits 0, 57 and 23 unset",
+    vector3, $multiple-word-size, compute-not-bits(list(0, 57, 23), $multiple-word-size));
+
+  check-equal("Bit 23 of vector3 to 0 again", element-setter(0, vector3, 23), 0);
+  bit-vector-consistency-checks("Only bits 0, 57 and 23 unset",
+    vector3, $multiple-word-size, compute-not-bits(list(0, 57, 23), $multiple-word-size));
+
+  check-equal("Bit 5 of vector3 to 1", element-setter(1, vector3, 5), 1);
+  bit-vector-consistency-checks("Only bits 0, 57 and 23 unset",
+    vector3, $multiple-word-size, compute-not-bits(list(0, 57, 23), $multiple-word-size));
+
+  check-equal("Bit 57 of vector1 to 0 again", (vector3[57] := 0), 0);
+  bit-vector-consistency-checks("Only bits 0, 57 and 23 unset",
+    vector3, $multiple-word-size, compute-not-bits(list(0, 57, 23), $multiple-word-size));
+end test;
 
 define suite bit-vector-elements-suite
     (description: "Tests for element setters and getters")
   test bit-vector-elements-tiny-vector;
+  test bit-vector-elements-small-vector;
+  test bit-vector-elements-huge-vector;
+  test bit-vector-elements-multiple-word-vector;
 end suite;

--- a/sources/collections/tests/bit-vector-not.dylan
+++ b/sources/collections/tests/bit-vector-not.dylan
@@ -44,62 +44,60 @@ define test bit-vector-not!-empty-vector (description: "")
     result-pad, 0);
 end test;
 
+define method bit-vector-not-sized-vector(size :: <integer>)
+  let vector1 :: <bit-vector> = make(<bit-vector>, size: size);
+  let vector2 :: <bit-vector> = make(<bit-vector>, size: size, fill: 1);
+  let vector3 :: <bit-vector> = make(<bit-vector>, size: size);
 
-define test bit-vector-not-tiny-vector (description: "")
-  let vector1 :: <bit-vector> = make(<bit-vector>, size: $tiny-size);
-  let vector2 :: <bit-vector> = make(<bit-vector>, size: $tiny-size, fill: 1);
-  let vector3 :: <bit-vector> = make(<bit-vector>, size: $tiny-size);
-
-  let vector3-elements = list(0, 2, 3, 7, 8, 10, 12);
-  let not-vector3-elements = list(1, 4, 5, 6, 9, 11, 13);
-  do(method(bit) vector3[bit] := 1 end, vector3-elements);
+  let vector3-elements = random-elements(size);
+  let not-vector3-elements = compute-not-bits(vector3-elements, size);
+  set-bits(vector3, vector3-elements);
 
   // bit-vector-not of an all-zero vector
   //
   let (result, result-pad) = bit-vector-not(vector1);
   bit-vector-checks(result, result-pad,
     "bit-vector-not of an all-zero vector with default pad",
-    $tiny-size, #"all-ones", 1);
+    size, #"all-ones", 1);
 
   let (result, result-pad) = bit-vector-not(vector1, pad: 1);
   bit-vector-checks(result, result-pad,
     "bit-vector-not of an all-zero vector with pad = 1",
-    $tiny-size, #"all-ones", 0);
+    size, #"all-ones", 0);
 
   // bit-vector-not of an all-one vector
   //
   let (result, result-pad) = bit-vector-not(vector2, pad: 0);
   bit-vector-checks(result, result-pad,
     "bit-vector-not of an all-one vector with pad = 0",
-    $tiny-size, #"all-zeros", 1);
+    size, #"all-zeros", 1);
 
   let (result, result-pad) = bit-vector-not(vector2, pad: 1);
   bit-vector-checks(result, result-pad,
     "bit-vector-not of an all-one vector with pad = 1",
-    $tiny-size, #"all-zeros", 0);
+    size, #"all-zeros", 0);
 
   // bit-vector-not of a vector
   //
   let (result, result-pad) = bit-vector-not(vector3);
   bit-vector-checks(result, result-pad,
     "bit-vector-not of a vector with default pad",
-    $tiny-size, not-vector3-elements, 1);
+    size, not-vector3-elements, 1);
 
   let (result, result-pad) = bit-vector-not(vector3, pad: 1);
   bit-vector-checks(result, result-pad,
     "bit-vector-not of a vector with pad = 1",
-    $tiny-size, not-vector3-elements, 0);
-end test;
+    size, not-vector3-elements, 0);
+end method;
 
+define method bit-vector-not!-sized-vector(size :: <integer>)
+  let vector1 :: <bit-vector> = make(<bit-vector>, size: size);
+  let vector2 :: <bit-vector> = make(<bit-vector>, size: size);
+  let vector3 :: <bit-vector> = make(<bit-vector>, size: size);
 
-define test bit-vector-not!-tiny-vector (description: "")
-  let vector1 :: <bit-vector> = make(<bit-vector>, size: $tiny-size);
-  let vector2 :: <bit-vector> = make(<bit-vector>, size: $tiny-size);
-  let vector3 :: <bit-vector> = make(<bit-vector>, size: $tiny-size);
-
-  let vector3-elements = list(1, 4, 5, 6, 9, 11, 13);
-  let not-vector3-elements = list(0, 2, 3, 7, 8, 10, 12);
-  do(method(bit) vector3[bit] := 1 end, vector3-elements);
+  let vector3-elements = random-elements(size);
+  let not-vector3-elements = compute-not-bits(vector3-elements, size);
+  set-bits(vector3, vector3-elements);
 
   // bit-vector-not! of an all-zero vector
   //
@@ -108,14 +106,14 @@ define test bit-vector-not!-tiny-vector (description: "")
     result, vector1);
   bit-vector-checks(result, result-pad,
     "bit-vector-not! of an all-zero vector with default pad",
-    $tiny-size, #"all-ones", 1);
+    size, #"all-ones", 1);
 
   let (result, result-pad) = bit-vector-not!(vector2, pad: 1);
   check-equal("With pad = 1, bit-vector-not!(vector2) == vector2",
     result, vector2);
   bit-vector-checks(result, result-pad,
     "bit-vector-not! of an all-zero vector with pad = 1",
-    $tiny-size, #"all-ones", 0);
+    size, #"all-ones", 0);
 
   // bit-vector-not of an all-one vector
   //
@@ -124,14 +122,14 @@ define test bit-vector-not!-tiny-vector (description: "")
     result, vector1);
   bit-vector-checks(result, result-pad,
     "bit-vector-not! of an all-one vector with pad = 0",
-    $small-size, #"all-zeros", 1);
+    size, #"all-zeros", 1);
 
   let (result, result-pad) = bit-vector-not!(vector2, pad: 1);
   check-equal("With pad = 1, bit-vector-not!(vector2) == vector2",
     result, vector2);
   bit-vector-checks(result, result-pad,
     "bit-vector-not! of an all-one vector with pad = 1",
-    $tiny-size, #"all-zeros", 0);
+    size, #"all-zeros", 0);
 
   // bit-vector-not of a vector
   //
@@ -140,35 +138,55 @@ define test bit-vector-not!-tiny-vector (description: "")
     result, vector3);
   bit-vector-checks(result, result-pad,
     "bit-vector-not! of a vector with default pad",
-    $tiny-size, not-vector3-elements, 1);
+    size, not-vector3-elements, 1);
 
   let (result, result-pad) = bit-vector-not!(vector3, pad: 1);
   check-equal("With pad = 1, bit-vector-not!(vector3) == vector3",
     result, vector3);
   bit-vector-checks(result, result-pad,
     "bit-vector-not! of a vector with pad = 1",
-    $tiny-size, vector3-elements, 0);
+    size, vector3-elements, 0);
+end method;
+
+define test bit-vector-not-tiny-vector (description: "")
+    bit-vector-not-sized-vector($tiny-size);
 end test;
 
+define test bit-vector-not!-tiny-vector (description: "")
+    bit-vector-not!-sized-vector($tiny-size);
+end test;
+
+define test bit-vector-not-small-vector (description: "")
+    bit-vector-not-sized-vector($tiny-size);
+end test;
+
+define test bit-vector-not!-small-vector (description: "")
+    bit-vector-not!-sized-vector($small-size);
+end test;
 
 define test bit-vector-not-huge-vector ()
+    bit-vector-not-sized-vector($huge-size);
 end test;
 
 define test bit-vector-not!-huge-vector ()
+    bit-vector-not!-sized-vector($huge-size);
 end test;
 
 define test bit-vector-not-multiple-word-sized-vector ()
+    bit-vector-not-sized-vector($multiple-word-size);
 end test;
 
 define test bit-vector-not!-multiple-word-sized-vector ()
+    bit-vector-not!-sized-vector($multiple-word-size);
 end test;
-
 
 define suite bit-vector-not-suite ()
   test bit-vector-not-empty-vector;
   test bit-vector-not!-empty-vector;
   test bit-vector-not-tiny-vector;
   test bit-vector-not!-tiny-vector;
+  test bit-vector-not-small-vector;
+  test bit-vector-not!-small-vector;
   test bit-vector-not-huge-vector;
   test bit-vector-not!-huge-vector;
   test bit-vector-not-multiple-word-sized-vector;

--- a/sources/collections/tests/bit-vector-not.dylan
+++ b/sources/collections/tests/bit-vector-not.dylan
@@ -7,7 +7,7 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 
-define test bit-vector-not-empty-vector (description: "")
+define test bit-vector-not-empty-vector ()
   let vector = make(<bit-vector>, size: 0);
 
   let (result, result-pad) = bit-vector-not(vector, pad: 0);
@@ -24,7 +24,7 @@ define test bit-vector-not-empty-vector (description: "")
 end test;
 
 
-define test bit-vector-not!-empty-vector (description: "")
+define test bit-vector-not!-empty-vector ()
   let vector = make(<bit-vector>, size: 0);
 
   let (result, result-pad) = bit-vector-not!(vector, pad: 0);
@@ -148,19 +148,19 @@ define method bit-vector-not!-sized-vector(size :: <integer>)
     size, vector3-elements, 0);
 end method;
 
-define test bit-vector-not-tiny-vector (description: "")
+define test bit-vector-not-tiny-vector ()
     bit-vector-not-sized-vector($tiny-size);
 end test;
 
-define test bit-vector-not!-tiny-vector (description: "")
+define test bit-vector-not!-tiny-vector ()
     bit-vector-not!-sized-vector($tiny-size);
 end test;
 
-define test bit-vector-not-small-vector (description: "")
+define test bit-vector-not-small-vector ()
     bit-vector-not-sized-vector($tiny-size);
 end test;
 
-define test bit-vector-not!-small-vector (description: "")
+define test bit-vector-not!-small-vector ()
     bit-vector-not!-sized-vector($small-size);
 end test;
 

--- a/sources/collections/tests/bit-vector-or.dylan
+++ b/sources/collections/tests/bit-vector-or.dylan
@@ -33,9 +33,7 @@ define method test-or-for-all-pad-values
 end method;
 
 
-define test bit-vector-or-tiny-vector
-    (description: "Test bit-vector-andc2 with tiny sized bit-vectors")
-
+define test bit-vector-or-tiny-vector ()
   let vector1 = make(<bit-vector>, size: $tiny-size);
   let vector2 = make(<bit-vector>, size: $tiny-size);
   let vector3 = make(<bit-vector>, size: $tiny-size, fill: 1);
@@ -104,9 +102,7 @@ define test bit-vector-or-tiny-vector
 
 end test;
 
-define test bit-vector-or-small-vector
-    (description: "Test bit-vector-andc2 with small sized bit-vectors")
-
+define test bit-vector-or-small-vector ()
   let vector1 = make(<bit-vector>, size: $small-size);
   let vector2 = make(<bit-vector>, size: $small-size);
   let vector3 = make(<bit-vector>, size: $small-size, fill: 1);
@@ -175,9 +171,7 @@ define test bit-vector-or-small-vector
 
 end test;
 
-define test bit-vector-or-huge-vector
-    (description: "Test bit-vector-andc2 with huge sized bit-vectors")
-
+define test bit-vector-or-huge-vector ()
   let vector1 = make(<bit-vector>, size: $huge-size);
   let vector2 = make(<bit-vector>, size: $huge-size);
   let vector3 = make(<bit-vector>, size: $huge-size, fill: 1);
@@ -246,9 +240,7 @@ define test bit-vector-or-huge-vector
 
 end test;
 
-define test bit-vector-or-multiple-word-vector
-    (description: "Test bit-vector-andc2 with multiple-word sized bit-vectors")
-
+define test bit-vector-or-multiple-word-vector ()
   let vector1 = make(<bit-vector>, size: $multiple-word-size);
   let vector2 = make(<bit-vector>, size: $multiple-word-size);
   let vector3 = make(<bit-vector>, size: $multiple-word-size, fill: 1);

--- a/sources/collections/tests/bit-vector-or.dylan
+++ b/sources/collections/tests/bit-vector-or.dylan
@@ -7,28 +7,29 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define method test-or-for-all-pad-values
-    (prefix :: <string>, vector1 :: <bit-vector>, vector2 :: <bit-vector>,
+    (prefix :: <string>,
+     size :: <integer>, vector1 :: <bit-vector>, vector2 :: <bit-vector>,
      bits00, bits01, bits10, bits11)
  => ()
   let (result, pad) = bit-vector-or(vector1, vector2);
   check-equal(concatenate(prefix, ", pad1=0, pad2=0: result pad"), pad, 0);
   bit-vector-consistency-checks(concatenate(prefix, ", pad1=0, pad2=0"),
-    result, $tiny-size, bits00);
+    result, size, bits00);
 
   let (result, pad) = bit-vector-or(vector1, vector2, pad1: 0, pad2: 1);
   check-equal(concatenate(prefix, ", pad1=0, pad2=0: result pad"), pad, 1);
   bit-vector-consistency-checks(concatenate(prefix, ", pad1=0, pad2=1"),
-    result, $tiny-size, bits01);
+    result, size, bits01);
 
   let (result, pad) = bit-vector-or(vector1, vector2, pad1: 1, pad2: 0);
   check-equal(concatenate(prefix, ", pad1=1, pad2=0: result pad"), pad, 1);
   bit-vector-consistency-checks(concatenate(prefix, ", pad1=1, pad2=0"),
-    result, $tiny-size, bits10);
+    result, size, bits10);
 
   let (result, pad) = bit-vector-or(vector1, vector2, pad1: 1, pad2: 1);
   check-equal(concatenate(prefix, ", pad1=1, pad2=1: result pad"), pad, 1);
   bit-vector-consistency-checks(concatenate(prefix, ", pad1=1, pad2=1"),
-    result, $tiny-size, bits11);
+    result, size, bits11);
 end method;
 
 
@@ -40,13 +41,13 @@ define test bit-vector-or-tiny-vector
   let vector3 = make(<bit-vector>, size: $tiny-size, fill: 1);
   let vector4 = make(<bit-vector>, size: $tiny-size, fill: 1);
 
-  let bits5 = list(2, 3, 5, 7, 11, 13);
-  let not-bits5 = list(0, 1, 4, 6, 8, 9, 10, 12);
+  let bits5 = list(2, 3);
+  let not-bits5 = list(0, 1);
   let vector5 = make(<bit-vector>, size: $tiny-size);
   set-bits(vector5, bits5);
 
-  let bits6 = list(1, 3, 6, 7, 9, 10, 12, 13);
-  let not-bits6 = list(0, 2, 4, 5, 8, 11);
+  let bits6 = list(1, 3);
+  let not-bits6 = list(0, 2);
   let vector6 = make(<bit-vector>, size: $tiny-size, fill: 1);
   unset-bits(vector6, not-bits6);
 
@@ -56,54 +57,269 @@ define test bit-vector-or-tiny-vector
   // Or two all-zero vectors together with different pad values
   //
   test-or-for-all-pad-values("Or two all-zero vectors",
-    vector1, vector2,
+    $tiny-size, vector1, vector2,
     #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
 
   // Or two all-one vectors together with different pad values
   //
   test-or-for-all-pad-values("Or two all-one vectors",
-    vector3, vector4,
+    $tiny-size, vector3, vector4,
     #"all-ones", #"all-ones", #"all-ones", #"all-ones");
 
   // Or an all-zero and all-one vector together with different pad values
   //
   test-or-for-all-pad-values("Or an all-one and all-zero vector",
-    vector1, vector3,
+    $tiny-size, vector1, vector3,
     #"all-ones", #"all-ones", #"all-ones", #"all-ones");
   test-or-for-all-pad-values("Or an all-zero and all-one vector",
-    vector3, vector1,
+    $tiny-size, vector3, vector1,
     #"all-ones", #"all-ones", #"all-ones", #"all-ones");
 
   // Or an all-zero vector with a mixed vector and different pad values
   //
   test-or-for-all-pad-values("Or an all-zero and mixed vector",
-    vector1, vector5,
+    $tiny-size, vector1, vector5,
     bits5, bits5, bits5, bits5);
   test-or-for-all-pad-values("Or a mixed and all-zero vector",
-    vector5, vector1,
+    $tiny-size, vector5, vector1,
     bits5, bits5, bits5, bits5);
 
   // Or an all-one vector with a mixed vector and different pad values
   //
   test-or-for-all-pad-values("Or an all-one and mixed vector",
-    vector3, vector5,
+    $tiny-size, vector3, vector5,
     #"all-ones", #"all-ones", #"all-ones", #"all-ones");
   test-or-for-all-pad-values("Or a mixed and all-one vector",
-    vector5, vector3,
+    $tiny-size, vector5, vector3,
     #"all-ones", #"all-ones", #"all-ones", #"all-ones");
 
   // Or two mixed vectors together with different pad values
   //
   test-or-for-all-pad-values("Or two vectors",
-    vector5, vector6,
+    $tiny-size, vector5, vector6,
     bits5-or-bits6, bits5-or-bits6, bits5-or-bits6, bits5-or-bits6);
   test-or-for-all-pad-values("Or two vectors again, arguments reversed",
-    vector6, vector5,
+    $tiny-size, vector6, vector5,
     bits6-or-bits5, bits6-or-bits5, bits6-or-bits5, bits6-or-bits5);
 
 end test;
 
+define test bit-vector-or-small-vector
+    (description: "Test bit-vector-andc2 with small sized bit-vectors")
+
+  let vector1 = make(<bit-vector>, size: $small-size);
+  let vector2 = make(<bit-vector>, size: $small-size);
+  let vector3 = make(<bit-vector>, size: $small-size, fill: 1);
+  let vector4 = make(<bit-vector>, size: $small-size, fill: 1);
+
+  let bits5 = list(2, 3, 5, 7, 11, 13);
+  let not-bits5 = list(0, 1, 4, 6, 8, 9, 10, 12);
+  let vector5 = make(<bit-vector>, size: $small-size);
+  set-bits(vector5, bits5);
+
+  let bits6 = list(1, 3, 6, 7, 9, 10, 12, 13);
+  let not-bits6 = list(0, 2, 4, 5, 8, 11);
+  let vector6 = make(<bit-vector>, size: $small-size, fill: 1);
+  unset-bits(vector6, not-bits6);
+
+  let bits5-or-bits6 = union(bits5, bits6);
+  let bits6-or-bits5 = bits5-or-bits6;
+
+  // Or two all-zero vectors together with different pad values
+  //
+  test-or-for-all-pad-values("Or two all-zero vectors",
+    $small-size, vector1, vector2,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+
+  // Or two all-one vectors together with different pad values
+  //
+  test-or-for-all-pad-values("Or two all-one vectors",
+    $small-size, vector3, vector4,
+    #"all-ones", #"all-ones", #"all-ones", #"all-ones");
+
+  // Or an all-zero and all-one vector together with different pad values
+  //
+  test-or-for-all-pad-values("Or an all-one and all-zero vector",
+    $small-size, vector1, vector3,
+    #"all-ones", #"all-ones", #"all-ones", #"all-ones");
+  test-or-for-all-pad-values("Or an all-zero and all-one vector",
+    $small-size, vector3, vector1,
+    #"all-ones", #"all-ones", #"all-ones", #"all-ones");
+
+  // Or an all-zero vector with a mixed vector and different pad values
+  //
+  test-or-for-all-pad-values("Or an all-zero and mixed vector",
+    $small-size, vector1, vector5,
+    bits5, bits5, bits5, bits5);
+  test-or-for-all-pad-values("Or a mixed and all-zero vector",
+    $small-size, vector5, vector1,
+    bits5, bits5, bits5, bits5);
+
+  // Or an all-one vector with a mixed vector and different pad values
+  //
+  test-or-for-all-pad-values("Or an all-one and mixed vector",
+    $small-size, vector3, vector5,
+    #"all-ones", #"all-ones", #"all-ones", #"all-ones");
+  test-or-for-all-pad-values("Or a mixed and all-one vector",
+    $small-size, vector5, vector3,
+    #"all-ones", #"all-ones", #"all-ones", #"all-ones");
+
+  // Or two mixed vectors together with different pad values
+  //
+  test-or-for-all-pad-values("Or two vectors",
+    $small-size, vector5, vector6,
+    bits5-or-bits6, bits5-or-bits6, bits5-or-bits6, bits5-or-bits6);
+  test-or-for-all-pad-values("Or two vectors again, arguments reversed",
+    $small-size, vector6, vector5,
+    bits6-or-bits5, bits6-or-bits5, bits6-or-bits5, bits6-or-bits5);
+
+end test;
+
+define test bit-vector-or-huge-vector
+    (description: "Test bit-vector-andc2 with huge sized bit-vectors")
+
+  let vector1 = make(<bit-vector>, size: $huge-size);
+  let vector2 = make(<bit-vector>, size: $huge-size);
+  let vector3 = make(<bit-vector>, size: $huge-size, fill: 1);
+  let vector4 = make(<bit-vector>, size: $huge-size, fill: 1);
+
+  let bits5 = random-elements($huge-size, seed: 186);
+  let not-bits5 = compute-not-bits(bits5, $huge-size);
+  let vector5 = make(<bit-vector>, size: $huge-size);
+  set-bits(vector5, bits5);
+
+  let bits6 = random-elements($huge-size, seed: 191);
+  let not-bits6 = compute-not-bits(bits6, $huge-size);
+  let vector6 = make(<bit-vector>, size: $huge-size, fill: 1);
+  unset-bits(vector6, not-bits6);
+
+  let bits5-or-bits6 = union(bits5, bits6);
+  let bits6-or-bits5 = bits5-or-bits6;
+
+  // Or two all-zero vectors together with different pad values
+  //
+  test-or-for-all-pad-values("Or two all-zero vectors",
+    $huge-size, vector1, vector2,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+
+  // Or two all-one vectors together with different pad values
+  //
+  test-or-for-all-pad-values("Or two all-one vectors",
+    $huge-size, vector3, vector4,
+    #"all-ones", #"all-ones", #"all-ones", #"all-ones");
+
+  // Or an all-zero and all-one vector together with different pad values
+  //
+  test-or-for-all-pad-values("Or an all-one and all-zero vector",
+    $huge-size, vector1, vector3,
+    #"all-ones", #"all-ones", #"all-ones", #"all-ones");
+  test-or-for-all-pad-values("Or an all-zero and all-one vector",
+    $huge-size, vector3, vector1,
+    #"all-ones", #"all-ones", #"all-ones", #"all-ones");
+
+  // Or an all-zero vector with a mixed vector and different pad values
+  //
+  test-or-for-all-pad-values("Or an all-zero and mixed vector",
+    $huge-size, vector1, vector5,
+    bits5, bits5, bits5, bits5);
+  test-or-for-all-pad-values("Or a mixed and all-zero vector",
+    $huge-size, vector5, vector1,
+    bits5, bits5, bits5, bits5);
+
+  // Or an all-one vector with a mixed vector and different pad values
+  //
+  test-or-for-all-pad-values("Or an all-one and mixed vector",
+    $huge-size, vector3, vector5,
+    #"all-ones", #"all-ones", #"all-ones", #"all-ones");
+  test-or-for-all-pad-values("Or a mixed and all-one vector",
+    $huge-size, vector5, vector3,
+    #"all-ones", #"all-ones", #"all-ones", #"all-ones");
+
+  // Or two mixed vectors together with different pad values
+  //
+  test-or-for-all-pad-values("Or two vectors",
+    $huge-size, vector5, vector6,
+    bits5-or-bits6, bits5-or-bits6, bits5-or-bits6, bits5-or-bits6);
+  test-or-for-all-pad-values("Or two vectors again, arguments reversed",
+    $huge-size, vector6, vector5,
+    bits6-or-bits5, bits6-or-bits5, bits6-or-bits5, bits6-or-bits5);
+
+end test;
+
+define test bit-vector-or-multiple-word-vector
+    (description: "Test bit-vector-andc2 with multiple-word sized bit-vectors")
+
+  let vector1 = make(<bit-vector>, size: $multiple-word-size);
+  let vector2 = make(<bit-vector>, size: $multiple-word-size);
+  let vector3 = make(<bit-vector>, size: $multiple-word-size, fill: 1);
+  let vector4 = make(<bit-vector>, size: $multiple-word-size, fill: 1);
+
+  let bits5 = random-elements($multiple-word-size, seed: 186);
+  let not-bits5 = compute-not-bits(bits5, $multiple-word-size);
+  let vector5 = make(<bit-vector>, size: $multiple-word-size);
+  set-bits(vector5, bits5);
+
+  let bits6 = random-elements($multiple-word-size, seed: 191);
+  let not-bits6 = compute-not-bits(bits6, $multiple-word-size);
+  let vector6 = make(<bit-vector>, size: $multiple-word-size, fill: 1);
+  unset-bits(vector6, not-bits6);
+
+  let bits5-or-bits6 = union(bits5, bits6);
+  let bits6-or-bits5 = bits5-or-bits6;
+
+  // Or two all-zero vectors together with different pad values
+  //
+  test-or-for-all-pad-values("Or two all-zero vectors",
+    $multiple-word-size, vector1, vector2,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+
+  // Or two all-one vectors together with different pad values
+  //
+  test-or-for-all-pad-values("Or two all-one vectors",
+    $multiple-word-size, vector3, vector4,
+    #"all-ones", #"all-ones", #"all-ones", #"all-ones");
+
+  // Or an all-zero and all-one vector together with different pad values
+  //
+  test-or-for-all-pad-values("Or an all-one and all-zero vector",
+    $multiple-word-size, vector1, vector3,
+    #"all-ones", #"all-ones", #"all-ones", #"all-ones");
+  test-or-for-all-pad-values("Or an all-zero and all-one vector",
+    $multiple-word-size, vector3, vector1,
+    #"all-ones", #"all-ones", #"all-ones", #"all-ones");
+
+  // Or an all-zero vector with a mixed vector and different pad values
+  //
+  test-or-for-all-pad-values("Or an all-zero and mixed vector",
+    $multiple-word-size, vector1, vector5,
+    bits5, bits5, bits5, bits5);
+  test-or-for-all-pad-values("Or a mixed and all-zero vector",
+    $multiple-word-size, vector5, vector1,
+    bits5, bits5, bits5, bits5);
+
+  // Or an all-one vector with a mixed vector and different pad values
+  //
+  test-or-for-all-pad-values("Or an all-one and mixed vector",
+    $multiple-word-size, vector3, vector5,
+    #"all-ones", #"all-ones", #"all-ones", #"all-ones");
+  test-or-for-all-pad-values("Or a mixed and all-one vector",
+    $multiple-word-size, vector5, vector3,
+    #"all-ones", #"all-ones", #"all-ones", #"all-ones");
+
+  // Or two mixed vectors together with different pad values
+  //
+  test-or-for-all-pad-values("Or two vectors",
+    $multiple-word-size, vector5, vector6,
+    bits5-or-bits6, bits5-or-bits6, bits5-or-bits6, bits5-or-bits6);
+  test-or-for-all-pad-values("Or two vectors again, arguments reversed",
+    $multiple-word-size, vector6, vector5,
+    bits6-or-bits5, bits6-or-bits5, bits6-or-bits5, bits6-or-bits5);
+
+end test;
 
 define suite bit-vector-or-suite ()
   test bit-vector-or-tiny-vector;
+  test bit-vector-or-small-vector;
+  test bit-vector-or-huge-vector;
+  test bit-vector-or-multiple-word-vector;
 end suite;

--- a/sources/collections/tests/bit-vector-utilities.dylan
+++ b/sources/collections/tests/bit-vector-utilities.dylan
@@ -63,13 +63,13 @@ end method;
 
 //
 // Generate a deterministic but unpredictable set of element
-// indices use to initialize a bit-vector. Derives a seed from
+// indices used to initialize a bit-vector. Derives a seed from
 // the size, or one can be provided (for example if two different
 // sequences are required)
 // Note: don't use 0 for seed as RNG will always return zero in
 // that case.
 //
-define method random-elements(size :: <integer>, #key seed = #f)
+define method random-elements(size :: <integer>, #key seed)
   => (elements :: <sequence>)
   // A pseudo-random source
   local method lehmer(v :: <integer>) => (vo :: <integer>)

--- a/sources/collections/tests/bit-vector-utilities.dylan
+++ b/sources/collections/tests/bit-vector-utilities.dylan
@@ -6,12 +6,13 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
+// Rationale: tiny is less than one byte,
+// huge is greater than a machine word,
+// small is intermediate.
+define constant $tiny-size = 4;
 define constant $small-size = 14;
-
-define constant $tiny-size = 14;
 define constant $huge-size = 117;
 define constant $multiple-word-size = 96;
-
 
 //
 // Print a bit-vector
@@ -47,7 +48,7 @@ end method;
 
 
 //
-// 
+//
 //
 define method compute-not-bits(bits :: <sequence>, size :: <integer>)
  => (not-bits :: <sequence>)
@@ -60,6 +61,40 @@ define method compute-not-bits(bits :: <sequence>, size :: <integer>)
   not-bits;
 end method;
 
+//
+// Generate a deterministic but unpredictable set of element
+// indices use to initialize a bit-vector. Derives a seed from
+// the size, or one can be provided (for example if two different
+// sequences are required)
+// Note: don't use 0 for seed as RNG will always return zero in
+// that case.
+//
+define method random-elements(size :: <integer>, #key seed = #f)
+  => (elements :: <sequence>)
+  // A pseudo-random source
+  local method lehmer(v :: <integer>) => (vo :: <integer>)
+	  modulo(v * 75, 65537);
+        end;
+  // initial seed
+  let rnd-val = seed | begin
+			 // run a few iterations first
+			 let v = size + 1;
+			 for (i from 1 to 10)
+			   v := lehmer(v);
+			 end for;
+			 v
+		       end;
+  assert-not-equal(rnd-val, 0);
+  // Now generate approx 50% set, 50% unset
+  let elements = list();
+  for (i from 0 below size)
+    rnd-val := lehmer(rnd-val);
+    if (logbit?(1, rnd-val))
+      elements := pair(i, elements);
+    end if;
+  end for;
+  elements
+end method;
 
 //
 // Return #t if a bit-vector's elements are all zero.
@@ -127,7 +162,7 @@ define method bit-vector-consistency-checks
 end method;
 
 define method bit-vector-checks
-    (vector :: <bit-vector>, pad :: <bit>, prefix :: <string>, 
+    (vector :: <bit-vector>, pad :: <bit>, prefix :: <string>,
      expected-size :: <integer>, expected-elements, expected-pad :: <bit>)
  => ()
   check-equal(concatenate(prefix, ": expected size"),

--- a/sources/collections/tests/bit-vector-xor.dylan
+++ b/sources/collections/tests/bit-vector-xor.dylan
@@ -32,9 +32,7 @@ define method test-xor-for-all-pad-values
     result, size, bits11);
 end method;
 
-define test bit-vector-xor-tiny-vector
-    (description: "Test bit-vector-andc2 with tiny sized bit-vectors")
-
+define test bit-vector-xor-tiny-vector ()
   let vector1 = make(<bit-vector>, size: $tiny-size);
   let vector2 = make(<bit-vector>, size: $tiny-size);
   let vector3 = make(<bit-vector>, size: $tiny-size, fill: 1);
@@ -105,9 +103,7 @@ define test bit-vector-xor-tiny-vector
 
 end test;
 
-define test bit-vector-xor-small-vector
-    (description: "Test bit-vector-andc2 with small sized bit-vectors")
-
+define test bit-vector-xor-small-vector ()
   let vector1 = make(<bit-vector>, size: $small-size);
   let vector2 = make(<bit-vector>, size: $small-size);
   let vector3 = make(<bit-vector>, size: $small-size, fill: 1);
@@ -178,9 +174,7 @@ define test bit-vector-xor-small-vector
 
 end test;
 
-define test bit-vector-xor-huge-vector
-    (description: "Test bit-vector-andc2 with huge sized bit-vectors")
-
+define test bit-vector-xor-huge-vector ()
   let vector1 = make(<bit-vector>, size: $huge-size);
   let vector2 = make(<bit-vector>, size: $huge-size);
   let vector3 = make(<bit-vector>, size: $huge-size, fill: 1);
@@ -251,9 +245,7 @@ define test bit-vector-xor-huge-vector
 
 end test;
 
-define test bit-vector-xor-multiple-word-vector
-    (description: "Test bit-vector-andc2 with multiple-word sized bit-vectors")
-
+define test bit-vector-xor-multiple-word-vector ()
   let vector1 = make(<bit-vector>, size: $multiple-word-size);
   let vector2 = make(<bit-vector>, size: $multiple-word-size);
   let vector3 = make(<bit-vector>, size: $multiple-word-size, fill: 1);

--- a/sources/collections/tests/bit-vector-xor.dylan
+++ b/sources/collections/tests/bit-vector-xor.dylan
@@ -48,9 +48,8 @@ define test bit-vector-xor-tiny-vector ()
   let vector6 = make(<bit-vector>, size: $tiny-size, fill: 1);
   unset-bits(vector6, not-bits6);
 
-  let bits5-xor-bits6
-    = intersection(union(bits5, bits6),
-                   compute-not-bits(intersection(bits5, bits6), $tiny-size));
+  let bits5-xor-bits6 = intersection(union(bits5, bits6),
+    compute-not-bits(intersection(bits5, bits6), $tiny-size));
   let bits6-xor-bits5 = bits5-xor-bits6;
 
   // Xor two all-zero vectors together with different pad values
@@ -87,10 +86,10 @@ define test bit-vector-xor-tiny-vector ()
   //
   test-xor-for-all-pad-values("Xor an all-one and mixed vector",
     $tiny-size, vector3, vector5,
-      not-bits5, not-bits5, not-bits5, not-bits5);
+    not-bits5, not-bits5, not-bits5, not-bits5);
   test-xor-for-all-pad-values("Xor a mixed and all-one vector",
     $tiny-size, vector5, vector3,
-      not-bits5, not-bits5, not-bits5, not-bits5);
+    not-bits5, not-bits5, not-bits5, not-bits5);
 
   // Xor two mixed vectors together with different pad values
   //
@@ -119,9 +118,8 @@ define test bit-vector-xor-small-vector ()
   let vector6 = make(<bit-vector>, size: $small-size, fill: 1);
   unset-bits(vector6, not-bits6);
 
-  let bits5-xor-bits6
-    = intersection(union(bits5, bits6),
-                   compute-not-bits(intersection(bits5, bits6), $small-size));
+  let bits5-xor-bits6 = intersection(union(bits5, bits6),
+    compute-not-bits(intersection(bits5, bits6), $small-size));
   let bits6-xor-bits5 = bits5-xor-bits6;
 
   // Xor two all-zero vectors together with different pad values
@@ -158,10 +156,10 @@ define test bit-vector-xor-small-vector ()
   //
   test-xor-for-all-pad-values("Xor an all-one and mixed vector",
     $small-size, vector3, vector5,
-      not-bits5, not-bits5, not-bits5, not-bits5);
+    not-bits5, not-bits5, not-bits5, not-bits5);
   test-xor-for-all-pad-values("Xor a mixed and all-one vector",
     $small-size, vector5, vector3,
-      not-bits5, not-bits5, not-bits5, not-bits5);
+    not-bits5, not-bits5, not-bits5, not-bits5);
 
   // Xor two mixed vectors together with different pad values
   //
@@ -190,9 +188,8 @@ define test bit-vector-xor-huge-vector ()
   let vector6 = make(<bit-vector>, size: $huge-size, fill: 1);
   unset-bits(vector6, not-bits6);
 
-  let bits5-xor-bits6
-    = intersection(union(bits5, bits6),
-                   compute-not-bits(intersection(bits5, bits6), $huge-size));
+  let bits5-xor-bits6 = intersection(union(bits5, bits6),
+    compute-not-bits(intersection(bits5, bits6), $huge-size));
   let bits6-xor-bits5 = bits5-xor-bits6;
 
   // Xor two all-zero vectors together with different pad values
@@ -229,10 +226,10 @@ define test bit-vector-xor-huge-vector ()
   //
   test-xor-for-all-pad-values("Xor an all-one and mixed vector",
     $huge-size, vector3, vector5,
-      not-bits5, not-bits5, not-bits5, not-bits5);
+    not-bits5, not-bits5, not-bits5, not-bits5);
   test-xor-for-all-pad-values("Xor a mixed and all-one vector",
     $huge-size, vector5, vector3,
-      not-bits5, not-bits5, not-bits5, not-bits5);
+    not-bits5, not-bits5, not-bits5, not-bits5);
 
   // Xor two mixed vectors together with different pad values
   //
@@ -261,9 +258,8 @@ define test bit-vector-xor-multiple-word-vector ()
   let vector6 = make(<bit-vector>, size: $multiple-word-size, fill: 1);
   unset-bits(vector6, not-bits6);
 
-  let bits5-xor-bits6
-    = intersection(union(bits5, bits6),
-                   compute-not-bits(intersection(bits5, bits6), $multiple-word-size));
+  let bits5-xor-bits6 = intersection(union(bits5, bits6),
+    compute-not-bits(intersection(bits5, bits6), $multiple-word-size));
   let bits6-xor-bits5 = bits5-xor-bits6;
 
   // Xor two all-zero vectors together with different pad values
@@ -300,10 +296,10 @@ define test bit-vector-xor-multiple-word-vector ()
   //
   test-xor-for-all-pad-values("Xor an all-one and mixed vector",
     $multiple-word-size, vector3, vector5,
-      not-bits5, not-bits5, not-bits5, not-bits5);
+    not-bits5, not-bits5, not-bits5, not-bits5);
   test-xor-for-all-pad-values("Xor a mixed and all-one vector",
     $multiple-word-size, vector5, vector3,
-      not-bits5, not-bits5, not-bits5, not-bits5);
+    not-bits5, not-bits5, not-bits5, not-bits5);
 
   // Xor two mixed vectors together with different pad values
   //

--- a/sources/collections/tests/bit-vector-xor.dylan
+++ b/sources/collections/tests/bit-vector-xor.dylan
@@ -7,30 +7,30 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define method test-xor-for-all-pad-values
-    (prefix :: <string>, vector1 :: <bit-vector>, vector2 :: <bit-vector>,
+    (prefix :: <string>,
+     size :: <integer>, vector1 :: <bit-vector>, vector2 :: <bit-vector>,
      bits00, bits01, bits10, bits11)
  => ()
   let (result, pad) = bit-vector-xor(vector1, vector2);
   check-equal(concatenate(prefix, ", pad1=0, pad2=0: result pad"), pad, 0);
   bit-vector-consistency-checks(concatenate(prefix, ", pad1=0, pad2=0"),
-    result, $tiny-size, bits00);
+    result, size, bits00);
 
   let (result, pad) = bit-vector-xor(vector1, vector2, pad1: 0, pad2: 1);
   check-equal(concatenate(prefix, ", pad1=0, pad2=0: result pad"), pad, 1);
   bit-vector-consistency-checks(concatenate(prefix, ", pad1=0, pad2=1"),
-    result, $tiny-size, bits01);
+    result, size, bits01);
 
   let (result, pad) = bit-vector-xor(vector1, vector2, pad1: 1, pad2: 0);
   check-equal(concatenate(prefix, ", pad1=1, pad2=0: result pad"), pad, 1);
   bit-vector-consistency-checks(concatenate(prefix, ", pad1=1, pad2=0"),
-    result, $tiny-size, bits10);
+    result, size, bits10);
 
   let (result, pad) = bit-vector-xor(vector1, vector2, pad1: 1, pad2: 1);
   check-equal(concatenate(prefix, ", pad1=1, pad2=1: result pad"), pad, 0);
   bit-vector-consistency-checks(concatenate(prefix, ", pad1=1, pad2=1"),
-    result, $tiny-size, bits11);
+    result, size, bits11);
 end method;
-
 
 define test bit-vector-xor-tiny-vector
     (description: "Test bit-vector-andc2 with tiny sized bit-vectors")
@@ -40,13 +40,13 @@ define test bit-vector-xor-tiny-vector
   let vector3 = make(<bit-vector>, size: $tiny-size, fill: 1);
   let vector4 = make(<bit-vector>, size: $tiny-size, fill: 1);
 
-  let bits5 = list(2, 3, 5, 7, 11, 13);
-  let not-bits5 = list(0, 1, 4, 6, 8, 9, 10, 12);
+  let bits5 = list(2, 3);
+  let not-bits5 = list(0, 1);
   let vector5 = make(<bit-vector>, size: $tiny-size);
   set-bits(vector5, bits5);
 
-  let bits6 = list(1, 3, 6, 7, 9, 10, 12, 13);
-  let not-bits6 = list(0, 2, 4, 5, 8, 11);
+  let bits6 = list(1, 3);
+  let not-bits6 = list(0, 2);
   let vector6 = make(<bit-vector>, size: $tiny-size, fill: 1);
   unset-bits(vector6, not-bits6);
 
@@ -58,54 +58,275 @@ define test bit-vector-xor-tiny-vector
   // Xor two all-zero vectors together with different pad values
   //
   test-xor-for-all-pad-values("Xor two all-zero vectors",
-    vector1, vector2,
+    $tiny-size, vector1, vector2,
     #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
 
   // Xor two all-one vectors together with different pad values
   //
   test-xor-for-all-pad-values("Xor two all-one vectors",
-    vector3, vector4,
+    $tiny-size, vector3, vector4,
     #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
 
   // Xor an all-zero and all-one vector together with different pad values
   //
   test-xor-for-all-pad-values("Xor an all-one and all-zero vector",
-    vector1, vector3,
+    $tiny-size, vector1, vector3,
     #"all-ones", #"all-ones", #"all-ones", #"all-ones");
   test-xor-for-all-pad-values("Xor an all-zero and all-one vector",
-    vector3, vector1,
+    $tiny-size, vector3, vector1,
     #"all-ones", #"all-ones", #"all-ones", #"all-ones");
 
   // Xor an all-zero vector with a mixed vector and different pad values
   //
   test-xor-for-all-pad-values("Xor an all-zero and mixed vector",
-    vector1, vector5,
+    $tiny-size, vector1, vector5,
     bits5, bits5, bits5, bits5);
   test-xor-for-all-pad-values("Xor a mixed and all-zero vector",
-    vector5, vector1,
+    $tiny-size, vector5, vector1,
     bits5, bits5, bits5, bits5);
 
   // Xor an all-one vector with a mixed vector and different pad values
   //
   test-xor-for-all-pad-values("Xor an all-one and mixed vector",
-    vector3, vector5,
+    $tiny-size, vector3, vector5,
       not-bits5, not-bits5, not-bits5, not-bits5);
   test-xor-for-all-pad-values("Xor a mixed and all-one vector",
-    vector5, vector3,
+    $tiny-size, vector5, vector3,
       not-bits5, not-bits5, not-bits5, not-bits5);
 
   // Xor two mixed vectors together with different pad values
   //
   test-xor-for-all-pad-values("Xor two vectors",
-    vector5, vector6,
+    $tiny-size, vector5, vector6,
     bits5-xor-bits6, bits5-xor-bits6, bits5-xor-bits6, bits5-xor-bits6);
   test-xor-for-all-pad-values("Xor two vectors again, arguments reversed",
-    vector6, vector5,
+    $tiny-size, vector6, vector5,
     bits6-xor-bits5, bits6-xor-bits5, bits6-xor-bits5, bits6-xor-bits5);
 
 end test;
 
+define test bit-vector-xor-small-vector
+    (description: "Test bit-vector-andc2 with small sized bit-vectors")
+
+  let vector1 = make(<bit-vector>, size: $small-size);
+  let vector2 = make(<bit-vector>, size: $small-size);
+  let vector3 = make(<bit-vector>, size: $small-size, fill: 1);
+  let vector4 = make(<bit-vector>, size: $small-size, fill: 1);
+
+  let bits5 = list(2, 3, 5, 7, 11, 13);
+  let not-bits5 = list(0, 1, 4, 6, 8, 9, 10, 12);
+  let vector5 = make(<bit-vector>, size: $small-size);
+  set-bits(vector5, bits5);
+
+  let bits6 = list(1, 3, 6, 7, 9, 10, 12, 13);
+  let not-bits6 = list(0, 2, 4, 5, 8, 11);
+  let vector6 = make(<bit-vector>, size: $small-size, fill: 1);
+  unset-bits(vector6, not-bits6);
+
+  let bits5-xor-bits6
+    = intersection(union(bits5, bits6),
+                   compute-not-bits(intersection(bits5, bits6), $small-size));
+  let bits6-xor-bits5 = bits5-xor-bits6;
+
+  // Xor two all-zero vectors together with different pad values
+  //
+  test-xor-for-all-pad-values("Xor two all-zero vectors",
+    $small-size, vector1, vector2,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+
+  // Xor two all-one vectors together with different pad values
+  //
+  test-xor-for-all-pad-values("Xor two all-one vectors",
+    $small-size, vector3, vector4,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+
+  // Xor an all-zero and all-one vector together with different pad values
+  //
+  test-xor-for-all-pad-values("Xor an all-one and all-zero vector",
+    $small-size, vector1, vector3,
+    #"all-ones", #"all-ones", #"all-ones", #"all-ones");
+  test-xor-for-all-pad-values("Xor an all-zero and all-one vector",
+    $small-size, vector3, vector1,
+    #"all-ones", #"all-ones", #"all-ones", #"all-ones");
+
+  // Xor an all-zero vector with a mixed vector and different pad values
+  //
+  test-xor-for-all-pad-values("Xor an all-zero and mixed vector",
+    $small-size, vector1, vector5,
+    bits5, bits5, bits5, bits5);
+  test-xor-for-all-pad-values("Xor a mixed and all-zero vector",
+    $small-size, vector5, vector1,
+    bits5, bits5, bits5, bits5);
+
+  // Xor an all-one vector with a mixed vector and different pad values
+  //
+  test-xor-for-all-pad-values("Xor an all-one and mixed vector",
+    $small-size, vector3, vector5,
+      not-bits5, not-bits5, not-bits5, not-bits5);
+  test-xor-for-all-pad-values("Xor a mixed and all-one vector",
+    $small-size, vector5, vector3,
+      not-bits5, not-bits5, not-bits5, not-bits5);
+
+  // Xor two mixed vectors together with different pad values
+  //
+  test-xor-for-all-pad-values("Xor two vectors",
+    $small-size, vector5, vector6,
+    bits5-xor-bits6, bits5-xor-bits6, bits5-xor-bits6, bits5-xor-bits6);
+  test-xor-for-all-pad-values("Xor two vectors again, arguments reversed",
+    $small-size, vector6, vector5,
+    bits6-xor-bits5, bits6-xor-bits5, bits6-xor-bits5, bits6-xor-bits5);
+
+end test;
+
+define test bit-vector-xor-huge-vector
+    (description: "Test bit-vector-andc2 with huge sized bit-vectors")
+
+  let vector1 = make(<bit-vector>, size: $huge-size);
+  let vector2 = make(<bit-vector>, size: $huge-size);
+  let vector3 = make(<bit-vector>, size: $huge-size, fill: 1);
+  let vector4 = make(<bit-vector>, size: $huge-size, fill: 1);
+
+  let bits5 = random-elements($huge-size, seed: 189);
+  let not-bits5 = compute-not-bits(bits5, $huge-size);
+  let vector5 = make(<bit-vector>, size: $huge-size);
+  set-bits(vector5, bits5);
+
+  let bits6 = random-elements($huge-size, seed: 194);
+  let not-bits6 = compute-not-bits(bits6, $huge-size);
+  let vector6 = make(<bit-vector>, size: $huge-size, fill: 1);
+  unset-bits(vector6, not-bits6);
+
+  let bits5-xor-bits6
+    = intersection(union(bits5, bits6),
+                   compute-not-bits(intersection(bits5, bits6), $huge-size));
+  let bits6-xor-bits5 = bits5-xor-bits6;
+
+  // Xor two all-zero vectors together with different pad values
+  //
+  test-xor-for-all-pad-values("Xor two all-zero vectors",
+    $huge-size, vector1, vector2,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+
+  // Xor two all-one vectors together with different pad values
+  //
+  test-xor-for-all-pad-values("Xor two all-one vectors",
+    $huge-size, vector3, vector4,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+
+  // Xor an all-zero and all-one vector together with different pad values
+  //
+  test-xor-for-all-pad-values("Xor an all-one and all-zero vector",
+    $huge-size, vector1, vector3,
+    #"all-ones", #"all-ones", #"all-ones", #"all-ones");
+  test-xor-for-all-pad-values("Xor an all-zero and all-one vector",
+    $huge-size, vector3, vector1,
+    #"all-ones", #"all-ones", #"all-ones", #"all-ones");
+
+  // Xor an all-zero vector with a mixed vector and different pad values
+  //
+  test-xor-for-all-pad-values("Xor an all-zero and mixed vector",
+    $huge-size, vector1, vector5,
+    bits5, bits5, bits5, bits5);
+  test-xor-for-all-pad-values("Xor a mixed and all-zero vector",
+    $huge-size, vector5, vector1,
+    bits5, bits5, bits5, bits5);
+
+  // Xor an all-one vector with a mixed vector and different pad values
+  //
+  test-xor-for-all-pad-values("Xor an all-one and mixed vector",
+    $huge-size, vector3, vector5,
+      not-bits5, not-bits5, not-bits5, not-bits5);
+  test-xor-for-all-pad-values("Xor a mixed and all-one vector",
+    $huge-size, vector5, vector3,
+      not-bits5, not-bits5, not-bits5, not-bits5);
+
+  // Xor two mixed vectors together with different pad values
+  //
+  test-xor-for-all-pad-values("Xor two vectors",
+    $huge-size, vector5, vector6,
+    bits5-xor-bits6, bits5-xor-bits6, bits5-xor-bits6, bits5-xor-bits6);
+  test-xor-for-all-pad-values("Xor two vectors again, arguments reversed",
+    $huge-size, vector6, vector5,
+    bits6-xor-bits5, bits6-xor-bits5, bits6-xor-bits5, bits6-xor-bits5);
+
+end test;
+
+define test bit-vector-xor-multiple-word-vector
+    (description: "Test bit-vector-andc2 with multiple-word sized bit-vectors")
+
+  let vector1 = make(<bit-vector>, size: $multiple-word-size);
+  let vector2 = make(<bit-vector>, size: $multiple-word-size);
+  let vector3 = make(<bit-vector>, size: $multiple-word-size, fill: 1);
+  let vector4 = make(<bit-vector>, size: $multiple-word-size, fill: 1);
+
+  let bits5 = random-elements($multiple-word-size, seed: 262);
+  let not-bits5 = compute-not-bits(bits5, $multiple-word-size);
+  let vector5 = make(<bit-vector>, size: $multiple-word-size);
+  set-bits(vector5, bits5);
+
+  let bits6 = random-elements($multiple-word-size, seed: 267);
+  let not-bits6 = compute-not-bits(bits6, $multiple-word-size);
+  let vector6 = make(<bit-vector>, size: $multiple-word-size, fill: 1);
+  unset-bits(vector6, not-bits6);
+
+  let bits5-xor-bits6
+    = intersection(union(bits5, bits6),
+                   compute-not-bits(intersection(bits5, bits6), $multiple-word-size));
+  let bits6-xor-bits5 = bits5-xor-bits6;
+
+  // Xor two all-zero vectors together with different pad values
+  //
+  test-xor-for-all-pad-values("Xor two all-zero vectors",
+    $multiple-word-size, vector1, vector2,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+
+  // Xor two all-one vectors together with different pad values
+  //
+  test-xor-for-all-pad-values("Xor two all-one vectors",
+    $multiple-word-size, vector3, vector4,
+    #"all-zeros", #"all-zeros", #"all-zeros", #"all-zeros");
+
+  // Xor an all-zero and all-one vector together with different pad values
+  //
+  test-xor-for-all-pad-values("Xor an all-one and all-zero vector",
+    $multiple-word-size, vector1, vector3,
+    #"all-ones", #"all-ones", #"all-ones", #"all-ones");
+  test-xor-for-all-pad-values("Xor an all-zero and all-one vector",
+    $multiple-word-size, vector3, vector1,
+    #"all-ones", #"all-ones", #"all-ones", #"all-ones");
+
+  // Xor an all-zero vector with a mixed vector and different pad values
+  //
+  test-xor-for-all-pad-values("Xor an all-zero and mixed vector",
+    $multiple-word-size, vector1, vector5,
+    bits5, bits5, bits5, bits5);
+  test-xor-for-all-pad-values("Xor a mixed and all-zero vector",
+    $multiple-word-size, vector5, vector1,
+    bits5, bits5, bits5, bits5);
+
+  // Xor an all-one vector with a mixed vector and different pad values
+  //
+  test-xor-for-all-pad-values("Xor an all-one and mixed vector",
+    $multiple-word-size, vector3, vector5,
+      not-bits5, not-bits5, not-bits5, not-bits5);
+  test-xor-for-all-pad-values("Xor a mixed and all-one vector",
+    $multiple-word-size, vector5, vector3,
+      not-bits5, not-bits5, not-bits5, not-bits5);
+
+  // Xor two mixed vectors together with different pad values
+  //
+  test-xor-for-all-pad-values("Xor two vectors",
+    $multiple-word-size, vector5, vector6,
+    bits5-xor-bits6, bits5-xor-bits6, bits5-xor-bits6, bits5-xor-bits6);
+  test-xor-for-all-pad-values("Xor two vectors again, arguments reversed",
+    $multiple-word-size, vector6, vector5,
+    bits6-xor-bits5, bits6-xor-bits5, bits6-xor-bits5, bits6-xor-bits5);
+
+end test;
 
 define suite bit-vector-xor-suite ()
   test bit-vector-xor-tiny-vector;
+  test bit-vector-xor-small-vector;
+  test bit-vector-xor-huge-vector;
+  test bit-vector-xor-multiple-word-vector;
 end suite;

--- a/sources/collections/tests/copy-sequence.dylan
+++ b/sources/collections/tests/copy-sequence.dylan
@@ -7,28 +7,54 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define test copy-sequence-tiny-vector ()
-  let bits = list(2, 3, 5, 7, 11, 13);
+  let bits = list(2, 3);
   let vector = make(<bit-vector>, size: $tiny-size);
   set-bits(vector, bits);
 
   // Copy whole thing
   let new-vector = copy-sequence(vector);
-  bit-vector-consistency-checks("Copy whole tiny vector",
+  bit-vector-consistency-checks("Copy whole small vector",
     new-vector, $tiny-size, bits);
 
   // Copy from start to limit
+  let new-vector = copy-sequence(vector, end: 2);
+  bit-vector-consistency-checks("Copy small vector below bit 2",
+    new-vector, 2, list());
+
+  // Copy from limit to end
+  let new-vector = copy-sequence(vector, start: 2);
+  bit-vector-consistency-checks("Copy small vector from bit 2",
+    new-vector, 2, list(0, 1));
+
+  // Copy with both limits inside
+  let new-vector = copy-sequence(vector, start: 1, end: 3);
+  bit-vector-consistency-checks("Copy small vector between bits 1 and 3",
+    new-vector, 2, list(1));
+end test;
+
+define test copy-sequence-small-vector ()
+  let bits = list(2, 3, 5, 7, 11, 13);
+  let vector = make(<bit-vector>, size: $small-size);
+  set-bits(vector, bits);
+
+  // Copy whole thing
+  let new-vector = copy-sequence(vector);
+  bit-vector-consistency-checks("Copy whole small vector",
+    new-vector, $small-size, bits);
+
+  // Copy from start to limit
   let new-vector = copy-sequence(vector, end: 8);
-  bit-vector-consistency-checks("Copy tiny vector below bit 8",
+  bit-vector-consistency-checks("Copy small vector below bit 8",
     new-vector, 8, list(2, 3, 5, 7));
 
   // Copy from limit to end
   let new-vector = copy-sequence(vector, start: 5);
-  bit-vector-consistency-checks("Copy tiny vector from bit 5",
-    new-vector, $tiny-size - 5, list(0, 2, 6, 8));
+  bit-vector-consistency-checks("Copy small vector from bit 5",
+    new-vector, $small-size - 5, list(0, 2, 6, 8));
 
   // Copy with both limits inside
   let new-vector = copy-sequence(vector, start: 4, end: 11);
-  bit-vector-consistency-checks("Copy tiny vector between bits 4 and 11",
+  bit-vector-consistency-checks("Copy small vector between bits 4 and 11",
     new-vector, 7, list(1, 3));
 end test;
 
@@ -66,5 +92,6 @@ end test;
 
 define suite copy-sequence-suite()
   test copy-sequence-tiny-vector;
+  test copy-sequence-small-vector;
   test copy-sequence-huge-vector;
 end suite;

--- a/sources/collections/tests/fill.dylan
+++ b/sources/collections/tests/fill.dylan
@@ -15,43 +15,74 @@ end test;
 
 define test fill-tiny-vector ()
   let vector :: <bit-vector> = make(<bit-vector>, size: $tiny-size);
+  let bits = list(0, 2);
+  set-bits(vector, bits);
+
+  check-equal("fill!(vector, 1, start: 6, end: 9)",
+    fill!(vector, 1, start: 2, end: 4), vector);
+  bit-vector-consistency-checks("fill!(vector, 1, start:2, end: 4)",
+    vector, $tiny-size, list(0, 2, 3));
+
+  check-equal("fill!(vector, 1, start: 4)",
+    fill!(vector, 1, start: 4), vector);
+  bit-vector-consistency-checks("fill!(vector, 1, start: 4",
+    vector, $tiny-size, list(0, 2, 3));
+
+  check-equal("fill!(vector, 0, end: 7)",
+    fill!(vector, 0, end: 7), vector);
+  bit-vector-consistency-checks("fill!(vector, 0, end: 7)",
+    vector, $tiny-size, list());
+
+  check-equal("fill!(vector, 0, start: 0, end: $tiny-size)",
+    fill!(vector, 0, start: 0, end: $tiny-size), vector);
+  bit-vector-consistency-checks("fill!(vector, 0, start: 0, end: $small-size)",
+    vector, $tiny-size, #"all-zeros");
+
+  check-equal("fill!(vector, 0)",
+    fill!(vector, 0), vector);
+  bit-vector-consistency-checks("fill!(vector, 0)",
+    vector, $tiny-size, #"all-zeros");
+end test;
+
+define test fill-small-vector ()
+  let vector :: <bit-vector> = make(<bit-vector>, size: $small-size);
   let bits = list(0, 10);
   set-bits(vector, bits);
 
   check-equal("fill!(vector, 1, start: 6, end: 9)",
     fill!(vector, 1, start: 6, end: 9), vector);
   bit-vector-consistency-checks("fill!(vector, 1, start:6, end: 9)",
-    vector, $tiny-size, list(0, 6, 7, 8, 10));
+    vector, $small-size, list(0, 6, 7, 8, 10));
 
   check-equal("fill!(vector, 1, start: 4)",
     fill!(vector, 1, start: 4), vector);
   bit-vector-consistency-checks("fill!(vector, 1, start: 4",
-    vector, $tiny-size, list(0, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13));
+    vector, $small-size, list(0, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13));
 
   check-equal("fill!(vector, 0, end: 7)",
     fill!(vector, 0, end: 7), vector);
   bit-vector-consistency-checks("fill!(vector, 0, end: 7)",
-    vector, $tiny-size, list(7, 8, 9, 10, 11, 12, 13));
+    vector, $small-size, list(7, 8, 9, 10, 11, 12, 13));
 
-  check-equal("fill!(vector, 0, start: 0, end: $tiny-size)",
-    fill!(vector, 0, start: 0, end: $tiny-size), vector);
-  bit-vector-consistency-checks("fill!(vector, 0, start: 0, end: $tiny-size)",
-    vector, $tiny-size, #"all-zeros");
+  check-equal("fill!(vector, 0, start: 0, end: $small-size)",
+    fill!(vector, 0, start: 0, end: $small-size), vector);
+  bit-vector-consistency-checks("fill!(vector, 0, start: 0, end: $small-size)",
+    vector, $small-size, #"all-zeros");
 
   check-equal("fill!(vector, 1, start: 0, end: 8)",
     fill!(vector, 1, start: 0, end: 8), vector);
   bit-vector-consistency-checks("fill!(vector, 1, start: 0, end: 8)",
-    vector, $tiny-size, list(0, 1, 2, 3, 4, 5, 6, 7));
+    vector, $small-size, list(0, 1, 2, 3, 4, 5, 6, 7));
 
-  check-equal("fill!(vector, 1, start: 6, end: $tiny-size)",
-    fill!(vector, 1, start: 6, end: $tiny-size), vector);
-  bit-vector-consistency-checks("fill!(vector, 1, start: 6, end: $tiny-size)",
-    vector, $tiny-size, #"all-ones");
+  check-equal("fill!(vector, 1, start: 6, end: $small-size)",
+    fill!(vector, 1, start: 6, end: $small-size), vector);
+  bit-vector-consistency-checks("fill!(vector, 1, start: 6, end: $small-size)",
+    vector, $small-size, #"all-ones");
 
   check-equal("fill!(vector, 0)",
     fill!(vector, 0), vector);
   bit-vector-consistency-checks("fill!(vector, 0)",
-    vector, $tiny-size, #"all-zeros");
+    vector, $small-size, #"all-zeros");
 end test;
 
 
@@ -104,5 +135,6 @@ end test;
 
 define suite fill-suite (description: "Tests for fill!")
   test fill-tiny-vector;
+  test fill-small-vector;
   test fill-huge-vector;
 end suite;

--- a/sources/collections/tests/fill.dylan
+++ b/sources/collections/tests/fill.dylan
@@ -133,7 +133,7 @@ define test fill-huge-vector ()
 end test;
 
 
-define suite fill-suite (description: "Tests for fill!")
+define suite fill-suite ()
   test fill-tiny-vector;
   test fill-small-vector;
   test fill-huge-vector;


### PR DESCRIPTION
This PR is long-winded but straightforward. There were some unimplemented tests for bit-vectors (i.e. tests without any checks in them) and some that seemed to be missing altogether. The plan seemed to be run the basic tests (and, or, xor, etc.) on vectors which were 'tiny', 'small', 'huge' and 'multiple-word' sized. Tiny and small were the same so I made tiny to be 4 bits then we are testing vectors that are smaller than one byte. Huge vectors (117 bits) are larger than any current machine word and small vectors (14 bits) are intermediate. Multiple-word sized vectors remain 96 bits.