### PR TITLE
Use hexadecimal floating point notation in the output of the C back end

### DIFF
--- a/sources/common-dylan/tests/functions.dylan
+++ b/sources/common-dylan/tests/functions.dylan
@@ -943,6 +943,19 @@ define common-extensions function-test decode-float ()
                 1.0s0, sign);
   end with-test-unit;
 
+  with-test-unit ("decode-float of <single-float> subnormal")
+    let single-subnormal :: <single-float> = encode-single-float(as(<machine-word>, #x1));
+    let (significand :: <single-float>,
+         exponent :: <integer>,
+         sign :: <single-float>) = decode-float(single-subnormal);
+    check-equal("significand for <single-float> subnormal = 1 / radix",
+                1.0s0 / single-beta, significand);
+    check-equal("exponent for <single-float> subnormal = -148",
+                -148, exponent);
+    check-equal("sign for <single-float> subnormal = 1.0s0",
+                1.0s0, sign);
+  end with-test-unit;
+
   let double-beta :: <double-float> = as(<double-float>, float-radix(1.0d0));
 
   with-test-unit ("decode-float of <double-float> radix")
@@ -955,6 +968,35 @@ define common-extensions function-test decode-float ()
                 2, exponent);
     check-equal("sign for <double-float> radix = 1.0d0",
                 1.0d0, sign);
+  end with-test-unit;
+
+  with-test-unit ("decode-float of <double-float> subnormal")
+    let double-subnormal :: <double-float> =
+      encode-double-float(as(<machine-word>, #x1),
+                          as(<machine-word>, #x0));
+    let (significand :: <double-float>,
+         exponent :: <integer>,
+         sign :: <double-float>) = decode-float(double-subnormal);
+    check-equal("significand for <double-float> subnormal = 1 / radix",
+                1.0d0 / double-beta, significand);
+    check-equal("exponent for <double-float> subnormal = -1073",
+                -1073, exponent);
+    check-equal("sign for <double-float> subnormal = 1.0d0",
+                1.0d0, sign);
+  end with-test-unit;
+  with-test-unit ("decode-float of <double-float> negative subnormal")
+    let double-subnormal :: <double-float> =
+      encode-double-float(as(<machine-word>, #x0),
+                          as(<machine-word>, #x80000001));
+    let (significand :: <double-float>,
+         exponent :: <integer>,
+         sign :: <double-float>) = decode-float(double-subnormal);
+    check-equal("significand for <double-float> negative subnormal = 1 / radix",
+                1.0d0 / double-beta, significand);
+    check-equal("exponent for <double-float> negative subnormal = -1041",
+                -1041, exponent);
+    check-equal("sign for <double-float> negative subnormal = -1.0d0",
+                -1.0d0, sign);
   end with-test-unit;
 
 end function-test decode-float;

--- a/sources/dfmc/c-back-end/c-emit-object.dylan
+++ b/sources/dfmc/c-back-end/c-emit-object.dylan
@@ -92,42 +92,45 @@ define method emit-object
   print-raw-object(o, stream)
 end method;
 
-define method print-raw-object (o :: <float>, stream :: <stream>) => ()
-  // Sometimes, we can end up with an infinite or nan value here, so
-  // we want to make sure we print an appropriate C representation.
-  // In the future, we can look at using classify-float, but this
-  // is not yet available to us here.
-  let s = float-to-string(o);
-  write(stream,
-        select (s by \=)
-          "-{infinity}" => "-INFINITY";
-          "-{infinity}d0" => "(double)-INFINITY";
-          "-{infinity}x0" => "(long double)-INFINITY";
-          "+{infinity}" => "INFINITY";
-          "+{infinity}d0" => "(double)INFINITY";
-          "+{infinity}x0" => "(long double)INFINITY";
-          "{NaN}" => "NAN";
-          "{NaN}d0" => "(double)NAN";
-          "{NaN}x0" => "(long double)NAN";
-          otherwise =>
-            begin
-              //---*** Is there a better way to do this???
-              block (done)
-                let i = size(s) - 1;
-                while (i > -1)
-                  select (s[i])
-                    's' => s[i] := 'e'; done();        //---*** Should be 'f' but GCC complains!
-                    'd' => s[i] := 'e'; done();
-                    'x' => s[i] := 'e'; done();        //---*** Should be 'l' but GCC complains!
-                    otherwise => ;
-                  end select;
-                  i := i - 1
-                end while
-              end block;
-              s
-            end;
-        end select);
-end method;
+define constant xdigits :: <string> = "0123456789ABCDEF";
+define inline-only function c-float-cast
+  (x :: <float>) => (cast :: <string>)
+  select (x by instance?)
+    <single-float> => "(float)";
+    <double-float> =>"(double)";
+    <extended-float> => "(long double)";
+    otherwise => error("Float type not implemented");
+  end select;
+end function;
+
+define method print-raw-object
+    (x :: <float>, stream :: <stream>) => ()
+  write(stream, c-float-cast(x));
+  select (classify-float(x))
+    #"infinite" =>
+      if (negative?(x))
+	write-element(stream, '-');
+      end;
+      write(stream, "INFINITY");
+    #"nan" => write(stream, "NAN");
+    otherwise =>
+      let (significand, exponent, signum) = decode-float(x);
+      let one = as(object-class(x), 1);
+      if (negative?(signum))
+	write-element(stream, '-');
+      end if;
+      write(stream, "0x0.");
+      until (zero?(significand))
+	// Extract 4 bits (i.e. one hex digit) at a time
+	let x = scale-float(significand, 4);
+	let (quot, rem) = truncate/(x, one);
+	significand := rem;
+	let i = as(<integer>, quot);
+	write-element(stream, xdigits[i]);
+      end until;
+      format(stream, "p%d", exponent);
+  end;
+end method print-raw-object;
 
 // INTEGERS
 


### PR DESCRIPTION
The current C back-end uses `float-to-string` to emit normal (decimal) floats into the C source files. Unfortunately `float-to-string` has limitations which means it cannot represent all floats faithfully. This PR changes the C back-end to output hexadecimal floats which can represent `<single-float>` and  `<double-float>` with 100% fidelity.
As part of the implementation, `decode-float` now handles subnormal numbers properly.
Finally, there is some code to work around the breaking change to `decode-double-float` introduced in 1fde59f3734d6147b2006c4a7a0d2678bbbea5ce. Without this, it is not possible to bootstrap from 2019.1 using the C back end. 