### PR TITLE
[Doc] Intro to Dylan: Add DRM links

### DIFF
--- a/documentation/intro-dylan/source/conditions.rst
+++ b/documentation/intro-dylan/source/conditions.rst
@@ -16,7 +16,7 @@ Signaling
 
 Unlike the exceptions of C++ or Java, signaling a condition does *not* itself
 cause the current function or block to exit. Instead, calling the :drm:`signal`
-function is just like calling any other function. The ``signal`` function just
+function is just like calling any other function. The :drm:`signal` function just
 locates an appropriate handler and calls it normally.
 
 One consequence of this is that a handler can signal another condition in a very
@@ -45,7 +45,7 @@ Handlers
 A function :term:`establishes a handler` with the :drm:`let handler
 <let_handler>` statement. The handler remains in effect until the function
 exits. Other functions called by the first can establish new handlers. When the
-``signal`` function looks for a handler, it looks for the most recently
+:drm:`signal` function looks for a handler, it looks for the most recently
 established handler that fits the condition.
 
 In the example above, there are two handlers: ``handle-no-person-found`` and
@@ -53,7 +53,7 @@ In the example above, there are two handlers: ``handle-no-person-found`` and
 condition. Let us assume that the ``find-person-or-pet`` function established
 the ``handle-no-person-found`` handler and that the ``find-pet`` function
 established the ``handle-no-pet-found`` handler. Since ``handle-no-pet-found``
-was established later, it was the one chosen and called by ``signal`` in frame
+was established later, it was the one chosen and called by :drm:`signal` in frame
 3.
 
 The code to establish the handlers may have looked like this:
@@ -74,22 +74,22 @@ techniques.
 Returning from ``signal``
 -------------------------
 
-Because a ``signal`` call is just like any other function call, it can return
+Because a :drm:`signal` call is just like any other function call, it can return
 values. It returns whatever values the handler function returns. In the above
-example, ``signal`` never returns because we break into the debugger, and the
-``element`` function wouldn't do anything with the value if it did return, but
-your own code could call ``signal`` and handle any return values appropriately.
+example, :drm:`signal` never returns because we break into the debugger, and the
+:drm:`element` function wouldn't do anything with the value if it did return, but
+your own code could call :drm:`signal` and handle any return values appropriately.
 
 This technique allows you to use conditions as a sort of callback. You can
 establish a condition handler that returns a rarely-needed value, and another
 deeply nested function could retrieve that value if needed by signaling that
-condition and then taking the return value of the ``signal`` function.
+condition and then taking the return value of the :drm:`signal` function.
 
 Restart handlers
 ----------------
 
 You can recover from a problem by returning a fall-back value from the
-``signal`` function, but that technique has limitations. It does not provide
+:drm:`signal` function, but that technique has limitations. It does not provide
 much encapsulation or allow for complicated recovery information, and the
 recovery information has to be processed locally.
 
@@ -109,7 +109,7 @@ goldfish and signal a different condition instead, but other callers may
 establish different restart handlers with the appropriate behavior.
 
 Regardless, when the restart handler finishes, it returns, and then its caller
-returns, and so on until the original ``signal`` function returns, at which
+returns, and so on until the original :drm:`signal` function returns, at which
 point the program resumes work where it left off. You cannot use restart
 handlers or conditions to escape the program's normal flow of control. For that,
 Dylan offers blocks.
@@ -127,11 +127,11 @@ might appear as follows:
       1 + 1
     end; // returns 2
 
-But in addition to returning a value normally, a block can use a :term:`nonlocal
-exit`. This allows the block to exit at any time, optionally returning a value.
+But in addition to returning a value normally, a :drm:`block` can use a :term:`nonlocal
+exit`. This allows the :drm:`block` to exit at any time, optionally returning a value.
 In some ways, it is similar to the ``goto`` statement, the ``break`` statement,
 or the POSIX ``longjmp`` function. To use a nonlocal exit,
-specify a name in the parentheses following a ``block`` statement. Dylan
+specify a name in the parentheses following a :drm:`block` statement. Dylan
 binds this name to an :term:`exit function` which can be
 called from anywhere within the block or the functions it calls. The
 following block returns either ``"Weird!"`` or ``"All's well."``,
@@ -147,10 +147,10 @@ depending on the color of the sky.
     end block;
 
 Many programs need to dispose of resources or perform other cleanup work when
-exiting a block. The block may contain optional ``afterwards`` and ``cleanup``
-clauses. Neither affects the block's return value. The ``afterwards`` clause
+exiting a block. The block may contain optional :drm:`afterwards <block>` and :drm:`cleanup`
+clauses. Neither affects the block's return value. The :drm:`afterwards <block>` clause
 executes if the block ends normally without using its nonlocal exit, and the
-``cleanup`` clause executes when the block ends whether it ends normally or via
+:drm:`cleanup` clause executes when the block ends whether it ends normally or via
 nonlocal exit.
 
 .. code-block:: dylan
@@ -171,13 +171,13 @@ nonlocal exit.
 Blocks and conditions
 ---------------------
 
-In addition to the ``afterwards`` and ``cleanup`` clauses, a block may also
+In addition to the :drm:`afterwards <block>` and :drm:`cleanup` clauses, a block may also
 contain any number of ``exception`` clauses. The exception clauses establish handlers for
-a condition much like the ``let handler`` statement, but before they run the
+a condition much like the :drm:`let handler <let_handler>` statement, but before they run the
 handler calls the block's exit procedure and takes a nonlocal exit. In other
-words, it takes a short cut out of the normal flow of control. The ``signal``
+words, it takes a short cut out of the normal flow of control. The :drm:`signal`
 function that signaled the condition never returns to its caller. Instead, the
-program resumes execution after the block.
+program resumes execution after the :drm:`block`.
 
 The end result is similar to the ``try...catch...finally`` statements of C++ or
 Java:

--- a/documentation/intro-dylan/source/copyright.rst
+++ b/documentation/intro-dylan/source/copyright.rst
@@ -4,7 +4,7 @@ Copyright
 
 Copyright © 1995, 1996, 1998, 1999 Eric Kidd
 
-Copyright © 2002, 2003, 2004, 2011, 2012 The Dylan Hackers
+Copyright © 2002, 2003, 2004, 2011, 2012, 2019 The Dylan Hackers
 
 Companies, names and data used in examples herein are fictitious unless
 otherwise noted.

--- a/documentation/intro-dylan/source/expressions-variables.rst
+++ b/documentation/intro-dylan/source/expressions-variables.rst
@@ -32,9 +32,9 @@ support a number of standard naming conventions, as shown in this table:
 +-----------------+-----------------------------------------------------+
 | :drm:`<string>` | a class                                             |
 +-----------------+-----------------------------------------------------+
-| ``insert!``     | mutative function (modifies argument destructively) |
+| :drm:`add!`     | mutative function (modifies argument destructively) |
 +-----------------+-----------------------------------------------------+
-| ``empty?``      | predicate function (tests one or more arguments and |
+| :drm:`empty?`   | predicate function (tests one or more arguments and |
 |                 | returns either true or false)                       |
 +-----------------+-----------------------------------------------------+
 | ``write-line``  | a two word name                                     |
@@ -47,8 +47,8 @@ support a number of standard naming conventions, as shown in this table:
 True and False
 ==============
 
-Dylan represents true as ``#t`` and false as ``#f``. When evaluated in
-a Boolean context, all values other than ``#f`` are considered
+Dylan represents true as :drm:`#t` and false as :drm:`#f`. When evaluated in
+a Boolean context, all values other than :drm:`#f` are considered
 true. Thus, the number zero -- and other common "false" values --
 evaluate as true in Dylan.
 
@@ -103,14 +103,14 @@ Assignment, Equality and Identity
 
 Dylan uses all three of the "equals" operators
 found in C and Pascal, albeit in a different fashion. The
-assignment operator, ``:=``, rebinds Dylan variable
-names to new values. The equality operator, ``=``,
+assignment operator, :drm:`:=`, rebinds Dylan variable
+names to new values. The equality operator, :drm:`=`,
 tests for equality in Dylan and also appears in some
-language constructs such as ``let``. (Two Dylan objects
+language constructs such as :drm:`let`. (Two Dylan objects
 are equal, generally, if they belong to the same class and have equal
 substructure.)
 
-The C++ equality operator, ``==``, acts as the
+The C++ equality operator, :drm:`==`, acts as the
 :term:`identity` operator in Dylan. Two variables are
 :term:`identical` if and only if they are bound to the
 exact same object. For example, the following three expressions mean
@@ -159,7 +159,7 @@ Parallel Values
 ===============
 
 It's possible to bind more than one variable at a time in Dylan.
-For example, a single ``let`` statement could bind
+For example, a single :drm:`let` statement could bind
 ``x`` to 2, ``y`` to 3 and ``z`` to 4.
 
 .. code-block:: dylan
@@ -200,9 +200,9 @@ Module Variables and Constants
 
 Dylan supports :term:`module-level` variables,
 which serve roughly the same purpose as C's global variables. Although
-the ``let`` function may only be used within :term:`methods`
-(Dylan-speak for regular functions), the forms ``define variable`` and
-``define constant`` may be used at module top level.
+the :drm:`let` function may only be used within :term:`methods`
+(Dylan-speak for regular functions), the forms :drm:`define variable <define_variable>` and
+:drm:`define constant <define_constant>` may be used at module top level.
 
 .. code-block:: dylan
 

--- a/documentation/intro-dylan/source/methods-generic-functions.rst
+++ b/documentation/intro-dylan/source/methods-generic-functions.rst
@@ -24,7 +24,7 @@ above code more clear, the function could be rewritten as follows:
     end method;
 
 There have been two changes. The function now officially returns
-no values whatsoever. Also note that ``end`` has been
+no values whatsoever. Also note that :drm:`end` has been
 replaced by ``end method`` which could in turn be
 rewritten as ``end method hello-world``. In general,
 Dylan permits all the obvious combinations of keywords and labels to
@@ -49,7 +49,7 @@ must have its own type declaration; there's no syntax for saying
 "the last three parameters are all integers".
 
 Functions with variable numbers of parameters include the
-``#rest`` keyword in their parameter lists.
+:drm:`#rest` keyword in their parameter lists.
 Thus, the declaration for C's ``printf`` function
 would appear something like the following in Dylan:
 
@@ -123,7 +123,7 @@ Bare Methods
 Nameless methods may be declared inline. Such :term:`bare methods` are
 typically used as parameters to other methods.  For example, the
 following code fragment squares each element of a list using the built
-in ``map`` function and a bare method:
+in :drm:`map` function and a bare method:
 
 .. code-block:: dylan
 
@@ -131,7 +131,7 @@ in ``map`` function and a bare method:
       map(method(x) x * x end, numbers);
     end;
 
-The ``map`` function takes each element of
+The :drm:`map` function takes each element of
 the list ``numbers`` and applies the anonymous method. It
 then builds a new list using the resulting values and returns it.
 The method ``square-list`` might be invoked as
@@ -147,7 +147,7 @@ follows:
 Local Methods
 =============
 
-Local methods resemble bare methods but have names. They are
+:drm:`Local methods <local_method>` resemble bare methods but have names. They are
 declared within other methods, often as private utility routines.
 
 .. code-block:: dylan
@@ -191,8 +191,8 @@ Generic Functions
 =================
 
 A :term:`generic function` represents zero or more
-similar methods. Every method created by means of ``define
-method`` is automatically :term:`contained`
+similar methods. Every method created by means of :drm:`define
+method <define_method>` is automatically :term:`contained`
 within the generic function of the same name. For example, a 
 programmer could define three methods named ``display``,
 each of which acted on a different data type:
@@ -269,7 +269,7 @@ The following hypothetical method might print records to an output device:
       // ...print the records
     end method;
 
-The arguments following ``#key`` are keyword arguments. You could call this
+The arguments following :drm:`#key` are keyword arguments. You could call this
 method in several ways:
 
 .. code-block:: dylan
@@ -292,7 +292,7 @@ calls, the ``init-codes`` variable has the value ``""``.
 Programmers have quite a bit of flexibility in specifying keyword arguments.
 
 * The default value specifier (e.g. the ``= 66`` above) may be omitted, in
-  which case ``#f`` is used.
+  which case :drm:`#f` is used.
 * The type of the keyword argument may be specified or omitted, just as with
   regular arguments.
 * The keyword name can be different from the variable name used in the body of
@@ -314,7 +314,7 @@ The following method uses some of these features:
     end;
 
 Firstly, the ``start:`` and ``end:`` keyword arguments are both specialized as
-``<integer>``. The caller can only supply integers for these parameters.
+:drm:`<integer>`. The caller can only supply integers for these parameters.
 Secondly, the ``start:`` keyword argument is associated with the ``start``
 variable in the body of the method as usual, but because the Dylan language
 does not allow a variable named ``end``, that keyword argument is instead
@@ -325,7 +325,7 @@ were omitted, the value of the ``_end`` variable would be the size of the
 Rest Arguments
 ==============
 
-An argument list can also include ``#rest``, which is used with a variable name:
+An argument list can also include :drm:`#rest`, which is used with a variable name:
 
 .. code-block:: dylan
 
@@ -353,13 +353,13 @@ allows it. This section describes how that works. It is a little more advanced
 than rest of this introduction, so you may want to skip this section for now
 and refer back to it later.
 
-We described the ``#key`` and ``#rest`` parameter list tokens above. The
-``#key`` token may also be used by itself, e.g., ``define method foo (arg,
-#key)``. And there is a third parameter list token, ``#all-keys``, that
+We described the :drm:`#key` and :drm:`#rest` parameter list tokens above. The
+:drm:`#key` token may also be used by itself, e.g., ``define method foo (arg,
+#key)``. And there is a third parameter list token, :drm:`#all-keys`, that
 indicates that a method permits other keyword arguments than those listed.
 These features are only useful when working with a generic function and its
 family of methods. When used together, these tokens must appear in the order
-``#rest``, ``#key``, ``#all-keys``.
+:drm:`#rest`, :drm:`#key`, :drm:`#all-keys`.
 
 The table below shows the different kinds of parameter lists that a generic
 function can have, and what effect each has on the parameter lists of the
@@ -391,7 +391,7 @@ methods that it contains.
    Forbidden:
       No method may have this element in its parameter list.
    Automatic:
-      Each method effectively has ``#all-keys`` in its parameter list, even if
+      Each method effectively has :drm:`#all-keys` in its parameter list, even if
       it is not present.
 
 This table shows the different kinds of parameter lists that a method can have,

--- a/documentation/intro-dylan/source/modules-libraries.rst
+++ b/documentation/intro-dylan/source/modules-libraries.rst
@@ -13,7 +13,8 @@ Simple Modules
 Modules import names (or bindings) from other modules and export names
 for use by other modules. The names that may be imported/exported are
 the module-level (also called "global") variables such as those created
-by ``define variable``, ``define class``, ``define generic``, etc.
+by :drm:`define variable <define_variable>`, :drm:`define class
+<define_class>`, :drm:`define generic <define_generic>`, etc.
 
 The dependencies between modules must form a directed, acyclic
 graph. Two modules may not use each other, and no circular dependencies
@@ -34,7 +35,7 @@ chapters might look like this:
           capacity;
     end module;
 
-Like all normal modules, this one uses the ``dylan`` module, which
+Like all normal modules, this one uses the :drm:`dylan` module, which
 contains all of the standard built-in functions and classes. In turn,
 the ``vehicles`` module exports all three of the vehicle classes, the
 generic function ``tax``, several getter functions and a single
@@ -47,7 +48,7 @@ neither. In the above example, the slot ``serial-number`` is read-only,
 while the slot ``owner`` is read/write.
 
 Note that when a module adds a method to an imported generic function,
-the change affects all modules using that function. ``define method``
+the change affects all modules using that function. :drm:`define method <define_method>`
 adds the new method to the existing generic function object, which may
 be referenced by any module importing its binding. The module that
 originally defined the generic function may prevent this behavior by
@@ -72,12 +73,14 @@ and re-exports.
 Libraries
 =========
 
-Libraries contain modules. For example, the ``dylan``
-library contains the ``dylan`` module
-described earlier, the ``extensions`` module, and
+Libraries contain modules. For example, the :drm:`dylan`
+library contains the :drm:`dylan` module
+described earlier, the `extensions`_ module, and
 possibly several other implementation-dependent modules. Note that
 a library and a module may share the same name. Modules with the
 same name may also appear in more than one library.
+
+.. _extensions: https://opendylan.org/documentation/library-reference/language-extensions
 
 By default, a Dylan environment provides a library called
 ``dylan-user`` for the convenience of the programmer.
@@ -86,7 +89,7 @@ depend only on modules found in the Dylan library.
 
 Additionally, every library contains an implicit module, also
 known as ``dylan-user``, which imports all of the
-modules found in the ``dylan`` library. This may be
+modules found in the :drm:`dylan` library. This may be
 used for single module programs. Many Dylan environments, however,
 use it to bootstrap new library definitions. The vehicle library,
 for example, might be defined as follows in a ``dylan-user``
@@ -140,7 +143,7 @@ lets the compiler optimize more effectively. Both classes and generic
 functions are sealed by default.
 
 To allow code in other libraries to subclass a given class,
-declare it as ``open``:
+declare it as :drm:`open`:
 
 .. code-block:: dylan
 
@@ -153,9 +156,11 @@ use a similar syntax:
 
     define open generic sample-function (o :: <object>) => ();
 
-A third form, ``define sealed domain``, partially
+A third form, :drm:`define sealed domain <define_sealed_domain>`, partially
 seals a generic function, disallowing only some additions from outside
 a library.
 
 For more information on sealing, see the chapter
-"Controlling Dynamism" in the DRM.
+`Sealing`_ in the DRM.
+
+.. _Sealing: https://opendylan.org/books/drm/Sealing

--- a/documentation/intro-dylan/source/multiple-dispatch.rst
+++ b/documentation/intro-dylan/source/multiple-dispatch.rst
@@ -51,7 +51,7 @@ with these arguments performs three separate tasks:
 ``check-insurance``. The most specific method on
 ``inspect-vehicle`` -- the one for the classes
 ``<car>`` and ``<state-inspector>`` -- is invoked first
-and calls ``next-method`` to invoke the less-specific methods in turn.
+and calls :drm:`next-method` to invoke the less-specific methods in turn.
 
 For an exact definition of "specific", see the DRM.
 
@@ -74,4 +74,4 @@ though they were in a class of their own. For example:
     end;
 
 (In this example, none of the usual inspection methods will be
-invoked since the above code doesn't call ``next-method``.)
+invoked since the above code doesn't call :drm:`next-method`.)

--- a/documentation/intro-dylan/source/objects.rst
+++ b/documentation/intro-dylan/source/objects.rst
@@ -6,7 +6,7 @@ The features of Dylan's object system don't map directly onto the
 features found in C++. Dylan handles access control using
 :term:`modules`, not ``private`` declarations within
 individual classes. Standard Dylan has no destructors, but instead relies
-upon the garbage collector to recover memory and on block/cleanup
+upon the garbage collector to recover memory and on :drm:`block`/:drm:`cleanup`
 to recover lexically scoped resources. Dylan objects don't even have real
 member functions.
 
@@ -52,9 +52,9 @@ shown here:
    +-----------------------+-----------------+
 
 The built-in collection classes include a number of common data
-structures. Arrays, tables, vectors, ranges and deques should be
+structures. :drm:`Arrays <arrays>`, :drm:`tables`, :drm:`vectors`, :drm:`ranges` and :drm:`deques` should be
 provided by all Dylan implementations. The language specification
-also standardizes strings and byte-strings.
+also standardizes :drm:`strings` and :drm:`byte-strings <<byte-string>>`.
 
 Not all the built-in classes may be subclassed. This allows the
 compiler to heavily optimize code dealing with basic numeric types and
@@ -80,7 +80,7 @@ their data. A simple Dylan class shows how slots are declared:
 The above code would be quick and convenient to write while building a
 prototype, but it could be improved. The slots have no declared types
 so they default to :drm:`<object>`, and they don't specify default values
-so they default to ``#f``.  The following snippet fixes both problems:
+so they default to :drm:`#f`.  The following snippet fixes both problems:
 
 .. code-block:: dylan
 
@@ -107,9 +107,9 @@ programmer could write one of the following:
     make(<vehicle>, sn: 1000000)
     make(<vehicle>, sn: 2000000, owner: "Sal")
 
-In the first example, ``make`` returns a vehicle
+In the first example, :drm:`make` returns a vehicle
 with the specified serial number and the default owner. In the second
-example, ``make`` sets both slots using the keyword
+example, :drm:`make` sets both slots using the keyword
 arguments.
 
 Only one of ``required-init-keyword``, ``init-value`` and
@@ -187,14 +187,14 @@ must be invoked in the usual Dylan fashion; no syntactic sugar exists
 to make them look like C++ member functions.
 
 The version of tax for ``<truck>`` objects
-calls a special function named ``next-method``. This
+calls a special function named :drm:`next-method`. This
 function invokes the next most specific method of a generic function;
 in this case, the method for ``<vehicle>``
 objects.  Parameters to the current method get passed along
 automatically.
 
-Technically, ``next-method`` is a special parameter to a method, and
-may be passed explicitly using ``#next``.
+Technically, :drm:`next-method` is a special parameter to a method, and
+may be passed explicitly using :drm:`#next`.
 
 .. code-block:: dylan
 
@@ -226,10 +226,10 @@ model, see the chapter on :doc:`Multiple Dispatch <multiple-dispatch>`.
 Initializers
 ============
 
-The ``make`` function handles much of the
+The :drm:`make` function handles much of the
 drudgery of object construction. It processes keywords and initializes
 slots. Programmers may, however, customize this process by adding
-methods to the generic function ``initialize``. For
+methods to the generic function :drm:`initialize`. For
 example, if vehicle serial numbers must be at least seven digits:
 
 .. code-block:: dylan
@@ -241,13 +241,13 @@ example, if vehicle serial numbers must be at least seven digits:
       end if;
     end method;
 
-``initialize`` methods get called after regular
+:drm:`initialize` methods get called after regular
 slot initialization. They typically perform error checking or calculate
-derived slot values. Initialize methods must specify ``#key`` in their
+derived slot values. Initialize methods must specify :drm:`#key` in their
 parameter lists.
 
 It's possible to access the values of slot keywords from
-``initialize`` methods, and even to specify additional
+:drm:`initialize` methods, and even to specify additional
 keywords in the class declaration. See the DRM for further details.
 
 Abstract Classes and Overriding Make
@@ -268,7 +268,7 @@ be defined as follows:
 
 The above modification prevents the creation of direct instances
 of ``<vehicle>``. At the moment, calling
-``make`` on this class would result in an error.
+:drm:`make` on this class would result in an error.
 However, a programmer could add a method to make which allowed the
 intelligent creation of vehicles based on some criteria, thus making
 ``<vehicle>`` an :term:`instantiable abstract class`:
@@ -290,7 +290,7 @@ A number of new features appear in the parameter list. The expression
 meaning this method will be called only if ``class`` is exactly
 ``<vehicle>``, not a subclass such as ``<car>``.  Singleton dispatch
 is discussed in the chapter on :doc:`Multiple Dispatch
-<multiple-dispatch>`.  The use of ``#rest`` and ``#key`` in the same
+<multiple-dispatch>`.  The use of :drm:`#rest` and :drm:`#key` in the same
 parameter list means all keyword arguments will be stored in the
 ``keys`` parameter but if ``big?`` is passed it will be bound to the
 variable by the same name.  The new make method could be invoked in
@@ -303,7 +303,7 @@ any of the following fashions:
     make(<vehicle>, sn: x, big?: #t); //=> truck
     make(<vehicle>, sn: x);           //=> car
 
-Methods added to ``make`` don't actually need to create new objects. Dylan
+Methods added to :drm:`make` don't actually need to create new objects. Dylan
 officially allows them to return existing objects. This can be used to
 manage lightweight shared objects, such as the "flyweights" or "singletons"
 described by Gamma, et al., in


### PR DESCRIPTION
Fixes #97.

- Add `:drm:` links to the words that are defined in file `drmindex.py`.
- Add new words to `drmindex.py`.
- Add a link to `extensions` in Dylan Reference Library.
- Change a reference to chapter `Controlling dinamism` (not found) in DRM for
  chapter `Sealing`.