### PR TITLE
Track inlined code in LLVM debug information

### DIFF
--- a/sources/app/llvm-runtime-generator/llvm-runtime-c-header.dylan
+++ b/sources/app/llvm-runtime-generator/llvm-runtime-c-header.dylan
@@ -8,7 +8,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 define method print-raw-struct-c-declaration
     (be :: <llvm-back-end>, type :: <&raw-struct-type>, stream :: <stream>)
  => ();
-  format(stream, "struct %s {\n", type.^debug-name);
+  format(stream, "struct %s {\n", raw-mangle(be, type.^debug-name));
   for (member in type.raw-aggregate-members)
     let member-type = member.member-raw-type;
     format(stream, "  %s %s",
@@ -108,7 +108,7 @@ define method print-runtime-variable-declaration
   let type-name = descriptor.runtime-variable-type-name;
   select (type-name)
     #"<teb>" =>
-      format(stream, "struct TEB");
+      format(stream, "struct dylan_teb");
     otherwise =>
       print-primitive-c-type(be, dylan-value(type-name), stream);
   end select;

--- a/sources/dfmc/back-end/heaps.dylan
+++ b/sources/dfmc/back-end/heaps.dylan
@@ -2330,6 +2330,10 @@ define function lambda-heap-for-sure
        := begin
             let refs = make(<code-references>);
             for-computations (c in m)
+              for (origin = c.inlined-origin then origin.origin-next,
+                   while: origin)
+                maybe-claim-value-references(refs, origin.origin-lambda.^iep);
+              end for;
               if (instance?(c, <simple-call>)
                     // object-class(c) == <simple-call>
                     & call-iep?(c)

--- a/sources/dfmc/conversion/convert.dylan
+++ b/sources/dfmc/conversion/convert.dylan
@@ -1647,7 +1647,9 @@ define method convert-next-method-into
  => ()
   f.^function-next? := #t;
   let fragment
-    = generate-next-method-function-fragment(f, signature-spec, next-ref);
+    = with-expansion-source-form (model-definition(f))
+        generate-next-method-function-fragment(f, signature-spec, next-ref)
+      end;
   let (f-start, f-end, f-temp) = convert-1(env, fragment);
   insert-computations-after!(f.body, f-start, f-end);
   replace-temporary-in-users!(next-ref, f-temp);

--- a/sources/dfmc/conversion/define-class.dylan
+++ b/sources/dfmc/conversion/define-class.dylan
@@ -585,7 +585,9 @@ define method compute-slot-initialization-code
                   (class, slotd);
             #{ ?keyword ?name = ?init }
           elseif (^init-keyword-required?(slotd))
-            #{ ?keyword ?name = error("Missing init keyword \"%=:\"", ?keyword) }
+            with-expansion-source-form (model-definition(slotd))
+              #{ ?keyword ?name = error("Missing init keyword \"%=:\"", ?keyword) }
+            end
           else
             #{ ?keyword ?name = ?$unbound }
           end;

--- a/sources/dfmc/conversion/define-method.dylan
+++ b/sources/dfmc/conversion/define-method.dylan
@@ -367,16 +367,16 @@ end method;
 
 define method compute-and-install-method-dfm
     (method-object :: <&lambda>) => ()
-  let body = compute-method-body(method-object);
-  if (body)
-    with-parent-source-location  (model-source-location(method-object))
+  with-parent-source-location (model-source-location(method-object))
+    let body = compute-method-body(method-object);
+    if (body)
       convert-lambda-into*($top-level-environment, method-object, body);
       // format-out("COMPUTING DFM FOR %=\n", method-object);
-    end;
-    retract-body-fragments(method-object);
-    // one of this and the one below is redundant
-    lambda-optimized?(method-object) := #f;
-  end if;
+      retract-body-fragments(method-object);
+      // one of this and the one below is redundant
+      lambda-optimized?(method-object) := #f;
+    end if;
+  end;
 end method;
 
 define method compute-method-body (m :: <&lambda>)

--- a/sources/dfmc/definitions/top-level-convert.dylan
+++ b/sources/dfmc/definitions/top-level-convert.dylan
@@ -53,9 +53,12 @@ define method top-level-convert* (parent, fragments :: <sequence>)
 end method;
 
 define method top-level-convert (parent, fragment :: <fragment>)
+  let loc
+    = fragment-source-location(fragment)
+    | form-source-location(parent);
   list(make(<top-level-init-form>,
             parent-form: parent,
-            source-location: fragment-source-location(fragment),
+            source-location: loc,
             body:            fragment))
 end method;
 
@@ -180,9 +183,12 @@ define method top-level-convert-using-definition
                     end;
     end;
   else
+    let loc
+      = fragment-source-location(fragment)
+      | form-source-location(parent);
     list(make(<top-level-init-form>,
              parent-form: parent,
-             source-location: fragment-source-location(fragment),
+             source-location: loc,
              body: fragment));
   end;
 end method;
@@ -200,9 +206,12 @@ define method top-level-convert-using-definition
       end;
   if (compiling-for-macroexpansion?())
     // Descend no further.
+    let loc
+      = fragment-source-location(fragment)
+      | form-source-location(parent);
     list(make(<top-level-init-form>,
               parent-form: parent,
-              source-location: fragment-source-location(fragment),
+              source-location: loc,
               body: fragment));
   elseif (parent)
     top-level-convert(parent, expansion);

--- a/sources/dfmc/flow-graph/computation.dylan
+++ b/sources/dfmc/flow-graph/computation.dylan
@@ -6,11 +6,25 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
+define class <inlined-origin> (<object>)
+  constant slot origin-lambda :: <&lambda>,
+    required-init-keyword: lambda:;
+  constant slot origin-location :: false-or(<source-location>),
+    required-init-keyword: location:;
+  constant slot origin-next :: false-or(<inlined-origin>),
+    required-init-keyword: next:;
+end class;
+
+define thread variable *parent-inlined-origin* :: false-or(<inlined-origin>) = #f;
+
 define abstract dood-class <computation> (<queueable-item-mixin>)
 
   slot computation-source-location :: false-or(<source-location>)
          = parent-source-location(),
     init-keyword: source-location:;
+
+  slot inlined-origin :: false-or(<inlined-origin>) = *parent-inlined-origin*,
+    init-keyword: inlined-origin:;
 
   weak slot previous-computation :: false-or(<computation>) = #f,
     reinit-expression: #f,
@@ -1100,7 +1114,9 @@ define compiler-open generic dfm-context-id
 define inline function do-with-parent-computation
     (f :: <function>, c :: false-or(<computation>))
   with-parent-source-location (c & computation-source-location(c))
-    f();
+    dynamic-bind (*parent-inlined-origin* = c & c.inlined-origin)
+      f();
+    end;
   end;
 end function;
 

--- a/sources/dfmc/flow-graph/dfm-copier.dylan
+++ b/sources/dfmc/flow-graph/dfm-copier.dylan
@@ -32,8 +32,7 @@ define dont-copy-slots  <queueable-item-mixin>       using <dfm-copier> =
   { item-status => $queueable-item-absent };
 
 define dont-copy-slots  <computation>                using <dfm-copier> =
-  { computation-source-location => parent-source-location(),
-    computation-type => #f,
+  { computation-type => #f,
     %node-id => #f };
 
 define dont-copy-slots  <bind-exit>                  using <dfm-copier> =

--- a/sources/dfmc/flow-graph/flow-graph-library.dylan
+++ b/sources/dfmc/flow-graph/flow-graph-library.dylan
@@ -41,8 +41,13 @@ define module dfmc-flow-graph
     do-over-lambda-users,
     analyze-environments;
 
+  export
+    <inlined-origin>,
+    origin-lambda, origin-location, origin-next;
+
   export // computations
     <computation>,
+    inlined-origin, inlined-origin-setter,
     previous-computation, previous-computation-setter,
     temporary, temporary-setter,
     computation-value, computation-value-setter,

--- a/sources/dfmc/llvm-back-end/llvm-back-end.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-back-end.dylan
@@ -91,7 +91,7 @@ define sealed method initialize
   // Initialize MV return value structure
   back-end.%mv-struct-type
     := make(<&raw-struct-type>,
-            debug-name: "MV",
+            debug-name: "dylan-mv",
             options: #[],
             members:
               vector(make(<raw-aggregate-ordinary-member>,

--- a/sources/dfmc/llvm-back-end/llvm-back-end.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-back-end.dylan
@@ -60,6 +60,10 @@ define abstract class <llvm-back-end> (<back-end>, <llvm-builder>)
   constant slot %source-record-dbg-file-table :: <object-table>
     = make(<object-table>);
 
+  // Debug function table
+  constant slot %lambda-dbg-function-table :: <object-table>
+    = make(<object-table>);
+
   // LLVM debug type for each defined <&raw-type> instance (or <object>)
   constant slot %dbg-type-table :: <object-table>
     = make(<object-table>);

--- a/sources/dfmc/llvm-back-end/llvm-emit-computation.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-emit-computation.dylan
@@ -301,6 +301,7 @@ define method merge-results
     // Only one predecessor block
     emit-transfer(back-end, module, temp, results[0]);
   else
+    op--scl(back-end, c);
     emit-merge-assignment(back-end, c, temp, results);
   end if;
 end method;

--- a/sources/dfmc/llvm-back-end/llvm-emit-debug.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-emit-debug.dylan
@@ -206,27 +206,26 @@ define method emit-dbg-local-variable
      kind :: one-of(#"auto", #"argument", #"return"),
      value :: <llvm-value>, #key address? = #f)
  => ();
-  let source-location = c.dfm-source-location;
-  if (source-location)
-    let (dbg-file, dbg-line, dbg-column)
-      = source-location-dbg-loc(back-end, source-location);
-    let var-type
-      = llvm-reference-dbg-type(back-end, type-estimate(tmp));
-    let v = llvm-make-dbg-value-metadata(value);
-    let lv
-      = llvm-make-dbg-local-variable(kind,
-                                     *computation-dbg-scope-table*[c],
-                                     as(<string>, tmp.name),
-                                     dbg-file, dbg-line,
-                                     var-type);
-    let lvv = make(<llvm-metadata-value>, metadata: lv);
-    if (address?)
-      ins--call-intrinsic(back-end, "llvm.dbg.addr",
-                          vector(v, lvv, $empty-diexpression-value));
-    else
-      ins--call-intrinsic(back-end, "llvm.dbg.value",
-                          vector(v, lvv, $empty-diexpression-value));
-    end if;
+  let dbg-scope = llvm-builder-dbg-scope(back-end);
+  let dbg-line = llvm-builder-dbg-line(back-end);
+  let dbg-file = llvm-builder-dbg-file(back-end);
+
+  let var-type
+    = llvm-reference-dbg-type(back-end, type-estimate(tmp));
+  let v = llvm-make-dbg-value-metadata(value);
+  let lv
+    = llvm-make-dbg-local-variable(kind,
+                                   dbg-scope,
+                                   as(<string>, tmp.name),
+                                   dbg-file, dbg-line,
+                                   var-type);
+  let lvv = make(<llvm-metadata-value>, metadata: lv);
+  if (address?)
+    ins--call-intrinsic(back-end, "llvm.dbg.addr",
+                        vector(v, lvv, $empty-diexpression-value));
+  else
+    ins--call-intrinsic(back-end, "llvm.dbg.value",
+                        vector(v, lvv, $empty-diexpression-value));
   end if;
 end method;
 

--- a/sources/dfmc/llvm-back-end/llvm-emit.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-emit.dylan
@@ -55,6 +55,7 @@ define method emit-all (back-end :: <llvm-back-end>,
       retract-local-methods-in-heap(heap);
     cleanup
       remove-all-keys!(back-end.%dbg-type-table);
+      remove-all-keys!(back-end.%lambda-dbg-function-table);
       remove-all-keys!(back-end.%source-record-dbg-file-table);
       back-end.llvm-builder-module := #f;
     end block;

--- a/sources/dfmc/llvm-back-end/llvm-primitives-nlx.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-primitives-nlx.dylan
@@ -117,7 +117,7 @@ define method initialize-bef-struct-type (back-end :: <llvm-back-end>) => ()
 
   back-end.llvm-bef-struct-type
     := make(<&raw-struct-type>,
-	    debug-name: "BEF",
+	    debug-name: "dylan-bef",
 	    options: #[],
 	    members:
               vector(// Unwind exception header (must be doubleword aligned)

--- a/sources/dfmc/llvm-back-end/llvm-primitives-thread.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-primitives-thread.dylan
@@ -11,7 +11,7 @@ define method initialize-teb-struct-type (back-end :: <llvm-back-end>) => ()
   // Note that this layout is assumed by the debugger-manager library
   back-end.llvm-teb-struct-type
     := make(<&raw-struct-type>,
-	    debug-name: "TEB",
+	    debug-name: "dylan-teb",
 	    options: #[],
 	    members:
 	      vector(// Offset 0: Current bind-exit frame on stack

--- a/sources/lib/llvm/llvm-bitcode.dylan
+++ b/sources/lib/llvm/llvm-bitcode.dylan
@@ -1695,13 +1695,19 @@ define method write-metadata-record
      value-partition-table :: <explicit-key-collection>,
      metadata :: <llvm-DILocation-metadata>)
   => ();
+  local
+    method moni                 // metadata or null index
+         (m :: false-or(<llvm-metadata>))
+      => (id :: <integer>);
+      if (m) value-partition-table[llvm-metadata-forward(m)] + 1 else 0 end if
+    end method;
   write-record(stream, #"LOCATION",
                if (metadata.llvm-metadata-distinct?) 1 else 0 end,
                metadata.llvm-DILocation-metadata-line,
                metadata.llvm-DILocation-metadata-column,
                value-partition-table
                  [llvm-metadata-forward(metadata.llvm-DILocation-metadata-scope)],
-               0);              // inlinedAt
+               moni(metadata.llvm-DILocation-metadata-inlined-at));
 end method;
 
 define method write-metadata-record

--- a/sources/lib/llvm/llvm-builder.dylan
+++ b/sources/lib/llvm/llvm-builder.dylan
@@ -378,6 +378,45 @@ define function ins--dbg
   end if;
 end function;
 
+define function llvm-builder-dbg-scope
+    (builder :: <llvm-builder>) => (dbg-scope :: false-or(<llvm-metadata>));
+  let current-attachment = builder.llvm-builder-dbg;
+  let location
+    = current-attachment
+    & current-attachment.llvm-metadata-attachment-metadata;
+  location
+    & location.llvm-DILocation-metadata-scope
+end function;
+
+define function llvm-builder-dbg-line
+    (builder :: <llvm-builder>) => (dbg-line :: false-or(<integer>));
+  let current-attachment = builder.llvm-builder-dbg;
+  let location
+    = current-attachment
+    & current-attachment.llvm-metadata-attachment-metadata;
+  location
+    & location.llvm-DILocation-metadata-line
+end function;
+
+define function llvm-builder-dbg-file
+    (builder :: <llvm-builder>) => (dbg-file :: false-or(<llvm-metadata>));
+  let scope = llvm-builder-dbg-scope(builder);
+  scope
+    & scope-dbg-file(scope)
+end function;
+
+define method scope-dbg-file
+    (scope :: <llvm-DILexicalBlock-metadata>)
+ => (dbg-file :: false-or(<llvm-metadata>));
+  scope.llvm-DILexicalBlock-metadata-file
+end method;
+
+define method scope-dbg-file
+    (scope :: <llvm-DISubprogram-metadata>)
+ => (dbg-file :: false-or(<llvm-metadata>));
+  scope.llvm-DISubprogram-metadata-file
+end method;
+
 define inline function builder-metadata
     (builder :: <llvm-builder>, metadata :: <list>)
  => (augmented-metadata :: <list>);

--- a/sources/lib/llvm/llvm-builder.dylan
+++ b/sources/lib/llvm/llvm-builder.dylan
@@ -356,7 +356,8 @@ end macro;
 define function ins--dbg
     (builder :: <llvm-builder>,
      line-number :: <integer>, column-number :: <integer>,
-     scope :: <llvm-metadata>)
+     scope :: <llvm-metadata>,
+     #key inlined-at)
  => ();
   let current-attachment = builder.llvm-builder-dbg;
   if (~current-attachment
@@ -369,7 +370,7 @@ define function ins--dbg
     let node
       = make(<llvm-DILocation-metadata>,
              line: line-number, column: column-number,
-             scope: scope);
+             scope: scope, inlinedAt: inlined-at);
     builder.llvm-builder-dbg
       := make(<llvm-metadata-attachment>,
               kind: $llvm-metadata-kind-dbg,

--- a/sources/lib/llvm/llvm-library.dylan
+++ b/sources/lib/llvm/llvm-library.dylan
@@ -282,6 +282,10 @@ define module llvm-builder
     llvm-builder-dbg,
     llvm-builder-dbg-setter,
 
+    llvm-builder-dbg-file,
+    llvm-builder-dbg-line,
+    llvm-builder-dbg-scope,
+
     with-builder-function,
 
     llvm-builder-value,

--- a/sources/lib/llvm/llvm-specialized-metadata.dylan
+++ b/sources/lib/llvm/llvm-specialized-metadata.dylan
@@ -301,6 +301,8 @@ define class <llvm-DILocation-metadata> (<llvm-debug-info-metadata>)
     init-value: 0, init-keyword: column:;
   constant slot llvm-DILocation-metadata-scope :: <llvm-metadata>,
     required-init-keyword: scope:;
+  constant slot llvm-DILocation-metadata-inlined-at :: false-or(<llvm-metadata>),
+    init-value: #f, init-keyword: inlinedAt:;
 end class;
 
 define method metadata-partition-key
@@ -318,7 +320,12 @@ end method;
 define method metadata-referenced-metadata
     (metadata :: <llvm-DILocation-metadata>)
  => (referenced :: <vector>);
-  vector(metadata.llvm-DILocation-metadata-scope)
+  let at = metadata.llvm-DILocation-metadata-inlined-at;
+  if (at)
+    vector(metadata.llvm-DILocation-metadata-scope, at)
+  else
+    vector(metadata.llvm-DILocation-metadata-scope)
+  end if
 end method;
 
 define class <llvm-DISubprogram-metadata> (<llvm-debug-info-metadata>)

--- a/sources/lib/run-time/llvm-nlx.c
+++ b/sources/lib/run-time/llvm-nlx.c
@@ -145,7 +145,7 @@ static void opendylan_exception_cleanup(_Unwind_Reason_Code reason,
 // Initiate a non-local exit by unwinding
 void primitive_nlx(D bind_exit_frame)
 {
-  struct BEF *bef = (struct BEF *) bind_exit_frame;
+  struct dylan_bef *bef = (struct dylan_bef *) bind_exit_frame;
   struct _Unwind_Exception *bef_unwind_exception
     = (struct _Unwind_Exception *) &bef->bef_unwind_exception;
 
@@ -200,7 +200,8 @@ _Unwind_Reason_Code __opendylan_personality_v0(int version,
 
   // Locate the exception object's containing Bind Exit Frame
   // structure
-  struct BEF *bef = CONTAINER_OF(ex, struct BEF, bef_unwind_exception);
+  struct dylan_bef *bef
+    = CONTAINER_OF(ex, struct dylan_bef, bef_unwind_exception);
 
   // Locate where we are in the current function
   uintptr_t region_start = _Unwind_GetRegionStart(context);


### PR DESCRIPTION
These commits add support for tracking the origin of inlined code in the debug information generated by the LLVM back-end.
