### PR TITLE
Make test-suite compile for C back end

### DIFF
--- a/sources/dylan/tests/constants.dylan
+++ b/sources/dylan/tests/constants.dylan
@@ -8,7 +8,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 // Helper function to force evaluation at run-time,
 // instead of compile-time.
-define function run-time (x)
+define not-inline function run-time (x)
   x
 end function run-time;
 

--- a/sources/dylan/tests/constants.dylan
+++ b/sources/dylan/tests/constants.dylan
@@ -6,6 +6,12 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
+// Helper function to force evaluation at run-time,
+// instead of compile-time.
+define function run-time (x)
+  x
+end function run-time;
+
 /// Constant testing
 
 define dylan constant-test $permanent-hash-state ()
@@ -16,12 +22,12 @@ define dylan-extensions constant-test $minimum-integer ()
   //---*** Add some more tests here...
   check-condition("$minimum-integer - 1 overflows",
 		  <error>,
-		  $minimum-integer - 1)
+		  $minimum-integer - run-time(1))
 end constant-test $minimum-integer;
 
 define dylan-extensions constant-test $maximum-integer ()
   //---*** Add some more tests here...
   check-condition("$maximum-integer + 1 overflows",
 		  <error>,
-		  $maximum-integer + 1)
+		  $maximum-integer + run-time(1))
 end constant-test $maximum-integer;


### PR DESCRIPTION
At the moment, compiling the `libraries-test-suite-app` fails because the C back end creates a constant that is too big for the compiler to handle (reported as #1105)
This PR is not a fix for that but it does make the arithmetic happen at run-time, which means building the test-suite completes successfully, although the test itself does still fail 

    dylan-extensions-protocol-constants-test failed
      $maximum-integer + 1 overflows failed [no condition signaled]
      $minimum-integer - 1 overflows failed [no condition signaled]

The proper fix for #1105 will take a bit more thought, I believe.