### PR TITLE
Text mode compiler progress bar output

### DIFF
--- a/documentation/library-reference/source/index.rst
+++ b/documentation/library-reference/source/index.rst
@@ -18,6 +18,7 @@ provided with Open Dylan.
    hash-algorithms/index
    io/index
    coloring-stream/index
+   progress-stream/index
    logging/index
    numbers
    network/index

--- a/documentation/library-reference/source/progress-stream/index.rst
+++ b/documentation/library-reference/source/progress-stream/index.rst
@@ -1,0 +1,60 @@
+***************************
+The progress-stream library
+***************************
+
+.. current-library:: progress-stream
+.. current-module:: progress-stream
+
+Many text-mode programs that perform long-running, non-interactive
+tasks (such as compilers) provide a running indication of what
+fraction of the task is complete using a bar graph drawn using text
+characters. This library implements a wrapper stream that interleaves
+the progress bar graph with any status output. When output is not
+directed to a console then progress updates are ignored.
+
+.. class:: <progress-stream>
+   :abstract:
+   :instantiable:
+
+   :superclasses: :class:`<wrapper-stream>`
+
+   :keyword force?: If true, forces the wrapped stream to be treated as
+                    a console, allowing textual progress bar output.
+
+   :keyword: bar-width: An instance of :drm:`<integer>` representing
+             the number of bar characters to be included in textual
+             progress bar output. Defaults to 40.
+
+   :keyword: line-width: An instance of :drm:`<integer>` representing
+             the total line width (including both progress bar and label)
+             in characters. Defaults to 79.
+
+.. generic-function:: show-progress
+
+   :signature: show-progress (stream position range #key label) => ()
+
+   :parameter stream: An instance of :class:`<progress-stream>`.
+   :parameter position: An instance of :drm:`<integer>`.
+   :parameter range: An instance of :drm:`<integer>`.
+   :parameter #key label: An instance of :drm:`<object>`.
+
+   :description:
+
+      Graphically displays the current progress, proportional to
+      *position* divided by *range*, to the given *stream*. In the
+      case where *stream* is a console (i.e., unredirected
+      :var:`*standard-output*`), :gf:`show-progress` will draw a
+      textual progress bar with overall width configured in the
+      :class:`<progress-stream>` instance.
+
+.. generic-function:: stream-supports-show-progress?
+
+   :signature: stream-supports-show-progress? (stream) => (supports-show-progress?)
+
+   :parameter stream: An instance of :class:`<stream>`.
+   :value supports-show-progress?: An instance of :drm:`<boolean>`.
+
+   :description:
+
+      Returns a true value if the *stream* argument can usefully
+      support the :gf:`show-progress` operation.

--- a/sources/environment/commands/command-line.dylan
+++ b/sources/environment/commands/command-line.dylan
@@ -30,7 +30,7 @@ define class <command-line-server> (<object>)
     required-init-keyword: context:;
   constant slot server-input-stream :: <stream>,
     required-init-keyword: input-stream:;
-  constant slot server-output-stream :: <stream>,
+  constant slot server-output-stream :: <progress-stream>,
     required-init-keyword: output-stream:;
   slot server-incomplete-command-line :: false-or(<string>) = #f;
   slot server-last-command :: false-or(<command>) = #f;
@@ -303,6 +303,15 @@ define inline method message
   new-line(stream);
   force-output(stream);
 end method message;
+
+define method display-progress
+    (context :: <server-context>, position :: <integer>, range :: <integer>,
+     label :: false-or(<string>))
+ => ()
+  let server = context.context-server;
+  let stream = server.server-output-stream;
+  show-progress(stream, position, range, label: label);
+end method;
 
 define function display-condition
     (context :: <server-context>, condition :: <serious-condition>,

--- a/sources/environment/commands/library.dylan
+++ b/sources/environment/commands/library.dylan
@@ -12,6 +12,7 @@ define library environment-commands
   use system;
   use io;
   use commands;
+  use progress-stream;
 
   use build-system;
   use environment-protocols;

--- a/sources/environment/commands/main.dylan
+++ b/sources/environment/commands/main.dylan
@@ -37,6 +37,12 @@ define method make-environment-command-line-server
           profile-commands? :: <boolean> = #f)
  => (server :: <command-line-server>)
   let context = make(<environment-context>, banner: banner);
+  let output-stream
+    = if (instance?(output-stream, <progress-stream>))
+        output-stream
+      else
+        make(<progress-stream>, inner-stream: output-stream)
+      end if;
   make(<command-line-server>,
        context:           context,
        input-stream:      input-stream,

--- a/sources/environment/commands/module.dylan
+++ b/sources/environment/commands/module.dylan
@@ -21,6 +21,7 @@ define module command-lines
   use format;
   use locators;
   use release-info;
+  use progress-stream;
 
   // Command line servers
   export <command-line-server>,
@@ -33,6 +34,7 @@ define module command-lines
 
   // Utilities
   export message,
+         display-progress,
          display-condition,
          print-table;
 
@@ -129,6 +131,7 @@ define module environment-commands
 
   use commands;
   use command-lines;
+  use progress-stream;
 
   // Environment context
   export <environment-context>,

--- a/sources/environment/deuce/interactor-control.dylan
+++ b/sources/environment/deuce/interactor-control.dylan
@@ -70,7 +70,7 @@ define method make-interactor-command-line-server
   make(<command-line-server>,
        context:           context,
        input-stream:      input-stream,
-       output-stream:     output-stream,
+       output-stream:     make(<progress-stream>, inner-stream: output-stream),
        echo-input?:       echo-input?,
        profile-commands?: profile-commands?)
 end method;

--- a/sources/environment/deuce/library.dylan
+++ b/sources/environment/deuce/library.dylan
@@ -24,6 +24,7 @@ define library environment-deuce
 
   use commands;
   use environment-commands;
+  use progress-stream;
 
   export environment-deuce;
 end library environment-deuce;

--- a/sources/environment/deuce/module.dylan
+++ b/sources/environment/deuce/module.dylan
@@ -35,6 +35,7 @@ define module environment-deuce
     exclude: { command-error, <command-error> };
   use environment-commands,
     exclude: { command-title };
+  use progress-stream;
 
   use editor-manager,
     exclude: { <editor> };                // clashes with Deuce

--- a/sources/lib/build-system/build.dylan
+++ b/sources/lib/build-system/build.dylan
@@ -111,12 +111,6 @@ define method build-system
       with-build-directory (directory)
         jam-read-mkf(jam, as(<file-locator>, $dylanmakefile));
 
-        format(stream, "building targets:");
-        for (target in build-targets)
-          format(stream, " %s", target);
-        end for;
-        new-line(stream);
-
         jam-target-build(jam, build-targets,
                          progress-callback: wrap-progress-callback,
                          force?: force?,

--- a/sources/lib/progress-stream/library.dylan
+++ b/sources/lib/progress-stream/library.dylan
@@ -1,0 +1,28 @@
+Module:       Dylan-User
+Author:       Peter S. Housel
+Copyright:    Original Code is Copyright 2020 Gwydion Dylan Maintainers
+              All rights reserved.
+License:      See License.txt in this distribution for details.
+Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
+
+define library progress-stream
+  use common-dylan;
+  use io;
+
+  export progress-stream;
+end library;
+
+define module progress-stream
+  create
+    <progress-stream>,
+    stream-supports-show-progress?,
+    show-progress;
+end module;
+
+define module progress-stream-internals
+  use common-dylan;
+  use streams;
+  use streams-internals,
+    import: { <file-stream>, stream-console?, write-fill };
+  use progress-stream;
+end module;

--- a/sources/lib/progress-stream/progress-stream.dylan
+++ b/sources/lib/progress-stream/progress-stream.dylan
@@ -1,0 +1,165 @@
+Module:       progress-stream-internals
+Author:       Peter S. Housel
+Copyright:    Original Code is Copyright 2020 Gwydion Dylan Maintainers
+              All rights reserved.
+License:      See License.txt in this distribution for details.
+Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
+
+define constant $default-bar-width :: <integer> = 40;
+define constant $default-line-width :: <integer> = 79;
+
+define abstract class <progress-stream> (<wrapper-stream>)
+end class;
+
+define sealed method make
+    (class == <progress-stream>, #rest args,
+     #key inner-stream :: <stream>, force?, #all-keys)
+ => (progress-stream :: <progress-stream>);
+  if (force?
+        | (instance?(inner-stream, <file-stream>)
+             & stream-console?(inner-stream)))
+    apply(make, <console-progress-stream>, args)
+  else
+    apply(make, <dummy-progress-stream>, args)
+  end if
+end method;
+
+define class <dummy-progress-stream> (<progress-stream>)
+end class;
+
+define class <console-progress-stream> (<progress-stream>)
+  constant slot console-progress-bar-width :: <integer>,
+    init-keyword: bar-width:, init-value: $default-bar-width;
+  constant slot console-progress-line-width :: <integer>,
+    init-keyword: line-width:, init-value: $default-line-width;
+  slot console-progress-bars :: false-or(<integer>),
+    init-value: #f;
+  slot console-progress-label :: false-or(<string>),
+    init-value: #f;
+end class;
+
+define generic stream-supports-show-progress?
+    (stream :: <stream>)
+ => (supports-show-progress? :: <boolean>);
+
+define sideways method stream-supports-show-progress?
+    (stream :: <stream>)
+ => (supports-show-progress? :: <boolean>);
+  #f
+end method;
+
+define method stream-supports-show-progress?
+    (stream :: <console-progress-stream>)
+ => (supports-show-progress? :: <boolean>);
+  #t
+end method;
+
+define generic show-progress
+    (stream :: <progress-stream>, position :: <integer>, range :: <integer>,
+     #key label)
+ => ();
+
+define method show-progress
+    (stream :: <progress-stream>,
+     position :: <integer>, range :: <integer>,
+     #key label :: false-or(<string>))
+ => ();
+  // Do nothing
+end method;
+
+define method show-progress
+    (stream :: <console-progress-stream>,
+     position :: <integer>, range :: <integer>,
+     #key label :: false-or(<string>))
+ => ();
+  let inner = stream.inner-stream;
+  let bar-width = stream.console-progress-bar-width;
+  let line-width = stream.console-progress-line-width;
+  let bars = round/(position * bar-width, range);
+  if (bars ~= stream.console-progress-bars | label ~= stream.console-progress-label)
+    // The bar itself
+    write(inner, "\r[");
+    write-fill(inner, '=', bars);
+    write-fill(inner, ' ', bar-width - bars);
+    write(inner, "]");
+
+    // Label, and spaces to clear previous leftover label
+    let max-label-width = line-width - (bar-width + 2 + 1);
+    let current-post-bar-width
+      = if (label)
+          write-element(inner, ' ');
+          if (label.size <= max-label-width)
+            write(inner, label);
+            label.size + 1
+          else
+            write(inner, label, end: max-label-width - 3);
+            write(inner, "...");
+            max-label-width + 1
+          end if
+        else
+          0
+        end if;
+    let previous-label = stream.console-progress-label;
+    let previous-post-bar-width
+      = if (previous-label)
+          if (previous-label.size <= max-label-width)
+            previous-label.size + 1
+          else
+            max-label-width + 1
+          end if
+        else
+          0;
+        end if;
+    write-fill(inner, ' ', previous-post-bar-width - current-post-bar-width);
+    force-output(inner);
+    stream.console-progress-bars := bars;
+    stream.console-progress-label := label;
+  end if;
+end method;
+
+define function clear-bar
+    (stream :: <console-progress-stream>, available :: <integer>)
+  if (stream.console-progress-bars | stream.console-progress-label)
+    let max-label-width
+      = stream.console-progress-line-width
+      - (stream.console-progress-bar-width + 2 + 1);
+    let previous-label = stream.console-progress-label;
+    let previous-line-width
+      = stream.console-progress-bar-width + 2
+      + if (previous-label)
+          if (previous-label.size <= max-label-width)
+            previous-label.size + 1
+          else
+            max-label-width + 1
+          end if
+        else
+          0;
+        end if;
+    write-element(stream.inner-stream, '\r');
+    if (available < previous-line-width)
+      write-fill(stream.inner-stream, ' ', previous-line-width);
+      write-element(stream.inner-stream, '\r');
+    else
+    end if;
+    stream.console-progress-bars := #f;
+    stream.console-progress-label := #f;
+  end if;
+end function;
+
+define method write-element
+    (stream :: <console-progress-stream>, elt :: <object>) => ()
+  clear-bar(stream, 1);
+  write-element(stream.inner-stream, elt)
+end method write-element;
+
+define method write
+    (stream :: <console-progress-stream>, elements :: <sequence>,
+     #rest keys, #key start: _start, end: _end) => ()
+  clear-bar(stream, (_end | elements.size) - (_start | 0));
+  apply(write, stream.inner-stream, elements, keys)
+end method write;
+
+define method new-line (stream :: <console-progress-stream>) => ()
+  clear-bar(stream, 0);
+  new-line(stream.inner-stream);
+end method new-line;

--- a/sources/lib/progress-stream/progress-stream.lid
+++ b/sources/lib/progress-stream/progress-stream.lid
@@ -1,0 +1,10 @@
+Library:      progress-stream
+Synopsis:     Wrapper stream implementing progress display
+Author:       Peter S. Housel
+Target-Type:  dll
+Files:        library
+              progress-stream
+Copyright:    Original Code is Copyright 2020 Gwydion Dylan Maintainers
+              All rights reserved.
+License:      See License.txt in this distribution for details.
+Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND

--- a/sources/lib/progress-stream/tests/library.dylan
+++ b/sources/lib/progress-stream/tests/library.dylan
@@ -1,0 +1,25 @@
+Module:       Dylan-User
+Author:       Peter S. Housel
+Copyright:    Original Code is Copyright 2004 Gwydion Dylan Maintainers
+              All rights reserved.
+License:      See License.txt in this distribution for details.
+Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
+
+define library progress-stream-test-suite
+  use common-dylan;
+  use testworks;
+  use io;
+  use progress-stream;
+
+  export progress-stream-test-suite;
+end library progress-stream-test-suite;
+
+define module progress-stream-test-suite
+  use common-dylan;
+  use testworks;
+  use streams;
+  use format;
+  use progress-stream;
+
+  export progress-stream-test-suite;
+end module progress-stream-test-suite;

--- a/sources/lib/progress-stream/tests/progress-stream-test-suite.lid
+++ b/sources/lib/progress-stream/tests/progress-stream-test-suite.lid
@@ -1,0 +1,9 @@
+Library:      progress-stream-test-suite
+Target-Type:  dll
+Author:       Peter S. Housel
+Files:        library
+              progress-stream-test
+Copyright:    Original Code is Copyright 2020 Gwydion Dylan Maintainers
+              All rights reserved.
+License:      See License.txt in this distribution for details.
+Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND

--- a/sources/lib/progress-stream/tests/progress-stream-test.dylan
+++ b/sources/lib/progress-stream/tests/progress-stream-test.dylan
@@ -1,0 +1,99 @@
+Module: progress-stream-test-suite
+Author:       Peter S. Housel
+Copyright:    Original Code is Copyright 2020 Gwydion Dylan Maintainers
+              All rights reserved.
+License:      See License.txt in this distribution for details.
+Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
+
+//// Tests for module progress-stream
+
+define interface-specification-suite progress-stream-specification-suite ()
+  abstract class <progress-stream> (<wrapper-stream>);
+  function stream-supports-show-progress? (<stream>) => (<boolean>);
+  function show-progress (<progress-stream>, <integer>, <integer>, #"key", #"label") => ();
+end progress-stream-specification-suite;
+
+define test test-<progress-stream> ()
+  let output
+    = with-output-to-string (s)
+        let progress = make(<progress-stream>, inner-stream: s);
+        format(progress, "line 1\n");
+      end;
+  assert-equal("line 1\n", output);
+end test;
+
+define test test-stream-supports-show-progress? ()
+  let output
+    = with-output-to-string (s)
+        let progress-unforced = make(<progress-stream>, inner-stream: s);
+        assert-false(stream-supports-show-progress?(progress-unforced));
+        let progress-forced
+          = make(<progress-stream>, inner-stream: s, force?: #t);
+        assert-true(stream-supports-show-progress?(progress-forced));
+      end;
+end test;
+
+define test test-show-progress-simple ()
+  let output
+    = with-output-to-string (s)
+        let progress
+          = make(<progress-stream>, inner-stream: s, force?: #t,
+                 bar-width: 40);
+        show-progress(progress, 17, 43);
+        show-progress(progress, 22, 43, label: "Snerb");
+        show-progress(progress, 22, 43, label: "Snerb");
+        show-progress(progress, 22, 43, label: "Sner");
+      end;
+  assert-equal("\r[================                        ]"
+               "\r[====================                    ] Snerb"
+               "\r[====================                    ] Sner ",
+               output);
+end test;
+
+define test test-show-progress-mixed ()
+  let output
+    = with-output-to-string (s)
+        let progress
+          = make(<progress-stream>, inner-stream: s, force?: #t,
+                 bar-width: 40);
+        format(progress, "line 1\n");
+        show-progress(progress, 17, 43);
+        format(progress, "line 2\n");
+      end;
+  assert-equal("line 1\n"
+               "\r[================                        ]"
+               "\r                                          \r"
+               "line 2\n",
+               output);
+end test;
+
+define test test-show-progress-truncate ()
+  let output
+    = with-output-to-string (s)
+        let progress
+          = make(<progress-stream>, inner-stream: s, force?: #t,
+                 bar-width: 20, line-width: 36);
+        show-progress(progress, 43, 43);
+        show-progress(progress, 43, 43, label: "thalassocracy");
+        show-progress(progress, 43, 43, label: "thalassography");
+        show-progress(progress, 43, 43, label: "thalassocrat");
+      end;
+  assert-equal("\r[====================]"
+               "\r[====================] thalassocracy"
+               "\r[====================] thalassogr..."
+               "\r[====================] thalassocrat ",
+               output);
+end test;
+
+define suite progress-stream-module-test-suite ()
+  test test-<progress-stream>;
+  test test-stream-supports-show-progress?;
+  test test-show-progress-simple;
+  test test-show-progress-mixed;
+  test test-show-progress-truncate;
+end suite;
+
+define suite progress-stream-test-suite ()
+  suite progress-stream-specification-suite;
+  suite progress-stream-module-test-suite;
+end suite;

--- a/sources/registry/generic/progress-stream
+++ b/sources/registry/generic/progress-stream
@@ -1,0 +1,1 @@
+abstract://dylan/lib/progress-stream/progress-stream.lid

--- a/sources/registry/generic/progress-stream-test-suite
+++ b/sources/registry/generic/progress-stream-test-suite
@@ -1,0 +1,1 @@
+abstract://dylan/lib/progress-stream/tests/progress-stream-test-suite.lid


### PR DESCRIPTION
These commits add a compact text-mode progress bar to the compiler's build and link commands.
