### PR TITLE
dylan: Improve encode-double-float/decode-double-float

### DIFF
--- a/sources/dfmc/llvm-back-end/llvm-primitives-float.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-primitives-float.dylan
@@ -252,7 +252,10 @@ define side-effect-free stateless dynamic-extent &primitive-descriptor primitive
     let high = ins--trunc(be, high-64, type);
     values(low, high)
   elseif (word-size = 8)
-    values(f-bits, i64(0))
+    let low-mask = generic/-(generic/ash(1, 32), 1);
+    let low = ins--and(be, f-bits, low-mask);
+    let high = ins--lshr(be, f-bits, i64(32));
+    values(low, high)
   else
     error("Unsupported word-size "
             "for primitive-cast-double-float-as-machine-words");
@@ -270,7 +273,8 @@ define side-effect-free stateless dynamic-extent &primitive-descriptor primitive
         let high-64-shifted = ins--shl(be, high-64, i64(32));
         ins--or(be, high-64-shifted, low-64)
       elseif (word-size = 8)
-        low
+        let high-shifted = ins--shl(be, high, i64(32));
+        ins--or(be, high-shifted, low)
       end if;
   ins--bitcast(be, f-bits, $llvm-double-type)
 end;

--- a/sources/lib/llvm/llvm-bitcode.dylan
+++ b/sources/lib/llvm/llvm-bitcode.dylan
@@ -1174,8 +1174,15 @@ define method write-constant-record
       let (low :: <machine-word>, high :: <machine-word>)
         = decode-double-float(double-float);
       write-record(stream, #"FLOAT",
-                   make(<double-machine-word>, low: low, high: high));
-      
+                   if ($machine-word-size = 32)
+                     make(<double-machine-word>, low: low, high: high)
+                   elseif ($machine-word-size = 64)
+                     %logior(low, %shift-left(high, 32))
+                   else
+                     error("float-constant $machine-word-size = %d",
+                           $machine-word-size);
+                   end if);
+
     #"X86_FP80", #"FP128", #"PPC_FP128" =>
       error("Can't write %s floating point", type.llvm-primitive-type-kind);
   end select;

--- a/sources/lib/run-time/c-primitives-math.c
+++ b/sources/lib/run-time/c-primitives-math.c
@@ -110,21 +110,12 @@ DDFLT primitive_double_integer_as_double_float(DMINT low, DMINT high) {
 DUMINT primitive_cast_double_float_as_machine_words(DDFLT x) {
   INTDFLT intflt;
   intflt.f = x;
-#ifdef NO_LONGLONG
-  MV2U((DUMINT)intflt.i, 0);
-#else
-  MV2U((DUMINT)intflt.i, (DUMINT)(intflt.i >> LONG_BIT));
-#endif
+  MV2U((DUMINT)intflt.i & 0xFFFFFFFF, (DUMINT)(intflt.i >> 32));
 }
 
 DDFLT primitive_cast_machine_words_as_double_float(DUMINT low, DUMINT high) {
   INTDFLT intflt;
-#ifdef NO_LONGLONG
-  ignore(high);
-  intflt.i = (DULMINT)low;
-#else
-  intflt.i = ((DULMINT)high << LONG_BIT) | (DULMINT)low;
-#endif
+  intflt.i = ((DULMINT)high << 32) | (DULMINT)low;
   return(intflt.f);
 }
 
@@ -694,11 +685,7 @@ DMINT primitive_double_float_as_double_integer_byref(DDFLT f, DMINT* v2) {
 DMINT primitive_cast_double_float_as_machine_words_byref(DDFLT x, DMINT* v2) {
   INTDFLT intflt;
   intflt.f = x;
-#ifdef NO_LONGLONG
-  MV2_byref((DMINT)intflt.i, v2, 0);
-#else
-  MV2_byref((DMINT)intflt.i, v2, (DMINT)(intflt.i >> LONG_BIT));
-#endif
+  MV2_byref((DMINT)(intflt.i & 0xFFFFFFFF), v2, (DMINT)(intflt.i >> 32));
 }
 
 DMINT primitive_machine_word_divide_byref(DMINT x, DMINT y, DMINT* v2) {


### PR DESCRIPTION
Previously, on 32-bit platforms decode-double-float would return two
<machine-word> values each containing 32 bits of a 64-bit
<double-float>. On 64-bit platforms the entire 64 bits were placed in
one <machine-word> and the other contained zeroes. This made it
necessary to check the machine word size to know where the fields in
the floating point number could be found. This change changes the
behavior on 64-bit platforms so that each (64-bit) <machine-word>
contains 32 significant bits, reducing the need for users to check the
size.

* sources/lib/run-time/c-primitives-math.c
  (primitive_cast_double_float_as_machine_words): Extract the double
   bits in two halves with 32 significant bits each.
  (primitive_cast_machine_words_as_double_float,
   primitive_cast_double_float_as_machine_words_byref): Interpret the two
   arguments as two halves (with 32 significant bits each) to be
   reassembled.

* sources/dfmc/llvm-back-end/llvm-primitives-float.dylan
  (primitive primitive-cast-double-float-as-machine-words): On 64-bit
   target platforms extract the double bits in two halves with 32
   significant bits each.
  (primitive primitive-cast-machine-words-as-double-float): On 64-bit
   target platforms interpret the two arguments as two halves (with 32
   significant bits each) to be reassembled.

* sources/common-dylan/numerics.dylan
  (%float-exponent): Always extract the exponent from the high 32 bits
   regardless of machine word size.
  (classify-float): Always extract the exponent/discriminator from the
   high 32-bits regardless of machine word size.
  (decode-float): Always extract the exponent and significand from the
   two halves regardless of machine word size, and encode the result
   as two 32-bit halves.

* sources/lib/llvm/llvm-bitcode.dylan
  (write-constant-record on <llvm-float-constant>): On 64-bit host
   platforms assemble the <double-float> value into a single 64-bit
   <machine-word>.