### PR TITLE
Upper/lowercase formatting of hex integers

### DIFF
--- a/documentation/library-reference/source/common-dylan/common-extensions.rst
+++ b/documentation/library-reference/source/common-dylan/common-extensions.rst
@@ -653,6 +653,7 @@ The extensions are:
    :parameter base: An instance of :drm:`<integer>` (default 10).
    :parameter size: An instance of :drm:`<integer>` (default 0).
    :parameter fill: An instance of :drm:`<character>` (default 0).
+   :parameter lowercase?: An instance of :drm:`<boolean>` (default ``#f``).
    :value string: An instance of :drm:`<byte-string>`.
 
    :description:
@@ -660,7 +661,8 @@ The extensions are:
      Returns a string representation of *integer* in the given *base*, which
      must be between 2 and 36. The size of the string is right-aligned to
      *size*, and it is filled with the *fill* character. If the string is
-     already larger than *size* then it is not truncated.
+     already larger than *size* then it is not truncated. If *lowercase?* is
+     true then lowercase characters are used when *base* is higher than 10.
 
 .. macro:: iterate
    :statement:

--- a/documentation/library-reference/source/io/format.rst
+++ b/documentation/library-reference/source/io/format.rst
@@ -60,8 +60,9 @@ The directives are:
   which must be an integer.
 - ``%o`` Prints an octal representation of the next format argument,
   which must be an integer.
-- ``%x`` Prints a hexadecimal representation of the next format
-  argument, which must be an integer.
+- ``%x`` Prints a lowercase hexadecimal representation of the next format
+  argument, which must be an integer. Use ``%X`` (uppercase X) to output
+  uppercase instead.
 - ``%m`` Invokes the next format argument, which must be a function, on
   the stream passed to :gf:`format`.
 - ``%%`` Outputs a single ``%`` character.

--- a/documentation/release-notes/source/2021.1.rst
+++ b/documentation/release-notes/source/2021.1.rst
@@ -56,6 +56,9 @@ dylan Library
 common-dylan Library
 --------------------
 
+* ``integer-to-string`` has a new *lowercase?* keyword argument. When true,
+  lowercase characters are used when *base* is above 10.
+
 io Library
 ----------
 

--- a/documentation/release-notes/source/2021.1.rst
+++ b/documentation/release-notes/source/2021.1.rst
@@ -59,6 +59,11 @@ common-dylan Library
 io Library
 ----------
 
+* The behavior of the ``%x`` format directive has changed. "%x" now outputs
+  lowercase hexadecimal numbers and "%X" outputs uppercase. The old behavior
+  was to always output uppercase. Fixes `bug 1054
+  <https://github.com/dylan-lang/opendylan/issues/1054>`_.
+
 system Library
 --------------
 

--- a/sources/common-dylan/format.dylan
+++ b/sources/common-dylan/format.dylan
@@ -248,7 +248,8 @@ define function integer-to-string
     (integer :: <integer>,
      #key base :: <integer> = 10,
           size: string-size :: <integer> = 0,
-          fill :: <byte-character> = '0')
+          fill :: <byte-character> = '0',
+          lowercase? :: <boolean>)
  => (string :: <byte-string>)
   user-assert(2 <= base & base <= 36,
               "Base %d is not between 2 and 36",
@@ -283,7 +284,7 @@ define function integer-to-string
   let buffer-size = buffer.size;
   let string = make(<byte-string>, size: buffer-size);
   for (digit in buffer, index :: <integer> from buffer-size - 1 to 0 by -1)
-    string[index] := digit;
+    string[index] := if (lowercase?) as-lowercase(digit) else digit end;
   end for;
   string
 end function integer-to-string;

--- a/sources/common-dylan/tests/functions.dylan
+++ b/sources/common-dylan/tests/functions.dylan
@@ -211,10 +211,20 @@ define test test-integer-to-string ()
   check-equal("integer-to-string(127, base: 2, size: 8)",
               integer-to-string(127, base: 2, size: 8),
               "01111111");
+  check-equal("integer-to-string(100, base: 36) defaults to uppercase",
+              integer-to-string(100, base: 36),
+              "2S");
+  check-equal("integer-to-string(100, base: 36, lowercase?: #t)",
+              integer-to-string(100, base: 36, lowercase?: #t),
+              "2s");
   check-no-errors("integer-to-string($minimum-integer)",
                   integer-to-string($minimum-integer));
   check-no-errors("integer-to-string($maximum-integer)",
                   integer-to-string($maximum-integer));
+  check-condition("bad base (1) signals error",
+                  <error>, integer-to-string(100, base: 1));
+  check-condition("bad base (37) signals error",
+                  <error>, integer-to-string(100, base: 37));
 end test;
 
 define test test-number-to-string ()

--- a/sources/io/tests/format.dylan
+++ b/sources/io/tests/format.dylan
@@ -38,16 +38,18 @@ define test hex-control-strings ()
   check-equal("format %x with a positive integer",
               format-to-string("%X", 117), "75");
   check-equal("format %x with a negative integer",
-              format-to-string("%x", -91827364), "-5792CA4");
+              format-to-string("%x", -91827364), "-5792ca4");
+  check-equal("format %X outputs uppercase",
+              format-to-string("%X", 255), "FF");
 end test hex-control-strings;
 
 define test multiple-basic-control-strings ()
   check-equal("multiple control strings 1",
-              format-to-string("Hex: %x, Dec: %d", 234, 567), "Hex: EA, Dec: 567");
+              format-to-string("Hex: %x, Dec: %d", 234, 567), "Hex: ea, Dec: 567");
   check-equal("multiple control strings 2",
               format-to-string("Bin: %b, Oct: %o", 12, 34), "Bin: 1100, Oct: 42");
   check-equal("multiple control strings 3",
-              format-to-string("%d %% %b %% %o %% %x", 42, 42, 42, 42), "42 % 101010 % 52 % 2A");
+              format-to-string("%d %% %b %% %o %% %x", 42, 42, 42, 42), "42 % 101010 % 52 % 2a");
 end test multiple-basic-control-strings;
 
 define test existing-string-messages ()


### PR DESCRIPTION
Just trying to pick off an easy bug, #1054   3-stage bootstrap works. I didn't update all current uses of `%x` to be `%X` but that would be the minimal change. However, I feel like this is pretty safe since I believe C code can generally handle both upper and lowercase hex numbers, and that seems like the most likely non-carbon-based consumer of this kind of output.

Fixes #1054