### PR TITLE
Separate dylan-test-suite out of common-dylan-test-suite

### DIFF
--- a/sources/common-dylan/tests/common-dylan-test-suite-app-lib.dylan
+++ b/sources/common-dylan/tests/common-dylan-test-suite-app-lib.dylan
@@ -7,13 +7,11 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define library common-dylan-test-suite-app
-  use dylan-test-suite;
   use common-dylan-test-suite;
   use testworks;
-end library common-dylan-test-suite-app;
+end library;
 
 define module common-dylan-test-suite-app
-  use dylan-test-suite;
   use common-dylan-test-suite;
   use testworks;
-end module common-dylan-test-suite-app;
+end module;

--- a/sources/common-dylan/tests/common-dylan-test-suite-app.dylan
+++ b/sources/common-dylan/tests/common-dylan-test-suite-app.dylan
@@ -6,9 +6,4 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
-define suite common-dylan-test-suite-app ()
-  suite dylan-test-suite;
-  suite common-dylan-test-suite;
-end suite common-dylan-test-suite-app;
-
-run-test-application(common-dylan-test-suite-app);
+run-test-application(common-dylan-test-suite);

--- a/sources/common-dylan/tests/library.dylan
+++ b/sources/common-dylan/tests/library.dylan
@@ -12,10 +12,9 @@ define library common-dylan-test-suite
   use system,
     import: { file-system };
   use testworks;
-  use dylan-test-suite;
 
   export common-dylan-test-suite;
-end library common-dylan-test-suite;
+end library;
 
 define module common-dylan-test-suite
   use dylan;
@@ -38,9 +37,6 @@ define module common-dylan-test-suite
   use threads;
 
   use testworks;
-  // TODO(cgay): https://github.com/dylan-lang/opendylan/issues/1237
-  //             This shouldn't include the entire test suite.
-  use dylan-test-suite;                // to get collection testing
 
   // Common Dylan test suite
   export common-dylan-test-suite;

--- a/sources/common-dylan/tests/streams.dylan
+++ b/sources/common-dylan/tests/streams.dylan
@@ -115,17 +115,17 @@ end method find-stream-test-info;
 define sideways method make-test-instance
     (class :: subclass(<stream>)) => (stream :: <stream>)
   let info = find-stream-test-info(class);
-  assert(info, "Making test instance of unregistered stream class %=", class);
-  let make-function :: <function> = info.info-make-function;
-  make-function()
+  assert(info, "can't make test instance of unregistered stream class %=", class);
+  let make-stream :: <function> = info.info-make-function;
+  make-stream()
 end method make-test-instance;
 
 define sideways method destroy-test-instance
     (class :: subclass(<stream>), stream :: <stream>) => ()
   let info = find-stream-test-info(class);
-  assert(info, "Destroying test instance of unregistered stream class %=", class);
-  let destroy-function :: <function> = info.info-destroy-function;
-  destroy-function(stream)
+  assert(info, "can't destroy test instance of unregistered stream class %=", class);
+  let destroy-stream :: <function> = info.info-destroy-function;
+  destroy-stream(stream)
 end method destroy-test-instance;
 
 define constant $stream-tests :: <object-table> = make(<object-table>);


### PR DESCRIPTION
When we run tests for a library we should be able to expect that we're testing
that library, not all the libraries it depends on. For that we have
libraries-test-suite or testworks-run.