### PR TITLE
Fix for 2 undefined bindings 

### DIFF
--- a/sources/duim/examples/life/library.dylan
+++ b/sources/duim/examples/life/library.dylan
@@ -19,6 +19,7 @@ define module life
   use common-dylan;
   use simple-random;            // exported from common-dylan
   use simple-profiling;
+  use simple-format;
   use operating-system;         // exported from system
   use threads;
 

--- a/sources/duim/win32/whelp.dylan
+++ b/sources/duim/win32/whelp.dylan
@@ -150,7 +150,7 @@ define method do-with-open-registry-path
     body(key)
   else
     with-open-registry-subkey (subkey = key, first(path))
-      do-with-open-registry-path(subkey, rest(path), body)
+      do-with-open-registry-path(subkey, tail(path), body)
     end
   end
 end method do-with-open-registry-path;


### PR DESCRIPTION
As already mentioned on gitter here is a fix for 2 undefined bindings that popup
when compiling the DUIM life example on Windows 10 with the latest 2020.1 release:

1. undefined binding `format-to-string` solved by `use simple-format` added to
module definition

2. undefined binding `rest` in the `whelp.dylan` win32 DUIM backend. Maybe a 
Common Lisp vs Dylan 0versight.