### PR TITLE
Update LLDB support for python 3

### DIFF
--- a/documentation/getting-started-cli/source/debugging-with-gdb-lldb.rst
+++ b/documentation/getting-started-cli/source/debugging-with-gdb-lldb.rst
@@ -207,9 +207,9 @@ some objects will show only the class name without further detail.
 Because LLDB was principally a C debugger, some concepts such as
 pointers need to be considered. Given a Dylan class like:
 
-.. code-block:: none
+.. code-block:: dylan
 
-  define class <element>(<object>)
+  define class <element> (<object>)
    slot tag;
    slot content;
    slot attrs;

--- a/documentation/getting-started-cli/source/debugging-with-gdb-lldb.rst
+++ b/documentation/getting-started-cli/source/debugging-with-gdb-lldb.rst
@@ -39,7 +39,34 @@ presence of inlined functions and macro expansions.
 Understanding name mangling
 ---------------------------
 
-*Fill this in, particularly with a link to the Hacker's Guide!*
+Dylan identifiers (method and variable names) do not follow the same
+rules as C; they are case insensitive, can contain extra characters
+such as '<' or '-', and are part of the two-level namespace (module
+and library). There is a process, known as 'mangling', to turn Dylan
+identifiers into valid C identifiers. The reverse process is called
+demangling. C++ also mangles its variable and function names, for the
+same reason. When debugging, backtraces and frame summaries will show
+the mangled names rather than the Dylan names. An outline of the
+mangling rules is as follows:
+
+* Convert identifier to lower case
+* Replace incompatible symbols.
+  For example, ``-`` becomes ``_`` and ``<`` becomes ``L``.
+* Repeat for module and library identifiers
+* Join them like this: ``K`` identifier ``Y`` module ``V`` library.
+* If it is a method, append a suffix starting with ``M`` to distinguish the
+  specific methods within a generic function.
+
+There are a number of extra cases to shorten the mangled name. The ``Y``
+and module name are omitted if the module name is the same as the
+library. For modules in the Dylan library, the sequence
+``YmoduleVdylan`` is replaced by ``VKmodule`` and some modules have short
+names, for example ``i`` is the 'internal' module.
+
+For example, method ``format-err`` in the ``format-out`` module of the
+``io`` library becomes ``Kformat_errYformat_outVioMM0I``.
+
+For full details, see `the Hacker's guide <https://opendylan.org/documentation/hacker-guide/runtime/mangling.html?highlight=mangling>`_.
 
 Understanding stack traces
 --------------------------
@@ -105,17 +132,65 @@ entire Dylan application runs and exits prior to ``main`` being invoked.
 A reasonable alternative is to determine the C name of your entry point
 function and set a breakpoint on that instead.
 
-Inspecting Dylan objects in LLDB
+Debugging with LLDB
 --------------------------------
 
-In LLDB, you may import our Dylan support library::
+If you are using LLDB, there is a helper script provided. Start LLDB with::
 
-    command script import /path/to/opendylan/share/opendylan/lldb/dylan
+  dylan-lldb [args]
 
-Do not import the scripts under that directory directly as that will not
-work. Once this has been done, variables that are representing Dylan
-values will automatically be shown with additional data about their
-actual values.
+This will import the Dylan support library from ``/path/to/opendylan/share/opendylan/lldb/dylan``.
+Any LLDB arguments can be specified, as normal.
+
+The support library provides some extra commands and specialized
+summarizers for commonly-encountered Dylan objects.
+
+The command ``dylan-bt`` prints a Dylan-friendly backtrace by
+stripping out all frames which refer to internal runtime functions,
+leaving only Dylan code. For example, a backtrace like this::
+
+  * frame #0: 0x00007fff70e542c6 libsystem_kernel.dylib`__pthread_kill + 10
+    frame #1: 0x00007fff70f0fbf1 libsystem_pthread.dylib`pthread_kill + 284
+    frame #2: 0x00007fff70d71d8a libsystem_c.dylib`raise + 26
+    frame #3: 0x00000001001ef3bc libdylan.dylib`primitive_invoke_debugger(string=<unavailable>, arguments=<unavailable>) at c-primitives-debug.c:38:3 [opt]
+    frame #4: 0x0000000100134c34 libdylan.dylib`Kinvoke_debuggerVKiMM1I(condition_=<unavailable>) at boot.c:7140:3 [opt]
+    frame #5: 0x000000010013bd11 libdylan.dylib`Khandle_missed_dispatchVKgI(d_=<unavailable>, parent_=<unavailable>, args_={<simple-object-vector>: size: 1}) at new-dispatch.c:14382:13 [opt]
+    frame #6: 0x00000001001e5021 libdylan.dylib`general_engine_node_n_engine(a1=<unavailable>) at c-run-time.c:2023:12 [opt]
+    frame #7: 0x000000010014aaaf libdylan.dylib`Kdefault_handlerVKdMM1I(condition_=<unavailable>) at condition.c:2917:3 [opt]
+    frame #8: 0x000000010013bd11 libdylan.dylib`Khandle_missed_dispatchVKgI(d_=<unavailable>, parent_=<unavailable>, args_={<simple-object-vector>: size: 1}) at new-dispatch.c:14382:13 [opt]
+    frame #9: 0x00000001001e5021 libdylan.dylib`general_engine_node_n_engine(a1=<unavailable>) at c-run-time.c:2023:12 [opt]
+    frame #10: 0x00000001000d2b69 libcommon-dylan.dylib`Kdefault_last_handlerYcommon_dylan_internalsVcommon_dylanMM0I(condition_={<simple-error>}, next_handler_={<simple-closure-method>}) at common-extensions.c:1942:9 [opt]
+
+becomes::
+
+    frame #4    Kinvoke_debuggerVKiMM1I                                      0x00000100134c34 libdylan.dylib at boot.c:7140
+    frame #7    Kdefault_handlerVKdMM1I                                      0x0000010014aaaf libdylan.dylib at condition.c:2917
+    frame #10   Kdefault_last_handlerYcommon_dylan_internalsVcommon_dylanMM0I 0x000001000d2b69 libcommon-dylan.dylib at common-extensions.c:1942
+
+The command ``dylan-break-gf`` will set a breakpoint on all specific
+methods of a given generic function.  The generic function needs to be
+specified as ``name:module:library``, for example
+``format-err:format-out:io``.  Note that the functions may not be
+known until they are loaded, so it is necessary to run the program
+first, otherwise the message 'No generic function XXX was found.' will
+be shown.
+
+The second purpose of the helper script is to show Dylan objects in a
+more intuitive fashion. For example, lldb on its own will show most
+Dylan objects as plain hex values, for example::
+
+  (dylan_value) T33 = 0x0000000100d38060
+  (dylan_value) T35_0 = 0x00007ffeefbfe360
+  (dylan_value) Ustream_ = 0x0000000000000001
+
+With the helper, extra information is added to the right::
+
+  (dylan_value) T33 = 0x0000000100c38060 {<symbol>: #"libraries-test-suite-app"}
+  (dylan_value) T35_0 = 0x00007ffeefbfe370 {<simple-object-vector>: size: 1}
+  (dylan_value) Ustream_ = 0x0000000000000001 {<integer>: 0}
+
+The summarizer support has to be added on a class-by-class basis, so
+some objects will show only the class name without further detail.
 
 Inspecting Dylan objects in GDB
 -------------------------------

--- a/documentation/release-notes/source/2020.1.rst
+++ b/documentation/release-notes/source/2020.1.rst
@@ -179,6 +179,8 @@ GTK
 Debugging
 =========
 
+* The LLDB debugger support has been updated to work with Python 3.
+  For more information, see `Debugging with GDB or LLDB <https://opendylan.org/documentation/getting-started-cli/debugging-with-gdb-lldb.html>`_.
 
 Documentation
 =============

--- a/tools/lldb/dylan/__init__.py
+++ b/tools/lldb/dylan/__init__.py
@@ -1,38 +1,42 @@
 import lldb
 import lldb.formatters.Logger
-import commands
-import summaries
-import synthetics
+from dylan import commands
+from dylan import summaries
+from dylan import synthetics
 
 # We import various summary modules here so that the code in them can
 # execute the various registration functions.
 
 # Core summaries
-import summaries.core
-import summaries.system
+from dylan.summaries import core
+from dylan.summaries import system
 
 # Compiler (DFMC) summaries
-import summaries.dfmc.flow_graph
-import summaries.dfmc.reader
-import summaries.dfmc.modeling
-import summaries.dfmc.primitives
+from dylan.summaries.dfmc import flow_graph
+from dylan.summaries.dfmc import reader
+from dylan.summaries.dfmc import modeling
+from dylan.summaries.dfmc import primitives
 
 # LLVM summaries
-import summaries.llvm.types
-import summaries.llvm.constant
-import summaries.llvm.function
-import summaries.llvm.misc
+from dylan.summaries.llvm import types
+from dylan.summaries.llvm import constant
+from dylan.summaries.llvm import function
+from dylan.summaries.llvm import misc
 
 # Testworks
-import summaries.testworks
+from dylan.summaries import testworks
 
 def __lldb_init_module(debugger, internal_dict):
-  debugger.HandleCommand('command script add -f dylan.commands.dylan_break_gf dylan-break-gf')
-  debugger.HandleCommand('command script add -f dylan.commands.dylan_bt dylan-bt')
+  def cmd(name):
+    pyname = name.replace("-", "_")
+    helptext = "For more information run '%s -h'" % (name,)
+    return 'command script add -f dylan.commands.%s %s --help "%s"' % (pyname, name, helptext)
+  debugger.HandleCommand(cmd('dylan-break-gf'))
+  debugger.HandleCommand(cmd('dylan-bt'))
   debugger.HandleCommand('type format    add dylan_value -f hex')
   debugger.HandleCommand('type synthetic add dylan_value -l dylan.synthetics.SyntheticDylanValue -w dylan')
   debugger.HandleCommand('type synthetic add _K.* --regex -l dylan.synthetics.SyntheticDylanValue -w dylan')
-  debugger.HandleCommand('type summary   add dylan_byte_string -F dylan.summaries.core.dylan_byte_string_summary -w dylan')
+  debugger.HandleCommand('type summary   add dylan_byte_string -F dylan.summaries.core.dylan_string_summary -w dylan')
   debugger.HandleCommand('type summary   add dylan_object -F dylan.summaries.dylan_object_summary -w dylan')
   debugger.HandleCommand('type summary   add dylan_simple_object_vector -F dylan.summaries.core.dylan_simple_object_vector_summary -w dylan')
   debugger.HandleCommand('type summary   add _KL.* --regex -F dylan.summaries.dylan_object_summary -w dylan')

--- a/tools/lldb/dylan/accessors.py
+++ b/tools/lldb/dylan/accessors.py
@@ -1,7 +1,12 @@
-import lldb
-import struct
+"""
+Contains routines to work with Dylan objects obtained from
+LLDB's SBValue objects
+"""
 
-import mangling
+import struct
+import array
+import lldb
+from dylan.mangling import dylan_mangle_wrapper
 
 OBJECT_TAG = 0
 INTEGER_TAG = 1
@@ -32,50 +37,58 @@ UNICODE_STRING_SIZE = 0
 UNICODE_STRING_DATA = 1
 
 CLASS_SLOT_NAMES_CACHE = {}
+"""Map of wrapper address to list of slot names"""
 
 def ensure_value_class(value, class_name, module, library):
+  """Raise an exception if the value is not a member of the given class"""
   wrappersym = dylan_object_wrapper_symbol_name(value)
-  wrapper_symbol_name = mangling.dylan_mangle_wrapper(class_name, module, library)
+  wrapper_symbol_name = dylan_mangle_wrapper(class_name, module, library)
   if wrappersym != wrapper_symbol_name:
     raise Exception("%#x is not a %s (%s != %s)" % (int(value.address_of.GetValueAsUnsigned()), class_name, wrappersym, wrapper_symbol_name))
 
 def check_value_class(value, class_name, module, library):
+  """Return True if the value is a member of the given class"""
   actual_wrapper_name = dylan_object_wrapper_symbol_name(value)
-  desired_wrapper_name = mangling.dylan_mangle_wrapper(class_name, module, library)
+  desired_wrapper_name = dylan_mangle_wrapper(class_name, module, library)
   return actual_wrapper_name == desired_wrapper_name
 
 def dylan_tag_bits(value):
+  """Get type tag bits from a value"""
   return value.GetValueAsUnsigned() & 3
 
 def dylan_boolean_value(value):
+  """Return value as True/False"""
   ensure_value_class(value, '<boolean>', 'dylan', 'dylan')
   return not dylan_is_false(value)
 
 def dylan_byte_character_value(value):
+  """Return value as a character"""
   byte_value = value.GetValueAsUnsigned() >> 2
   if byte_value < 0 or byte_value > 255:
     return chr(0)
   return chr(byte_value)
 
 def dylan_byte_string_data(value):
+  """Return raw data from a <byte-string> value as a bytes object"""
   ensure_value_class(value, '<byte-string>', 'dylan', 'dylan')
   size = dylan_integer_value(dylan_slot_element(value, BYTE_STRING_SIZE))
-  if size == 0:
-    return ''
   return dylan_read_raw_data(value, BYTE_STRING_DATA, size)
 
 def dylan_class_name(value):
+  """Return value's class name as a string"""
   # We can't check that this is a <class> here as it might also
   # be a <function-class> or other subclass of <class>.
   class_name = dylan_slot_element(value, CLASS_DEBUG_NAME)
-  return dylan_byte_string_data(class_name)
+  return dylan_string(class_name)
 
 def dylan_double_float_data(value):
+  """Return value as a double-precision float"""
   ensure_value_class(value, '<double-float>', 'dylan', 'dylan')
   data = dylan_read_raw_data(value, DOUBLE_FLOAT_DATA, 8)
   return struct.unpack('d', data)[0]
 
 def dylan_double_integer_value(value):
+  """Return value as an integer"""
   ensure_value_class(value, '<double-integer>', 'dylan-extensions', 'dylan')
   target = lldb.debugger.GetSelectedTarget()
   int_type = target.GetBasicType(lldb.eBasicTypeInt)
@@ -84,6 +97,7 @@ def dylan_double_integer_value(value):
   return lo.GetValueAsSigned() + (hi.GetValueAsSigned() << 32)
 
 def dylan_float_data(value):
+  """Return value as a floating point number"""
   if dylan_is_single_float(value):
     return dylan_single_float_data(value)
   elif dylan_is_double_float(value):
@@ -93,69 +107,86 @@ def dylan_float_data(value):
     raise Exception("%s is a new type of float? %s" % (value, class_name))
 
 def dylan_generic_function_name(value):
-  return dylan_byte_string_data(dylan_slot_element(value, GENERIC_FUNCTION_DEBUG_NAME))
+  """Return the debug name of a generic function value as a string""" 
+  return  dylan_string(dylan_slot_element(value, GENERIC_FUNCTION_DEBUG_NAME))
 
 def dylan_generic_function_methods(value):
+  """Return the list of specializer methods of a generic function value as SBValues"""
   return dylan_list_elements(dylan_slot_element(value, GENERIC_FUNCTION_METHODS))
 
 def dylan_implementation_class_instance_slot_descriptors(iclass):
+  """Return the slot descriptors from an implementation class as an SBValue representing a <simple-object-vector>"""
   return dylan_slot_element(iclass, IMPLEMENTATION_CLASS_INSTANCE_SLOT_DESCRIPTORS)
 
 def dylan_implementation_class_repeated_slot_descriptor(iclass):
+  """Return the repeated slot descriptor from an implementation class as an SBValue or None if there isn't one"""
   repeated_slot = dylan_slot_element(iclass, IMPLEMENTATION_CLASS_REPEATED_SLOT_DESCRIPTOR)
   if dylan_is_false(repeated_slot):
     return None
   return repeated_slot
 
 def dylan_integer_value(value):
+  """Return value as an integer"""
   return value.GetValueAsUnsigned() >> 2
 
 def dylan_is_boolean(value):
+  """Return True if this value is a <boolean>"""
   return check_value_class(value, '<boolean>', 'dylan', 'dylan')
 
-def dylan_is_byte_string(value):
-  return check_value_class(value, '<byte-string>', 'dylan', 'dylan')
+def dylan_is_float(value):
+  """Return True if this value is a <float>"""
+  return dylan_is_double_float(value) or dylan_is_single_float(value)
+
+def dylan_is_single_float(value):
+  """Return True if this value is a <single-float>"""
+  return check_value_class(value, '<single-float>', 'dylan', 'dylan')
 
 def dylan_is_double_float(value):
+  """Return True if this value is a <double-float>"""
   return check_value_class(value, '<double-float>', 'dylan', 'dylan')
 
 def dylan_is_false(value):
+  """Return True if this value is #f"""
   target = lldb.debugger.GetSelectedTarget()
   address = lldb.SBAddress(value.GetValueAsUnsigned(), target)
-  if address.symbol.name == 'KPfalseVKi':
-    return True
-
-def dylan_is_float(value):
-  return dylan_is_double_float(value) or dylan_is_single_float(value)
+  return address.symbol.name == 'KPfalseVKi'
 
 def dylan_is_list(value):
+  """Return True if this value is a list (i.e., an instance of <pair>)"""
   return check_value_class(value, '<pair>', 'dylan', 'dylan')
 
 def dylan_is_simple_vector(value):
+  """Return True if this value is a <simple-object-vector>"""
   # XXX: Check for just <simple-object-vector> until we start looking at
   #      actual inheritance data.
   return check_value_class(value, '<simple-object-vector>', 'dylan', 'dylan')
 
-def dylan_is_single_float(value):
-  return check_value_class(value, '<single-float>', 'dylan', 'dylan')
-
 def dylan_is_stretchy_vector(value):
+  """Return True if this value is a <stretchy-object-vector>"""
   # XXX: Check for just <stretchy-object-vector> until we start looking at
   #      actual inheritance data.
   return check_value_class(value, '<stretchy-object-vector>', 'dylan', 'dylan')
 
 def dylan_is_string(value):
+  """Return True if this value is a <string>"""
   return dylan_is_byte_string(value) or dylan_is_unicode_string(value)
 
+def dylan_is_byte_string(value):
+  """Return True if this value is a <byte-string>"""
+  return check_value_class(value, '<byte-string>', 'dylan', 'dylan')
+
 def dylan_is_unicode_string(value):
+  """Return True if this value is a <unicode-string>"""
   return check_value_class(value, '<unicode-string>', 'dylan', 'dylan')
 
 def dylan_list_empty(value):
+  """Return True if this value is the empty list"""
   target = lldb.debugger.GetSelectedTarget()
   empty_list = target.FindFirstGlobalVariable('KPempty_listVKi').AddressOf().GetValueAsUnsigned()
   return value.GetValueAsUnsigned() == empty_list
 
 def dylan_list_elements(value):
+  """Assuming value is a list, return all the elements of value as a list of SBValues"""
   elements = []
   target = lldb.debugger.GetSelectedTarget()
   empty_list = target.FindFirstGlobalVariable('KPempty_listVKi').AddressOf().GetValueAsUnsigned()
@@ -165,10 +196,12 @@ def dylan_list_elements(value):
   return elements
 
 def dylan_machine_word_value(value):
+  """Get the value of a <machine-word> as an integer"""
   ensure_value_class(value, '<machine-word>', 'dylan-extensions', 'dylan')
   return dylan_slot_element(value, 0).GetValueAsUnsigned()
 
 def dylan_method_iep_function(value):
+  """Get the internal entry point (IEP) of a function"""
   def get_iep(value):
     if dylan_object_wrapper_subtype_mask(value) & 8192:
       return dylan_slot_element(value, KEYWORD_METHOD_IEP)
@@ -180,17 +213,20 @@ def dylan_method_iep_function(value):
   return address.GetFunction()
 
 def dylan_object_class(value):
+  """Return the class of an object as an SBValue"""
   iclass = dylan_object_implementation_class(value)
   ensure_value_class(iclass, '<implementation-class>', 'dylan-extensions', 'dylan')
   return dylan_slot_element(iclass, IMPLEMENTATION_CLASS_CLASS)
 
 def dylan_object_class_slot_descriptors(value):
+  """Return an object's slot descriptors as a list of SBValues"""
   # XXX: Add the repeated slot descriptor to this.
   iclass = dylan_object_implementation_class(value)
   descriptors = dylan_implementation_class_instance_slot_descriptors(iclass)
   return dylan_vector_elements(descriptors)
 
 def dylan_object_class_slot_names(value):
+  """Return an object's slot names as a list of strings"""
   wrapper_address = dylan_object_wrapper_address(value)
   cached_slot_names = CLASS_SLOT_NAMES_CACHE.get(wrapper_address, None)
   if cached_slot_names:
@@ -200,6 +236,7 @@ def dylan_object_class_slot_names(value):
   return slot_names
 
 def dylan_object_class_repeated_slot_name(value):
+  """Get the name of an object's repeated slot name as a string or None if there isn't one"""
   iclass = dylan_object_implementation_class(value)
   slot = dylan_implementation_class_repeated_slot_descriptor(iclass)
   if slot:
@@ -207,20 +244,24 @@ def dylan_object_class_repeated_slot_name(value):
   return None
 
 def dylan_object_class_name(value):
+  """Return the name of an object's class as a string"""
   class_object = dylan_object_class(value)
   return dylan_class_name(class_object)
 
 def dylan_object_implementation_class(value):
+  """Return the implementation class of an object as an SBValue"""
   wrapper = dylan_object_wrapper(value)
   return dylan_slot_element(wrapper, MM_WRAPPER_IMPLEMENTATION_CLASS)
 
 def dylan_object_wrapper(value):
+  """Return the wrapper for an object as an SBValue"""
   address = value.GetValueAsUnsigned()
   target = lldb.debugger.GetSelectedTarget()
   dylan_value_type = target.FindFirstType('dylan_value')
   return value.CreateValueFromAddress("wrapper", address, dylan_value_type)
 
 def dylan_object_wrapper_address(value):
+  """Return the machine address of an object's wrapper"""
   error = lldb.SBError()
   address = value.process.ReadPointerFromMemory(value.GetValueAsUnsigned(), error)
   if error.Success():
@@ -229,21 +270,25 @@ def dylan_object_wrapper_address(value):
     raise Exception(error.description)
 
 def dylan_object_wrapper_class(value):
+  """Return the implementation class of an object's wrapper as an SBValue"""
   ensure_value_class(value, '<mm-wrapper>', 'internal', 'dylan')
   iclass = dylan_slot_element(value, MM_WRAPPER_IMPLEMENTATION_CLASS)
   ensure_value_class(iclass, '<implementation-class>', 'dylan-extensions', 'dylan')
   return dylan_slot_element(iclass, IMPLEMENTATION_CLASS_CLASS)
 
 def dylan_object_wrapper_class_name(value):
+  """Return the name of an object's wrapper class as a string""" 
   class_object = dylan_object_wrapper_class(value)
   return dylan_class_name(class_object)
 
 def dylan_object_wrapper_subtype_mask(value):
+  """Return an object's wrapper subtype mask"""
   wrapper = dylan_object_wrapper(value)
   mask = dylan_slot_element(wrapper, MM_WRAPPER_SUBTYPE_MASK)
   return dylan_integer_value(mask)
 
 def dylan_object_wrapper_symbol_name(value):
+  """Return wrapper name of value as a string"""
   # We don't want to get the actual wrapper value object here
   # as that creates circular loops with synthetics by creating
   # an object, which creates a synthetic which looks at the wrapper
@@ -260,6 +305,9 @@ def dylan_object_wrapper_symbol_name(value):
   return address.symbol.name
 
 def dylan_read_raw_data(value, slot_index, size):
+  """Copy out and return size bytes from value at the indexed slot as a bytes object"""
+  if size == 0:
+    return b'';
   target = lldb.debugger.GetSelectedTarget()
   word_size = target.GetAddressByteSize()
   data_start = value.GetValueAsUnsigned() + ((1 + slot_index) * word_size)
@@ -271,28 +319,35 @@ def dylan_read_raw_data(value, slot_index, size):
     raise Exception(error.description)
 
 def dylan_simple_vector_size(vector):
+  """Return the size of a vector"""
   return dylan_integer_value(dylan_slot_element(vector, SIMPLE_OBJECT_VECTOR_SIZE))
 
 def dylan_simple_vector_element(vector, index):
+  """Return an element from a vector by index as an SBValue"""
   return dylan_slot_element(vector, SIMPLE_OBJECT_VECTOR_DATA + index)
 
 def dylan_single_float_data(value):
+  """Return value as a single-precision float"""
   ensure_value_class(value, '<single-float>', 'dylan', 'dylan')
   data = dylan_read_raw_data(value, SINGLE_FLOAT_DATA, 4)
   return struct.unpack('f', data)[0]
 
 def dylan_slot_index(value, name):
+  """Return the index of a named slot in an object"""
   slot_names = dylan_object_class_slot_names(value)
   return slot_names.index(name)
 
 def dylan_slot_descriptor_getter(value):
+  """Return a value's slot descriptor getter as an SBValue"""
   return dylan_slot_element(value, SLOT_DESCRIPTOR_GETTER)
 
 def dylan_slot_descriptor_name(value):
+  """Return a slot getter name as a string"""
   getter = dylan_slot_descriptor_getter(value)
   return dylan_generic_function_name(getter)
 
 def dylan_slot_element(value, index, name=None):
+  """Assuming value is a Dylan object, return the slot with the given index as an SBValue"""
   target = lldb.debugger.GetSelectedTarget()
   word_size = target.GetAddressByteSize()
   dylan_value_type = target.FindFirstType('dylan_value')
@@ -301,18 +356,22 @@ def dylan_slot_element(value, index, name=None):
   return value.CreateChildAtOffset(name, offset, dylan_value_type)
 
 def dylan_slot_element_by_name(value, name):
+  """Assuming value is a Dylan object, return the named slot as an SBValue"""
   slot_index = dylan_slot_index(value, name)
   return dylan_slot_element(value, slot_index, '[' + name + ']')
 
 def dylan_stretchy_vector_size(vector):
+  """Return size of a stretchy vector"""
   representation = dylan_slot_element_by_name(vector, 'stretchy-representation')
   return dylan_integer_value(dylan_slot_element(representation, SIMPLE_OBJECT_VECTOR_SIZE))
 
 def dylan_stretchy_vector_element(vector, index):
+  """Return one indexed element of a vector as an SBValue"""
   representation = dylan_slot_element_by_name(vector, 'stretchy-representation')
   return dylan_slot_element(representation, SIMPLE_OBJECT_VECTOR_DATA + index)
 
 def dylan_string_data(value):
+  """If it is a string, return contents of value as a bytes object"""
   if dylan_is_byte_string(value):
     return dylan_byte_string_data(value)
   elif dylan_is_unicode_string(value):
@@ -321,24 +380,45 @@ def dylan_string_data(value):
     class_name = dylan_object_class_name(value)
     raise Exception("%s is a new type of string? %s" % (value, class_name))
 
+def dylan_string(value):
+  """Assuming value is a Dylan string, return it as a Python str"""
+  if dylan_is_byte_string(value):
+    return str(dylan_byte_string_data(value), 'utf-8')
+  elif dylan_is_unicode_string(value):
+    data = dylan_unicode_string_data(value)
+    intsize = value.GetTarget().GetAddressByteSize()
+    if intsize == 8:
+      data_format = 'Q'
+    elif intsize == 4:
+      data_format = 'L'
+    else:
+      raise Exception("Unsupported character size")
+    return ''.join((chr(x) for x in array.array(data_format, data)))
+  else:
+    raise Exception("%s is a new type of string? %s" % (value, class_name))
+  
 def dylan_symbol_name(value):
+  """Return a symbol as a string"""
   ensure_value_class(value, '<symbol>', 'dylan', 'dylan')
   name = dylan_slot_element(value, SYMBOL_NAME)
-  return dylan_byte_string_data(name)
+  return dylan_string(name)
 
 def dylan_unicode_character_value(value):
-  return unichr(value.GetValueAsUnsigned() >> 2).encode('utf8')
+  """Return a value as a chr"""
+  codepoint = value.GetValueAsUnsigned() >> 2
+  # May raise here if not valid unicode, will handle it later
+  return chr(codepoint)
 
 def dylan_unicode_string_data(value):
+  """Return a value as a bytes object"""
   ensure_value_class(value, '<unicode-string>', 'dylan', 'dylan')
   size = dylan_integer_value(dylan_slot_element(value, UNICODE_STRING_SIZE))
-  if size == 0:
-    return ''
-  # We don't need to read the null termination because we don't want that in
-  # our UTF-8 encoded result.
-  data = dylan_read_raw_data(value, UNICODE_STRING_DATA, size * 4)
+  # Dylan's <unicode-character> is the same as <integer> hence is pointer-sized
+  intsize = value.GetTarget().GetAddressByteSize()
+  return dylan_read_raw_data(value, UNICODE_STRING_DATA, size * intsize)
 
 def dylan_sequence_empty(sequence):
+  """Return True if sequence is empty"""
   if dylan_is_simple_vector(sequence):
     return dylan_simple_vector_size(sequence) == 0
   elif dylan_is_stretchy_vector(sequence):
@@ -350,6 +430,7 @@ def dylan_sequence_empty(sequence):
     raise Exception("%s is a new type of sequence? %s" % (sequence, class_name))
 
 def dylan_vector_size(vector):
+  """Return size of a vector"""
   if dylan_is_simple_vector(vector):
     return dylan_simple_vector_size(vector)
   elif dylan_is_stretchy_vector(vector):
@@ -358,6 +439,7 @@ def dylan_vector_size(vector):
     return 0
 
 def dylan_vector_element(vector, index):
+  """Return indexed element of vector as an SBValue"""
   if dylan_is_simple_vector(vector):
     return dylan_simple_vector_element(vector, index)
   elif dylan_is_stretchy_vector(vector):
@@ -366,6 +448,7 @@ def dylan_vector_element(vector, index):
     return None
 
 def dylan_vector_elements(vector):
+  """Return all elements of vector as a list of SBValues"""
   elements = []
   # Specialize a bit to save a lot of extra type checks.
   if dylan_is_simple_vector(vector):

--- a/tools/lldb/dylan/accessors.py
+++ b/tools/lldb/dylan/accessors.py
@@ -112,7 +112,11 @@ def dylan_generic_function_name(value):
 
 def dylan_generic_function_methods(value):
   """Return the list of specializer methods of a generic function value as SBValues"""
-  return dylan_list_elements(dylan_slot_element(value, GENERIC_FUNCTION_METHODS))
+  methods = dylan_slot_element(value, GENERIC_FUNCTION_METHODS)
+  if methods.GetError().Success():
+    return dylan_list_elements(dylan_slot_element(value, GENERIC_FUNCTION_METHODS))
+  else:
+    raise Exception("'%s' was not a valid GF" % (value.GetName(),))
 
 def dylan_implementation_class_instance_slot_descriptors(iclass):
   """Return the slot descriptors from an implementation class as an SBValue representing a <simple-object-vector>"""

--- a/tools/lldb/dylan/commands.py
+++ b/tools/lldb/dylan/commands.py
@@ -32,10 +32,14 @@ def dylan_bt(debugger, command, result, internal_dict):
   thread = process.GetSelectedThread()
     
   for frame_idx, frame in enumerate(thread):
-    function = frame.GetFunctionName()
+    function = frame.GetFunction()
+    language = function.GetLanguage()
     function_name = frame.GetFunctionName() or ''
     is_dylan_function = False
-    if function_name and function_name.startswith('K') and function_name.endswith('I'):
+    if language == lldb.eLanguageTypeDylan or \
+       (function_name and \
+        function_name.startswith('K') and \
+        function_name.endswith('I'):
       if not function_name in INTERNAL_RUNTIME_FUNCTIONS:
         is_dylan_function = True
     if not options.all_frames:

--- a/tools/lldb/dylan/commands.py
+++ b/tools/lldb/dylan/commands.py
@@ -89,7 +89,11 @@ using this command
     if gf.GetError().Fail():
       print("No generic function %s was found." % (arg,))
       continue
-    methods = dylan_generic_function_methods(gf)
+    try:
+      methods = dylan_generic_function_methods(gf)
+    except:
+      print("Not able to determine methods of %s" % (arg,))
+      return
     ieps = [dylan_method_iep_function(m) for m in methods]
     # Create a breakpoint for each IEP rather than a single one for
     # all IEPs since there isn't an appropriate typemap in the SWIG

--- a/tools/lldb/dylan/commands.py
+++ b/tools/lldb/dylan/commands.py
@@ -19,7 +19,7 @@ def dylan_bt(debugger, command, result, internal_dict):
 
   try:
     options = parser.parse_args(command_args)
-  except:
+  except Exception:
     return
 
   target = debugger.GetSelectedTarget()
@@ -73,7 +73,7 @@ using this command
   parser.add_argument('gf', nargs='+', help='binding name in the form "name:module:library"')
   try:
     options = parser.parse_args(command_args)
-  except:
+  except Exception:
     return
 
   target = debugger.GetSelectedTarget()
@@ -91,7 +91,7 @@ using this command
       continue
     try:
       methods = dylan_generic_function_methods(gf)
-    except:
+    except Exception:
       print("Not able to determine methods of %s" % (arg,))
       return
     ieps = [dylan_method_iep_function(m) for m in methods]

--- a/tools/lldb/dylan/summaries/__init__.py
+++ b/tools/lldb/dylan/summaries/__init__.py
@@ -68,7 +68,10 @@ def dylan_integer_summary(value, internal_dict):
 def dylan_unicode_character_summary(value, internal_dict):
   try:
     unicode_character = dylan_unicode_character_value(value)
-    return '{<unicode-character>: %s}' % (unicode_character,)
+    if unicode_character.isprintable():
+      return '{<unicode-character>: %s (0x%x)}' % (unicode_character, ord(unicode_character))
+    else:
+      return '{<unicode-character>: (0x%x)}' % (ord(unicode_character), )
   except ValueError:
     return '{<unicode-character> (invalid)}'
 

--- a/tools/lldb/dylan/summaries/__init__.py
+++ b/tools/lldb/dylan/summaries/__init__.py
@@ -48,23 +48,29 @@ def dylan_object_summary(value, internal_dict):
     if summary is not None:
       return '{%s: %s}' % (class_name, summary)
     else:
-      return '{%s}' % class_name
+      return '{%s}' % (class_name,)
   else:
     try:
-      return '{%s}' % dylan_object_class_name(value)
+      return '{%s}' % (dylan_object_class_name(value),)
     except:
       return '{uninitialized}'
 
 def dylan_byte_character_summary(value, internal_dict):
   byte_character = dylan_byte_character_value(value)
-  return '{<byte-character>: %s (%s)}' % (byte_character, ord(byte_character))
+  if byte_character.isprintable():
+    return '{<byte-character>: %s (0x%x)}' % (byte_character, ord(byte_character))
+  else:
+    return '{<byte-character>: (0x%x)}' % (ord(byte_character),)
 
 def dylan_integer_summary(value, internal_dict):
-  return '{<integer>: %s}' % dylan_integer_value(value)
+  return '{<integer>: %s}' % (dylan_integer_value(value),)
 
 def dylan_unicode_character_summary(value, internal_dict):
-  unicode_character = dylan_unicode_character_value(value)
-  return '{<unicode-character>: %s}' % unicode_character
+  try:
+    unicode_character = dylan_unicode_character_value(value)
+    return '{<unicode-character>: %s}' % (unicode_character,)
+  except ValueError:
+    return '{<unicode-character> (invalid)}'
 
 def register(binding, module, library):
   def _register(function):

--- a/tools/lldb/dylan/summaries/core.py
+++ b/tools/lldb/dylan/summaries/core.py
@@ -1,4 +1,3 @@
-import array
 import lldb
 from dylan.accessors import *
 from dylan import summaries

--- a/tools/lldb/dylan/summaries/dfmc/modeling.py
+++ b/tools/lldb/dylan/summaries/dfmc/modeling.py
@@ -4,9 +4,9 @@ from dylan import summaries
 @summaries.register('<&class>', 'dfmc-modeling', 'dfmc-modeling')
 def class_summary(value, internal_dict):
   name = dylan_slot_element_by_name(value, 'private-^debug-name')
-  return dylan_string_data(name)
+  return dylan_string(name)
 
 @summaries.register('<&raw-type>', 'dfmc-modeling', 'dfmc-modeling')
 def raw_type_summary(value, internal_dict):
   name = dylan_slot_element_by_name(value, '^debug-name')
-  return dylan_string_data(name)
+  return dylan_string(name)

--- a/tools/lldb/dylan/summaries/dfmc/primitives.py
+++ b/tools/lldb/dylan/summaries/dfmc/primitives.py
@@ -10,4 +10,4 @@ def primitive_summary(value, internal_dict):
 @summaries.register('<&objc-msgsend>', 'dfmc-modeling', 'dfmc-modeling')
 def c_function_summary(value, internal_dict):
   name = dylan_slot_element_by_name(value, 'c-function-name')
-  return dylan_byte_string_data(name)
+  return dylan_string(name)

--- a/tools/lldb/dylan/summaries/dfmc/reader.py
+++ b/tools/lldb/dylan/summaries/dfmc/reader.py
@@ -15,7 +15,7 @@ def name_fragment_summary(value, internal_dict):
 @summaries.register('<string-fragment>', 'dfmc-reader', 'dfmc-reader')
 def string_fragment_summary(value, internal_dict):
   value = dylan_slot_element_by_name(value, 'fragment-value')
-  return dylan_string_data(value)
+  return dylan_string(value)
 
 @summaries.register('<keyword-syntax-symbol-fragment>', 'dfmc-reader', 'dfmc-reader')
 @summaries.register('<symbol-syntax-symbol-fragment>', 'dfmc-reader', 'dfmc-reader')

--- a/tools/lldb/dylan/summaries/llvm/function.py
+++ b/tools/lldb/dylan/summaries/llvm/function.py
@@ -8,5 +8,5 @@ def llvm_argument_summary(value, internal_dict):
   argument_name = ''
   # argument_name_value is false-or(<string>)
   if not dylan_is_false(argument_name_value):
-    argument_name = ' ' + dylan_byte_string_data(argument_name_value)
+    argument_name = ' ' + dylan_string(argument_name_value)
   return '%s%s' % (summaries.summary(argument_type), argument_name)

--- a/tools/lldb/dylan/summaries/llvm/misc.py
+++ b/tools/lldb/dylan/summaries/llvm/misc.py
@@ -7,19 +7,19 @@ def llvm_basic_block_summary(value, internal_dict):
   # bblock_name_value is false-or(<string>)
   if dylan_is_false(bblock_name_value):
     return ''
-  return dylan_string_data(bblock_name_value)
+  return dylan_string(bblock_name_value)
 
 @summaries.register('<llvm-metadata-string>', 'llvm', 'llvm')
 def llvm_metadata_string_summary(value, internal_dict):
   string_value = dylan_slot_element_by_name(value, 'llvm-metadata-string')
-  return dylan_string_data(string_value)
+  return dylan_string(string_value)
 
 @summaries.register('<llvm-named-metadata>', 'llvm', 'llvm')
 def llvm_named_metadata_summary(value, internal_dict):
   name_value = dylan_slot_element_by_name(value, 'llvm-named-metadata-name')
-  return dylan_string_data(name_value)
+  return dylan_string(name_value)
 
 @summaries.register('<llvm-module>', 'llvm', 'llvm')
 def llvm_module_summary(value, internal_dict):
   module_name_value = dylan_slot_element_by_name(value, 'llvm-module-name')
-  return dylan_string_data(module_name_value)
+  return dylan_string(module_name_value)

--- a/tools/lldb/dylan/summaries/llvm/types.py
+++ b/tools/lldb/dylan/summaries/llvm/types.py
@@ -6,7 +6,7 @@ def llvm_array_type_summary(value, internal_dict):
   size_value = dylan_slot_element_by_name(value, 'llvm-array-type-size')
   size = dylan_integer_value(size_value)
   element_type = dylan_slot_element_by_name(value, 'llvm-array-type-element-type')
-  return '[%d x %s]' % size, summaries.summary(element_type)
+  return '[%d x %s]' % (size, summaries.summary(element_type))
 
 @summaries.register('<llvm-function-type>', 'llvm', 'llvm')
 def llvm_function_type_summary(value, internal_dict):
@@ -54,7 +54,7 @@ def llvm_primitive_type_summary(value, internal_dict):
 def llvm_struct_type_summary(value, internal_dict):
   struct_name = dylan_slot_element_by_name(value, 'llvm-struct-type-name')
   if dylan_is_string(struct_name):
-    return '%' + dylan_string_data(struct_name)
+    return '%' + dylan_string(struct_name)
   elif dylan_is_false(struct_name):
     name = '{'
     first = True
@@ -74,4 +74,4 @@ def llvm_vector_type_summary(value, internal_dict):
   size_value = dylan_slot_element_by_name(value, 'llvm-vector-type-size')
   size = dylan_integer_value(size_value)
   element_type = dylan_slot_element_by_name(value, 'llvm-vector-type-element-type')
-  return '[%d x %s]' % size, summaries.summary(element_type)
+  return '[%d x %s]' % (size, summaries.summary(element_type))

--- a/tools/lldb/dylan/summaries/system.py
+++ b/tools/lldb/dylan/summaries/system.py
@@ -9,7 +9,7 @@ def posix_directory_locator_summary(value, internal_dict):
   if not dylan_boolean_value(relative):
     summary += '/'
   for p in dylan_vector_elements(path):
-    summary += dylan_string_data(p)
+    summary += dylan_string(p)
     summary += '/'
   return summary
 
@@ -22,8 +22,8 @@ def posix_file_locator_summary(value, internal_dict):
   if not dylan_is_false(directory):
     summary += summaries.summary(directory)
   if not dylan_is_false(base):
-    summary += dylan_string_data(base)
+    summary += dylan_string(base)
   if not dylan_is_false(extension):
     summary += '.'
-    summary += dylan_string_data(extension)
+    summary += dylan_string(extension)
   return summary

--- a/tools/lldb/dylan/summaries/testworks.py
+++ b/tools/lldb/dylan/summaries/testworks.py
@@ -5,7 +5,7 @@ from dylan import summaries
 @summaries.register('<test>', '%testworks', 'testworks')
 def runnable_summary(value, internal_dict):
   name = dylan_slot_element_by_name(value, 'component-name')
-  summary = dylan_string_data(name)
+  summary = dylan_string_data(name).decode('utf-8')
   tags = dylan_slot_element_by_name(value, 'test-tags')
   if not dylan_sequence_empty(tags):
     summary += ' (tags: '
@@ -16,9 +16,9 @@ def runnable_summary(value, internal_dict):
 @summaries.register('<suite>', '%testworks', 'testworks')
 def suite_summary(value, internal_dict):
   name = dylan_slot_element_by_name(value, 'component-name')
-  return dylan_string_data(name)
+  return dylan_string(name)
 
 @summaries.register('<tag>', '%testworks', 'testworks')
 def tag_summary(value, internal_dict):
   name = dylan_slot_element_by_name(value, 'tag-name')
-  return dylan_string_data(name)
+  return dylan_string(name)

--- a/tools/lldb/dylan/synthetics.py
+++ b/tools/lldb/dylan/synthetics.py
@@ -1,5 +1,5 @@
 import lldb
-from accessors import *
+from dylan.accessors import *
 
 class SyntheticHideChildren(object):
   """A synthetic that shows no children."""
@@ -112,7 +112,7 @@ class SyntheticSimpleObjectVector(object):
     if index >= 0 and index < self.element_count:
       # +2 is to skip past the object header and the size.
       offset = (index + 2) * self.dylan_value_type.GetByteSize()
-      return self.value.CreateChildAtOffset('[%d]' % index, offset, self.dylan_value_type)
+      return self.value.CreateChildAtOffset('[%d]' % (index,), offset, self.dylan_value_type)
     return None
 
   def has_children(self):

--- a/tools/scripts/dylan-lldb
+++ b/tools/scripts/dylan-lldb
@@ -1,11 +1,37 @@
 #! /bin/sh
 
+# Dylan LLDB helper script
+# This starts LLDB with some useful extensions preloaded
+# Usage: dylan-lldb [args...]
+# where [args...] are any LLDB arguments or options.
+
+# Relevant environment variables:
+# OPEN_DYLAN_LLDB - overrides the location of the lldb executable 
+#  Default is `lldb` on the path.
+# OPEN_DYLAN_LLDB_HELPER - overrides the location of the extension packages
+#  Default is ./share/opendylan/lldb/dylan relative to the OD installation firectory. For development use mainly
+# PYTHONPATH - this is used by LLDB itself to find the Python support packages
+#  On some systems it needs to be set manually, for example lldb-9 on Debian has PYTHONPATH=/usr/lib/llvm-9/lib/python3.7/site-packages
+#  Default is whatever `lldb -P` prints
+
+
 # Find some pathnames
-compiler=`which dylan-compiler`
-lldb=$OPEN_DYLAN_LLDB
+lldb="$OPEN_DYLAN_LLDB"
 if test ! -x "$lldb"; then
   lldb=`which lldb`
 fi
+helper="$OPEN_DYLAN_LLDB_HELPER"
+if test xx = x"$helper"x; then
+    # If we weren't given the helper explicitly, look
+    # relative to the compiler on the path
+    compiler=`which dylan-compiler`
+    if test -x "$compiler"; then
+	compilerDir="`dirname "$compiler"`"
+	# Normalize the path name. Can't use realpath or readlink due to portability.
+	dylanDir="`cd "${compilerDir}"/..;pwd`"
+	helper=$dylanDir/share/opendylan/lldb/dylan
+    fi
+fi    
 
 # Exit if there's an error
 # We do this after finding the path names as the script
@@ -13,23 +39,15 @@ fi
 set -e
 
 # Validate pathnames
-if test ! -x "$compiler"; then
-  echo "Could not find 'dylan-compiler' on the PATH."
-  exit 1
-fi
 
 if test ! -x "$lldb"; then
   echo "Could not find 'lldb' on the PATH."
   exit 1
 fi
-
-compilerDir="`dirname "$compiler"`"
-# Normalize the path name. Can't use realpath or readlink due to portability.
-dylanDir="`cd "${compilerDir}"/..;pwd`"
-helper=$dylanDir/share/opendylan/lldb/dylan
 if test ! -d "$helper"; then
   echo "Could not find $helper."
   exit 1
 fi
+
 
 $lldb -O "command script import $helper" "$@"


### PR DESCRIPTION
Make minor changes for Python 3 (e.g. change print statements to functions).
Modify the code to account for the different relationship of
bytes and string objects in Python 3.
Add comments to the accessor functions.
Add some inline help to the dylan-bt and dylan-break-gf add-in commands.
Improve flexibility of file locations in the dylan-lldb helper script.