### PR TITLE
Fix LLVM dispatch cache

### DIFF
--- a/sources/dfmc/llvm-back-end/llvm-entry-points.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-entry-points.dylan
@@ -1533,16 +1533,16 @@ end entry-point-descriptor;
 // Terminals
 
 define singular variable-arity outer entry-point-descriptor general-engine-node-n
-    (engine :: <engine-node>, function :: <generic-function>)
+    (engine :: <engine-node>, parent :: <generic-function>)
  => (#rest values);
   let word-size = back-end-word-size(be);
 
   // Identify the corresponding generic function
-  let parent = op--parent-gf(be, function);
+  let function = op--parent-gf(be, parent);
 
   // Extract the gf's signature
   let gf-class :: <&class> = dylan-value(#"<generic-function>");
-  let gf-cast = op--object-pointer-cast(be, parent, gf-class);
+  let gf-cast = op--object-pointer-cast(be, function, gf-class);
   let signature-slot-ptr
     = op--getslotptr(be, gf-cast, gf-class, #"function-signature");
   let signature = ins--load(be, signature-slot-ptr, alignment: word-size);
@@ -1640,17 +1640,17 @@ define singular outer entry-point-descriptor general-engine-node-3
 end entry-point-descriptor;
 
 define singular variable-arity outer entry-point-descriptor general-engine-node-spread
-    (engine :: <engine-node>, function :: <generic-function>)
+    (engine :: <engine-node>, parent :: <generic-function>)
  => (#rest values);
   let module = be.llvm-builder-module;
   let word-size = back-end-word-size(be);
 
   // Identify the corresponding generic function
-  let parent = op--parent-gf(be, function);
+  let function = op--parent-gf(be, parent);
 
   // Extract the gf's signature
   let gf-class :: <&class> = dylan-value(#"<generic-function>");
-  let gf-cast = op--object-pointer-cast(be, parent, gf-class);
+  let gf-cast = op--object-pointer-cast(be, function, gf-class);
   let signature-slot-ptr
     = op--getslotptr(be, gf-cast, gf-class, #"function-signature");
   let signature = ins--load(be, signature-slot-ptr, alignment: word-size);

--- a/sources/dylan/discrimination.dylan
+++ b/sources/dylan/discrimination.dylan
@@ -168,7 +168,9 @@ define function subst-engine-node-1 (new-e, old-e, ds :: <dispatch-state>) => ()
       for (i :: <integer> from 0 below size(vec))
         engine-node-subster(new-e, old-e, vector-element(vec, i))
       end for;
-      for (e :: <cache-header-engine-node> in gf-cache-info-users(cache))
+      for (e :: false-or(<cache-header-engine-node>)
+             in gf-cache-info-users(cache),
+           while?: e)
         if (pointer-id?(cache-header-engine-node-next(e), old-e))
           cache-header-engine-node-next(e) := new-e
         end if

--- a/sources/dylan/generic-function.dylan
+++ b/sources/dylan/generic-function.dylan
@@ -165,7 +165,8 @@ define method decache-gf (g :: <generic-function>) => ()
   let cache = %gf-cache(g);
   if (instance?(cache, <gf-cache-info>))
     let cache :: <gf-cache-info> = cache;
-    for (x in gf-cache-info-users(cache))
+    for (x :: false-or(<cache-header-engine-node>)
+           in gf-cache-info-users(cache))
       if (x)
         let x :: <cache-header-engine-node> = x;
         cache-header-engine-node-next(x) := $absent-engine-node;


### PR DESCRIPTION
These commits fix a longstanding bug in the generated engine node entry points which prevented per-call-site dispatch caches from being maintained. A fix for an incorrect type declaration in the dispatch cache code, now necessary because the LLVM back-end does not omit type checks within the Dylan library, is also included..
