### PR TITLE
[system] change type of run-application's command argument

### DIFF
--- a/sources/system/tests/specification.dylan
+++ b/sources/system/tests/specification.dylan
@@ -186,7 +186,7 @@ define interface-specification-suite operating-system-specification-suite ()
   function owner-organization () => (false-or(<string>));
   class <application-process> (<object>);
   function run-application
-    (type-union(<string>, limited(<sequence>, of: <string>)),
+    (<sequence>,
      #"key", #"under-shell?", #"inherit-console?", #"activate?",
      #"minimize?", #"hide?", #"outputter", #"asynchronous?",
      #"environment", #"working-directory",


### PR DESCRIPTION
Using limited types in an API like this means the caller has to do
`  as(limited(<vector>, of: <string>), vector("a", "b"))`
instead of just
`  vector("a", "b")`

Also added some doc comments and moved one variable closer to where it's used.