### PR TITLE
common-dylan: Add end argument to replace-subsequence!

### DIFF
--- a/sources/common-dylan/common-extensions.dylan
+++ b/sources/common-dylan/common-extensions.dylan
@@ -367,7 +367,7 @@ define method join
     let result = make(object-class(first), size: result-size);
     let result-index :: <integer> = 0;
     local method copy-to-result (seq :: <sequence>)
-            result := replace-subsequence!(result, seq, start: result-index);
+            result := replace-subsequence!(result, seq, start: result-index, end: result-index + seq.size);
             result-index := result-index + seq.size;
           end;
     copy-to-result(first);


### PR DESCRIPTION
The replacement size should be the same as sequence size.
If this is not explicitely indicated the whole result suffix will be
discarded, with a huge performance penalty for large sequences,
as this operation is done in the inner loop.