### PR TITLE
common-dylan, io: simplify adding debug info to objects printed rep

### DIFF
--- a/documentation/library-reference/source/common-dylan/common-extensions.rst
+++ b/documentation/library-reference/source/common-dylan/common-extensions.rst
@@ -198,6 +198,34 @@ The extensions are:
      The *format-string* is a format string as defined on page 112 of
      the DRM.
 
+.. generic-function:: debug-name
+
+   Return the "name" of an object for identification purposes during debugging.
+
+   :signature: debug-name *object*
+
+   :parameter object: An instance of :drm:`<object>`.
+   :value name: An instance of :drm:`<object>`.
+
+   :description:
+
+     Add a method to this generic function in order to make your objects more
+     identifiable during debugging. The default ``print-object`` method will
+     include the result of calling this method when printing your objects in
+     the debugger, along with the class name and memory address of the object.
+
+     For example, given the following code...
+
+     .. code-block:: dylan
+
+        define class <foo> (<object>) slot id; end;
+        define method debug-name (f :: <foo>) f.id end;
+        define constant $foo = make(<foo>, id: "abc");
+
+     the debugger will display ``$foo`` as ``{<foo> abc}``.  Without adding a
+     ``debug-name`` method all ``<foo>`` objects will display as ``{<foo>
+     #xADDRESS}`` or possibly even just ``{<foo>}`` if a copying GC is in use.
+
 .. method:: default-handler
    :specializer: <warning>
 

--- a/documentation/library-reference/source/io/print.rst
+++ b/documentation/library-reference/source/io/print.rst
@@ -286,9 +286,14 @@ IO library's *print* module.
 
      Prints an object to a stream. Extend the ability of :func:`print` to print
      objects by adding methods to this generic function. When :func:`print`
-     actually prints an object, it calls ``print-object``.
+     actually prints an object, it calls :func:`print-object`.  Never call
+     :func:`print-object` directly.
 
-     Never call ``print-object`` directly.
+     Note that if you simply want to make your objects easier to identify while
+     debugging, it is easiest to add a method to the ``debug-name`` generic
+     function, exported from :doc:`common-dylan <../common-dylan/index>`.  The
+     default :func:`print-object` method includes the result of calling
+     ``debug-name`` in its output.
 
 .. function:: print-to-string
 

--- a/sources/common-dylan/library.dylan
+++ b/sources/common-dylan/library.dylan
@@ -74,6 +74,7 @@ define module common-extensions
               <simple-condition>,
               <stretchy-sequence>,
               <string-table>,
+              debug-name,
               false-or,
               ignorable,
               ignore,

--- a/sources/io/print.dylan
+++ b/sources/io/print.dylan
@@ -352,19 +352,18 @@ end method;
 define open generic print-object (object, stream :: <stream>)
     => ();
 
-/// Any object.
-///
 define method print-object (object :: <object>, stream :: <stream>) => ()
   printing-logical-block (stream, prefix: "{", suffix: "}")
     write-class-name(object.object-class, stream);
-    let oname = object.debug-name;
-    if (oname)
-      write(stream, " ");
-      write(stream, oname);
+    let dbg-name = object.debug-name;
+    if (dbg-name)
+      // The return type of debug-name is unspecified so don't call write
+      // directly.
+      format(stream, " %s", dbg-name);
     else
       write(stream, " ");
       write(stream, machine-word-to-string(address-of(object)));
-    end if;
+    end;
   end;
 end method;
 

--- a/sources/io/tests/library.dylan
+++ b/sources/io/tests/library.dylan
@@ -10,6 +10,7 @@ define library io-test-suite
   use common-dylan,
     import: { byte-vector, common-dylan, machine-words, simple-random, threads };
   use io;
+  use strings;
   use system;
   use testworks;
 
@@ -30,14 +31,14 @@ define module io-test-suite
   use file-system;
   use locators;
   use machine-words;
-
   use streams;
   use streams-internals;
   use print;
   use print-internals;
   use format;
   use standard-io;
-
+  use strings,
+    import: { starts-with? };
   use testworks;
 
   use common-dylan-test-suite,  // For stream testing protocol

--- a/sources/io/tests/print.dylan
+++ b/sources/io/tests/print.dylan
@@ -31,8 +31,25 @@ define test test-print ()
   //---*** Fill this in...
 end test;
 
+define class <test-print-object-1> (<object>) end;
+define class <test-print-object-2> (<object>) end;
+
+define method debug-name (object :: <test-print-object-1>)
+  "qqq"
+end;
+
 define test test-print-object ()
-  //---*** Fill this in...
+  // With a debug-name method no address is included.
+  let output = with-output-to-string (s)
+                 print(make(<test-print-object-1>), s)
+               end;
+  assert-equal(output, "{<test-print-object-1> qqq}");
+
+  // Without a debug-name method an address IS included.
+  let output = with-output-to-string (s)
+                 print(make(<test-print-object-2>), s)
+               end;
+  assert-true(starts-with?(output, "{<test-print-object-2> #x"));
 end test;
 
 define test test-print-to-string ()


### PR DESCRIPTION
Export debug-name from common-dylan. This makes it easier to add identifying
information to objects for display during debugging, by simply adding

  `define method debug-name (o :: <my-object>) ... end`

without needing to find and import all of these definitions:
```dylan
  dylan:dylan-extensions:debug-name
  io:print:print-object
  io:pprint:printing-logical-block (optional, undocumented)
  io:streams:<stream>
```