### PR TITLE
Fix bitrot in the GTK bindings and the GTK DUIM port 

### DIFF
--- a/sources/dfmc/llvm-back-end/llvm-back-end-types.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-back-end-types.dylan
@@ -169,8 +169,15 @@ define method llvm-object-type
  => (type :: <llvm-type>);
   let class = o.&object-class;
   ^ensure-slots-initialized(class);
-  let rslotd = class.^repeated-slot-descriptor; 
-  let repeated-size = rslotd & ^slot-value(o, ^size-slot-descriptor(rslotd));
+  let rslotd = class.^repeated-slot-descriptor;
+  let repeated-size-value
+    = rslotd & ^slot-value(o, ^size-slot-descriptor(rslotd));
+  let repeated-size
+    = if (o.^object-class == dylan-value(#"<byte-string>"))
+        repeated-size-value + 1 // for NUL termination
+      else
+        repeated-size-value
+      end if;
   llvm-class-type(back-end, class, repeated-size: repeated-size)
 end method;
 

--- a/sources/duim/gtk/gtk-medium.dylan
+++ b/sources/duim/gtk/gtk-medium.dylan
@@ -386,7 +386,8 @@ define sealed method decode-ink
     (medium :: <gtk-medium>, gcontext :: <CairoContext>, color :: <color>)
  => (color :: <native-color>, fill-style, operation :: <integer>,
      image :: false-or(<image>))
-  values(allocate-color(color, medium.%palette), $GDK-SOLID, $boole-1, #f)
+  values(allocate-color(color, medium.%palette), 0 /* $GDK-SOLID unused */,
+         $boole-1, #f)
 end method decode-ink;
 
 define sealed method decode-ink
@@ -394,7 +395,8 @@ define sealed method decode-ink
  => (color :: <native-color>, fill-style, operation :: <integer>,
      image :: false-or(<image>))
   let color = contrasting-color->color(color);
-  values(allocate-color(color, medium.%palette), $GDK-SOLID, $boole-1, #f)
+  values(allocate-color(color, medium.%palette), 0 /* $GDK-SOLID unused */,
+         $boole-1, #f)
 end method decode-ink;
 
 define sealed method decode-ink

--- a/sources/gtk/gdkpixbuf-dylan/gdkpixbuf.dylan
+++ b/sources/gtk/gdkpixbuf-dylan/gdkpixbuf.dylan
@@ -168,12 +168,6 @@ define C-function gdk-pixbuf-get-formats
   c-name: "gdk_pixbuf_get_formats";
 end;
 
-define C-function gdk-pixbuf-gettext
-  input parameter msgid_ :: <C-string>;
-  result res :: <C-string>;
-  c-name: "gdk_pixbuf_gettext";
-end;
-
 define C-function gdk-pixbuf-new-from-stream-async
   input parameter stream_ :: <GInputStream>;
   input parameter cancellable_ :: <GCancellable>;

--- a/sources/gtk/gdkpixbuf-dylan/library.dylan
+++ b/sources/gtk/gdkpixbuf-dylan/library.dylan
@@ -170,7 +170,6 @@ define module gdkpixbuf
     gdk-pixbuf-save-to-stream-finish,
     gdk-pixbuf-new-from-stream-at-scale-async,
     gdk-pixbuf-new-from-stream-async,
-    gdk-pixbuf-gettext,
     gdk-pixbuf-get-formats,
     gdk-pixbuf-get-file-info,
     gdk-pixbuf-from-pixdata,

--- a/sources/gtk/gobject-dylan/gobject-glue.dylan
+++ b/sources/gtk/gobject-dylan/gobject-glue.dylan
@@ -216,17 +216,17 @@ define function dylan-meta-marshaller (closure :: <GClosure>,
                                        invocation-hint :: <gpointer>,
                                        marshal-data :: <gpointer>)
   let values = #();
-  for (i from 0 below n-param-values)
+  for (i :: <integer> from 0 below n-param-values)
 
 //    let address = integer-as-raw(param-values.raw-pointer-address.raw-as-integer + i * sizeof-gvalue());
 //    let value* = make(<GValue>, address: address);
 
+    let offset :: <integer> = i * as(<integer>, sizeof-gvalue());
     let value = make-c-pointer(<GValue>,
                                primitive-machine-word-add
                                  (primitive-cast-pointer-as-raw
                                    (primitive-unwrap-c-pointer(param-values)),
-                                  integer-as-raw
-                                    (i * sizeof-gvalue())),
+                                  integer-as-raw(offset)),
                                #[]);
     values := pair(g-value-to-dylan(value), values);
 //    value*;

--- a/sources/lib/llvm/llvm-bitcode.dylan
+++ b/sources/lib/llvm/llvm-bitcode.dylan
@@ -1215,7 +1215,9 @@ define method write-constant-record
   elseif (aggregate-string?(value))
     let contents = map(llvm-integer-constant-integer,
                        value.llvm-aggregate-constant-values);
-    if (zero?(contents.last))
+    if (every?(zero?, contents))
+      write-record(stream, #"NULL");
+    elseif (zero?(contents.last))
       write-abbrev-record(stream, #"cstring",
                           copy-sequence(contents, end: contents.size - 1));
     else


### PR DESCRIPTION
Changes that ensure that `<byte-string>` constants output by the LLVM back-end are NUL-terminated are also included.