### PR TITLE
Improve formatting of floats as strings

### DIFF
--- a/sources/common-dylan/format.dylan
+++ b/sources/common-dylan/format.dylan
@@ -413,6 +413,10 @@ define function float-to-string
                 add!(buffer, as(<character>, as(<integer>, '0') + remainder))
               end method;
         let scale :: <integer> = truncate/(log(float), log(ten));
+        // Handle bad rounding case
+        if (float >= ten ^ (1 + scale))
+          scale := scale + 1;
+        end;
         if (scale > 0 & scale <= dec-point)
           dec-point := dec-point - scale;
         end;

--- a/sources/common-dylan/tests/functions.dylan
+++ b/sources/common-dylan/tests/functions.dylan
@@ -130,7 +130,12 @@ define constant $float-string-mappings
       #(100.0,         "100.00000"),
       #(100.0d0,       "100.00000d0"),
       #(123456789.0,   "1.2345679s8"),
-      #(123456789.0d0, "1.2345678d8"));
+      #(123456789.0d0, "1.2345678d8"),
+      // Added for bug 
+      #(1.0d5,         "100000.00d0"),
+      #(1.0s6,         "1000000.0"),
+      #(1.0d6,         "1000000.0d0"),
+      #(1.0d7,         "1.0000000d7"));
 
 define common-extensions function-test float-to-string ()
   for (float-mapping in $float-string-mappings)


### PR DESCRIPTION
When calculating the exponent (power of 10) a rounding error sometimes gives the wrong exponent. This causes the number of significand digits to be wrong, and the number is printed incorrectly. This is particularly common when the number to be formatted is itself a power of ten.

Fixes #1263 although there are further problems with float formatting, namely the output precision is too limited.