### PR TITLE
dfmc-llvm-back-end: Fix potential stack overflows

### DIFF
--- a/sources/dfmc/llvm-back-end/llvm-emit-computation.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-emit-computation.dylan
@@ -234,6 +234,13 @@ end method;
 
 define method emit-result-assignment
     (back-end :: <llvm-back-end>, c :: <computation>,
+     temp :: <temporary>, result :: <llvm-spill-mv>)
+ => ();
+  temporary-value(temp) := result;
+end method;
+
+define method emit-result-assignment
+    (back-end :: <llvm-back-end>, c :: <computation>,
      temp :: <temporary>, result :: <llvm-global-mv>)
  => ()
   let primary = ins--extractvalue(back-end, result.llvm-mv-struct, 0);

--- a/sources/dfmc/llvm-back-end/llvm-emit-computation.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-emit-computation.dylan
@@ -1567,6 +1567,7 @@ define method emit-computation
     let phi-operands = make(<stretchy-object-vector>);
 
     // Stack-allocated bind exit frame
+    let stacksave = ins--call-intrinsic(back-end, "llvm.stacksave", #[]);
     let typeid = op--typeid(back-end, c.entry-state);
     let bef = op--allocate-bef(back-end, typeid);
     temporary-value(c.entry-state) := bef;
@@ -1587,6 +1588,7 @@ define method emit-computation
       add-merge-operands(temp,
                          merge-c & merge-c.merge-right-value,
                          back-end.llvm-builder-basic-block);
+      ins--call-intrinsic(back-end, "llvm.stackrestore", vector(stacksave));
       ins--br(back-end, merge-bb);
     end if;
 
@@ -1627,6 +1629,7 @@ define method emit-computation
       add-merge-operands(temp, merge-c.merge-left-value,
                          back-end.llvm-builder-basic-block);
     end if;
+    ins--call-intrinsic(back-end, "llvm.stackrestore", vector(stacksave));
     ins--br(back-end, merge-bb);
 
     // No match, resume unwind


### PR DESCRIPTION
In various scenarios the LLVM alloca instruction may appear within loop code, causing potential stack overflows for long-running loops. These changes fix these problems by either lifting alloca out of the loop to the beginning of the function body, or by using the llvm.stacksave and llvm.stackrestore intrinsics.