### PR TITLE
environment: Make elisp-format dispatch-coloring data optional

### DIFF
--- a/documentation/release-notes/source/2020.1.rst
+++ b/documentation/release-notes/source/2020.1.rst
@@ -80,6 +80,12 @@ Compiler
 * The compiler now displays a text mode progress bar during the
   compilation and link phases.
 
+* The compiler no longer generates dispatch coloring information in
+  Emacs Lisp format by default. When it is needed, it can still be
+  requested by supplying the ``-dispatch-coloring elisp`` command-line
+  option at build time. (Note that the IDE dispatch coloring display
+  does not make use of the elisp-format files.)
+
 Run-time
 ========
 

--- a/sources/environment/commands/build.dylan
+++ b/sources/environment/commands/build.dylan
@@ -178,6 +178,8 @@ define class <build-project-command> (<abstract-link-command>)
     init-keyword: link?:;
   constant slot %output :: <sequence> = #[],
     init-keyword: output:;
+  constant slot %dispatch-coloring :: false-or(<symbol>) = #f,
+    init-keyword: dispatch-coloring:;
   constant slot %release? :: <boolean> = #f,
     init-keyword: release?:;
 end class <build-project-command>;
@@ -187,6 +189,7 @@ define command-line build => <build-project-command>
      documentation: "Builds the executable for a project.")
   optional project :: <project-object> = "the project to build";
   keyword output :: $keyword-list-type = "debug output types [default none]";
+  keyword dispatch-coloring :: <symbol> = "dispatch coloring output type";
   flag clean         = "do a clean build? [off by default]";
   flag save          = "save the compiler database [save by default]";
   flag link          = "link the executable [link by default]";
@@ -223,6 +226,7 @@ define method do-execute-command
            save-databases?:      command.%save?,
            messages:             messages,
            output:               command.%output,
+           dispatch-coloring:    command.%dispatch-coloring,
            progress-callback:    progress-callback,
            warning-callback:     curry(note-compiler-warning, context),
            error-handler:        curry(compiler-condition-handler, context)))

--- a/sources/environment/console/command-line.dylan
+++ b/sources/environment/console/command-line.dylan
@@ -63,6 +63,8 @@ define abstract class <basic-main-command> (<basic-command>)
     init-keyword: assemble?:;
   constant slot %dfm?           :: <boolean> = #f,
     init-keyword: dfm?:;
+  constant slot %dispatch-coloring :: false-or(<symbol>) = #f,
+    init-keyword: dispatch-coloring:;
 /*---*** fill this in later.
   constant slot %exports?       :: <boolean> = #f,
     init-keyword: exports?:;
@@ -106,7 +108,8 @@ define method execute-main-command
                        if (command.%dfm?) add!(output, #"dfm") end;
                        if (command.%harp?) add!(output, #"harp") end;
                        output
-                     end)
+                     end,
+        dispatch-coloring: command.%dispatch-coloring)
   end;
   if (build? | command.%link?)
     let target = command.%target;

--- a/sources/environment/console/compiler-command-line.dylan
+++ b/sources/environment/console/compiler-command-line.dylan
@@ -19,6 +19,7 @@ define command-line main => <main-command>
   keyword back-end :: <symbol> = "the compiler back-end to use";
   keyword build-script :: <file-locator> = "the (Jam) build script";
   keyword target :: <symbol> = "the type of executable";
+  keyword dispatch-coloring :: <symbol> = "the dispatch coloring output type";
 
   flag help             = "show this help summary";
   flag logo             = "displays the copyright banner";

--- a/sources/environment/console/environment-command-line.dylan
+++ b/sources/environment/console/environment-command-line.dylan
@@ -95,6 +95,7 @@ define command-line main => <main-command>
   keyword back-end :: <symbol> = "the compiler back-end to use";
   keyword build-script :: <file-locator> = "the (Jam) build script";
   keyword target :: <symbol> = "the type of executable";
+  keyword dispatch-coloring :: <symbol> = "the dispatch coloring output type";
 
   flag help             = "show this help summary";
   flag logo             = "displays the copyright banner";

--- a/sources/environment/dfmc/projects/projects.dylan
+++ b/sources/environment/dfmc/projects/projects.dylan
@@ -307,6 +307,7 @@ end macro with-project-location-handler;
 define sealed method build-project
     (project-object :: <dfmc-project-object>,
      #key clean? = #f, link? = #t, release? = #f, output = #[],
+          dispatch-coloring = #f,
           abort-on-all-warnings? = #f,
           abort-on-serious-warnings? = #f,
           warning-callback :: false-or(<function>),
@@ -332,6 +333,7 @@ define sealed method build-project
                 update-libraries(project,
                                  force?: clean?,
                                  save?:  save-databases?,
+                                 dispatch-coloring: dispatch-coloring,
                                  abort-on-all-warnings?: abort-on-all-warnings?,
                                  abort-on-serious-warnings?: abort-on-serious-warnings?,
                                  assembler-output?: assembler-output?,
@@ -342,6 +344,7 @@ define sealed method build-project
                                 force-parse?:   clean?,
                                 force-compile?: clean?,
                                 save?: save-databases?,
+                                dispatch-coloring: dispatch-coloring,
                                 abort-on-all-warnings?: abort-on-all-warnings?,
                                 abort-on-serious-warnings?: abort-on-serious-warnings?,
                                 assembler-output?: assembler-output?,

--- a/sources/project-manager/projects/compilation.dylan
+++ b/sources/project-manager/projects/compilation.dylan
@@ -317,6 +317,7 @@ define method compile-library (project :: <project>,
                                #rest flags,
                                #key force-compile? = #f,
                                     force-parse?   = #f,
+                                    dispatch-coloring = #f,
                                     abort-on-all-warnings?     = #f,
                                     abort-on-serious-warnings? = #f,
                                     default-binding = #f,
@@ -347,7 +348,10 @@ define method compile-library (project :: <project>,
               compile-all?: force-batch?,
               compile-if-built?: force-objects?,
               flags);
-          #f
+        if (dispatch-coloring)
+          project-output-dispatch-colors(project, dispatch-coloring);
+        end if;
+        #f
       exception (c :: <abort-compilation>)
         internal-message("Aborting compilation of %s due to warnings",
                          project.project-name);
@@ -364,6 +368,7 @@ define thread variable *contexts-to-recompile* = #f;
 define method update-libraries (project :: <project>,
                                 #key force? = #f,
                                      save?  = #f,
+                                     dispatch-coloring = #f,
                                      abort-on-all-warnings?     = #f,
                                      abort-on-serious-warnings? = #f,
                                      continue-after-abort? = #f,
@@ -469,7 +474,9 @@ define method update-libraries (project :: <project>,
                 proj.%database-saved := #t;
                 note-database-saved(proj)
               end;
-
+              if (dispatch-coloring)
+                project-output-dispatch-colors(proj, dispatch-coloring);
+              end if;
             end block;
           end for;
         end dynamic-bind;

--- a/sources/project-manager/projects/implementation.dylan
+++ b/sources/project-manager/projects/implementation.dylan
@@ -894,6 +894,17 @@ end function;
 // it uses source-record-dispatch-decisions directly.  This function is only
 // for emacs support.
 
+define method project-output-dispatch-colors
+    (project :: <project>, dispatch-coloring :: <symbol>)
+  user-warning("Not writing dispatch coloring info in %s format",
+               as(<string>, dispatch-coloring));
+end method;
+
+define method project-output-dispatch-colors
+    (project :: <project>, dispatch-coloring == #"elisp")
+  project-dump-emacs-dispatch-colors(project);
+end method;
+
 define function project-dump-emacs-dispatch-colors (project :: <project>)
   let dir = project.project-build-location;
   when (dir)

--- a/sources/project-manager/projects/lid-projects.dylan
+++ b/sources/project-manager/projects/lid-projects.dylan
@@ -610,8 +610,6 @@ end;
 define method note-compiled-definitions (project :: <lid-project>)
   generate-makefile(project);
   copy-extra-records(project, build-settings: project.project-build-settings);
-  // This is just for emacs support (not used by environment).
-  project-dump-emacs-dispatch-colors(project);
 end;
 
 define method copy-extra-records (project :: <lid-project>,

--- a/sources/project-manager/projects/projects-library.dylan
+++ b/sources/project-manager/projects/projects-library.dylan
@@ -69,6 +69,7 @@ define module projects
     project-progress-report,
     project-condition-report,
     project-dump-conditions,
+    project-output-dispatch-colors,
     project-dump-emacs-dispatch-colors,
     <project-warning>,
     <project-serious-warning>,


### PR DESCRIPTION
This change makes the output of dispatch-coloring data in Emacs Lisp format conditional on explicitly requesting it.
