### PR TITLE
system-test-suite improvements

### DIFF
--- a/sources/common-dylan/tests/functions.dylan
+++ b/sources/common-dylan/tests/functions.dylan
@@ -460,17 +460,23 @@ define common-extensions function-test fill-table! ()
               table[1], "One");
 end function-test fill-table!;
 
+// Application startup handling
+
 define common-extensions function-test application-name ()
-  //---*** Fill this in...
-end function-test application-name;
+  check-instance?("application-name returns #f or a string",
+                  false-or(<string>), application-name());
+end function-test;
 
 define common-extensions function-test application-filename ()
-  //---*** Fill this in...
-end function-test application-filename;
+  let filename = application-filename();
+  check-true("application-filename returns #f or a valid, existing file name",
+             ~filename | file-exists?(filename));
+end function-test;
 
 define common-extensions function-test application-arguments ()
-  //---*** Fill this in...
-end function-test application-arguments;
+  check-instance?("application-arguments returns a sequence",
+                  <sequence>, application-arguments());
+end function-test;
 
 define common-extensions function-test tokenize-command-line ()
   //---*** Fill this in...

--- a/sources/common-dylan/tests/library.dylan
+++ b/sources/common-dylan/tests/library.dylan
@@ -9,6 +9,8 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 define library common-dylan-test-suite
   use dylan;
   use common-dylan;
+  use system,
+    import: { file-system };
   use testworks;
   use testworks-specs;
   use dylan-test-suite;
@@ -29,6 +31,8 @@ define module common-dylan-test-suite
   use simple-format;
   use simple-random;
   use simple-profiling;
+  use file-system,
+    import: { file-exists? };
   use transcendentals;
   use byte-vector;
   use machine-words;

--- a/sources/system/tests/file-system.dylan
+++ b/sources/system/tests/file-system.dylan
@@ -16,7 +16,6 @@ register-stream-class-info("<file-stream>", <file-stream>,
 define sideways method make-stream-tests-of-size
     (class :: subclass(<file-stream>), stream-size :: <integer>)
  => (streams :: <sequence>)
-  let class-info = stream-class-info(<wrapper-stream>);
   let tests :: <stretchy-object-vector> = make(<stretchy-object-vector>);
   //---*** Nothing yet...
   tests

--- a/sources/system/tests/library.dylan
+++ b/sources/system/tests/library.dylan
@@ -39,7 +39,9 @@ define module system-test-suite
   // to be registered, and also slows compilation. Whatever's being used from
   // this needs to be factored out into a library that can be shared and has no
   // tests in it.
-  use common-dylan-test-suite;        // For generic stream testing
+  use common-dylan-test-suite,
+    import: { make-stream-tests-of-size,
+              register-stream-class-info };
 
   use testworks;
   use testworks-specs;

--- a/sources/system/tests/operating-system.dylan
+++ b/sources/system/tests/operating-system.dylan
@@ -349,40 +349,10 @@ define operating-system function-test machine-concurrent-thread-count ()
 end;
 
 
-// Application startup handling
-
-define operating-system function-test application-name ()
-  check-instance?("application-name returns #f or a string",
-                  false-or(<string>), application-name());
-end function-test application-name;
-
-define operating-system function-test application-filename ()
-  let filename = application-filename();
-  check-true("application-filename returns #f or a valid, existing file name",
-             ~filename
-               | begin
-                   let locator = as(<file-locator>, filename);
-                   file-exists?(locator)
-                 end)
-end function-test application-filename;
-
-define operating-system function-test application-arguments ()
-  check-instance?("application-arguments returns a sequence",
-                  <sequence>, application-arguments());
-end function-test application-arguments;
-
 define operating-system function-test command-line-option-prefix ()
   check-instance?("command-line-option-prefix returns a character",
                   <character>, command-line-option-prefix());
 end function-test command-line-option-prefix;
-
-define operating-system function-test exit-application ()
-  //---*** Fill this in...
-end function-test exit-application;
-
-define operating-system function-test register-application-exit-function ()
-  //---*** Fill this in...
-end function-test register-application-exit-function;
 
 
 // Environment variables

--- a/sources/system/tests/specification.dylan
+++ b/sources/system/tests/specification.dylan
@@ -55,6 +55,8 @@ define module-spec locators ()
   open abstract class <physical-locator> (<locator>);
   open abstract instantiable class <directory-locator> (<physical-locator>);
   open abstract instantiable class <file-locator> (<physical-locator>);
+  instantiable class <native-directory-locator> (<directory-locator>);
+  instantiable class <native-file-locator> (<file-locator>);
   open generic-function supports-open-locator? (<locator>) => (<boolean>);
   open generic-function open-locator (<locator>) => (<stream>);
   open generic-function supports-list-locator? (<locator>) => (<boolean>);
@@ -132,8 +134,6 @@ define module-spec file-system ()
 
   // Native locators
   abstract class <native-file-system-locator> (<file-system-locator>);
-  instantiable class <native-directory-locator> (<directory-locator>);
-  instantiable class <native-file-locator> (<file-locator>);
 
   // Classes
   open abstract instantiable class <file-stream>

--- a/sources/system/tests/specification.dylan
+++ b/sources/system/tests/specification.dylan
@@ -209,14 +209,7 @@ define module-spec operating-system ()
   function parent-process-id () => (<integer>);
   function machine-concurrent-thread-count () => (<integer>);
 
-  // Application startup handling
-  function application-name () => (false-or(<string>));
-  //---*** application-filename should return <file-locator>...
-  function application-filename () => (false-or(<string>));
-  function application-arguments () => (<sequence>);
   function command-line-option-prefix () => (<character>);
-  function exit-application (<integer>) => ();
-  function register-application-exit-function (<function>) => ();
 
   // Environment variables
   function environment-variable (<string>) => (false-or(<string>));


### PR DESCRIPTION
We now run 143 more checks than before, so I guess that's progress.

**master branch results:**

```
system-test-suite failed
  file-system-module-test-suite failed
    file-system-protocol-test-suite failed
      file-system-protocol-classes-test crashed [Stream class {<class>: <wrapper-stream>} not registered for testing]
        make <file-stream> with required arguments crashed [Error evaluating assertion expressions: Stream class {<class>: <wrapper-stream>} not registered for testing]

system-test-suite FAILED in 0.314075 seconds:
  Ran 16 suites: 13 passed (81.250000%), 3 failed, 0 skipped, 0 not implemented, 0 crashed
  Ran 57 tests: 56 passed (98.245616%), 0 failed, 0 skipped, 0 not implemented, 1 crashed
  Ran 0 benchmarks
  Ran 1604 checks: 1603 passed (99.937656%), 0 failed, 0 skipped, 0 not implemented, 1 crashed
```

**tests branch results:**
```
system-test-suite failed
  file-system-module-test-suite failed
    file-system-protocol-test-suite failed
      file-system-protocol-classes-test failed
        make <file-stream> with required arguments crashed [Error evaluating assertion expressions: Assertion failed: can't make test instance of unregistered stream class {<class>: <file-stream>}]
        The variable <file-system-directory-locator> is a class failed [expression "#f" evaluates to #f.]
        The variable <file-system-file-locator> is a class failed [expression "#f" evaluates to #f.]

system-test-suite FAILED in 0.291091 seconds:
  Ran 16 suites: 13 passed (81.250000%), 3 failed, 0 skipped, 0 not implemented, 0 crashed
  Ran 57 tests: 56 passed (98.245616%), 1 failed, 0 skipped, 0 not implemented, 0 crashed
  Ran 0 benchmarks
  Ran 1747 checks: 1744 passed (99.828280%), 2 failed, 0 skipped, 0 not implemented, 1 crashed
```