### PR TITLE
Display compiler version

### DIFF
--- a/sources/environment/console/command-line.dylan
+++ b/sources/environment/console/command-line.dylan
@@ -21,6 +21,7 @@ define abstract class <basic-main-command> (<basic-command>)
     init-keyword: project:;
   constant slot %help?          :: <boolean> = #f,
     init-keyword: help?:;
+  // If this is true, show a welcome message for the interactive compiler.
   constant slot %logo?          :: <boolean> = #f,
     init-keyword: logo?:;
   constant slot %version?       :: <boolean> = #f,
@@ -167,13 +168,18 @@ define method do-execute-command
             $success-exit-code
           end method run;
     if (command.%help?)
+      message(context, "%s %s\n", release-product-name(), release-short-version());
       run(<help-command>)
     elseif (command.%version?)
       run(<version-command>)
     elseif (command.%shortversion?)
       run(<version-command>, short: "short")
     else
-      command.%logo? & message(context, dylan-banner());
+      if (command.%logo?)
+        message(context, dylan-banner());
+      else
+        message(context, "%s %s\n", release-product-name(), release-short-version());
+      end;
       let personal-root = command.%personal-root;
       let system-root   = command.%system-root;
       let back-end      = command.%back-end;

--- a/sources/environment/console/compiler-command-line.dylan
+++ b/sources/environment/console/compiler-command-line.dylan
@@ -16,17 +16,17 @@ define command-line main => <main-command>
      documentation: "Command-line version of Open Dylan.")
   optional project :: <file-locator> = "the project to be built";
 
-  keyword back-end :: <symbol> = "the compiler back-end to use";
+  keyword back-end :: <symbol>           = "the compiler back-end to use";
   keyword build-script :: <file-locator> = "the (Jam) build script";
-  keyword target :: <symbol> = "the type of executable";
-  keyword dispatch-coloring :: <symbol> = "the dispatch coloring output type";
+  keyword target :: <symbol>             = "the type of executable";
+  keyword dispatch-coloring :: <symbol>  = "the dispatch coloring output type";
 
   flag help             = "show this help summary";
-  flag logo             = "displays the copyright banner";
-  flag version          = "displays the version";
-  flag shortversion     = "displays the shortversion";
+  flag logo             = "display the copyright banner";
+  flag version          = "display the version";
+  flag shortversion     = "display the short version";
   flag debugger         = "enter the debugger if this program crashes";
-  flag echo-input       = "echoes all input to the console";
+  flag echo-input       = "echo all input to the console";
   flag verbose          = "show verbose output";
 
   flag import           = "import the project";
@@ -43,7 +43,7 @@ define command-line main => <main-command>
   keyword personal-root :: <directory-locator> = "personal area root";
   keyword system-root   :: <directory-locator> = "system area root";
   keyword internal-debug :: $keyword-list-type
-                        = "show debug messages (e.g. for linker,project-manager)";
+                        = "show debug messages (e.g. for linker, project-manager)";
   flag unify            = "combine libraries into a single executable";
   flag profile-commands = "profile the execution of each command";
   flag harp             = "generate HARP output";

--- a/sources/environment/console/environment-command-line.dylan
+++ b/sources/environment/console/environment-command-line.dylan
@@ -98,11 +98,11 @@ define command-line main => <main-command>
   keyword dispatch-coloring :: <symbol> = "the dispatch coloring output type";
 
   flag help             = "show this help summary";
-  flag logo             = "displays the copyright banner";
-  flag version          = "displays the version";
-  flag shortversion     = "displays the shortversion";
+  flag logo             = "display the copyright banner";
+  flag version          = "display the version";
+  flag shortversion     = "display the short version";
   flag debugger         = "enter the debugger if this program crashes";
-  flag echo-input       = "echoes all input to the console";
+  flag echo-input       = "echo all input to the console";
   flag verbose          = "show verbose output";
 
   flag import           = "import the project";
@@ -126,7 +126,7 @@ define command-line main => <main-command>
   keyword personal-root :: <directory-locator> = "personal area root";
   keyword system-root   :: <directory-locator> = "system area root";
   keyword internal-debug :: $keyword-list-type
-                        = "show debug messages (e.g. for linker,project-manager)";
+                        = "show debug messages (e.g. for linker, project-manager)";
   flag unify            = "combine the libraries into a single executable";
   flag profile-commands = "profile the execution of each command";
   flag harp             = "generate HARP output";


### PR DESCRIPTION
Display the compiler version at the beginning of the build.

Also make the `dylan-compiler -help` output more consistent in its grammar.