### PR TITLE
common-dylan: Remove simple-io module

### DIFF
--- a/documentation/release-notes/source/2019.2.rst
+++ b/documentation/release-notes/source/2019.2.rst
@@ -47,6 +47,9 @@ dylan Library
 common-dylan Library
 --------------------
 
+* The simple-io module has been removed.  This module was deprecated in Open
+  Dylan 2014.1 and is replaced by the simple-format module.
+
 
 io Library
 ----------

--- a/sources/common-dylan/library.dylan
+++ b/sources/common-dylan/library.dylan
@@ -22,7 +22,6 @@ define library common-dylan
     simple-profiling,
     simple-timers,
     simple-format,
-    simple-io,
     byte-vector,
     transcendentals;
 end library common-dylan;
@@ -147,10 +146,6 @@ define module simple-format
   create format-out,
          format-to-string;
 end module simple-format;
-
-define module simple-io
-  use simple-format, export: all;
-end module simple-io;
 
 define module simple-random
   create <random>,


### PR DESCRIPTION
This was deprecated in 2014.1 and is replaced by the simple-format module.