### PR TITLE
dfmc-optimization: Prevent type loss from raw pointer casts

### DIFF
--- a/sources/dfmc/optimization/calls.dylan
+++ b/sources/dfmc/optimization/calls.dylan
@@ -350,8 +350,9 @@ define primitive-coercion-inverses
 define primitive-coercion-inverses
   primitive-cast-integer-as-raw and primitive-cast-raw-as-integer;
 
-define primitive-coercion-inverses
-  primitive-cast-pointer-as-raw and primitive-cast-raw-as-pointer;
+// NB this loses type information in the other direction
+define reverse primitive-coercion-inverses
+  primitive-cast-raw-as-pointer of primitive-cast-pointer-as-raw;
 
 // TODO: generalize the coercion macro to accommodate wrap-c-pointer
 //


### PR DESCRIPTION
This compiler change provides a fix for issue #1068, addressing the issues identified by @pedro-w there.
