### PR TITLE
Fix bug in dfmc-reader:skip-multi-line-comments

### DIFF
--- a/documentation/release-notes/source/2021.1.rst
+++ b/documentation/release-notes/source/2021.1.rst
@@ -20,6 +20,10 @@ Compiler
 * Fixed a crash in the optimizer that ocurred when compiling certain
   C-FFI primitive functions.
 
+* Multi-line comments that contain comment delimiters within strings are now
+  parsed correctly. For example: ``/* "//h/a/" */`` Fixes `bug 1325
+  <https://github.com/dylan-lang/opendylan/issues/1325>`_.
+
 Run-time
 ========
 

--- a/sources/dfmc/reader/tests/comments-test-suite.dylan
+++ b/sources/dfmc/reader/tests/comments-test-suite.dylan
@@ -1,23 +1,45 @@
 Module: dfmc-reader-test-suite
 License: See License.txt in this distribution for details.
 
+define not-inline function verify-fragment-is-99 (text)
+  let f = read-fragment(text);
+  assert-true(f, format-to-string("no fragment was read from %=", text));
+  verify-literal(f, 99, <integer-fragment>);
+end function;
+
 define test test-line-comment ()
-  let f = read-fragment("// ignore\n1");
-  verify-literal(f, 1, <integer-fragment>);
+  verify-fragment-is-99("// ignore\n99");
 end test;
 
 define test test-multi-line-comment ()
-  let f = read-fragment("/* ignore */1/* ignore again */");
-  verify-literal(f, 1, <integer-fragment>);
+  verify-fragment-is-99("/* ignore */99/* ignore again */");
 end test;
 
 define test test-nested-multi-line-comment ()
-  let f = read-fragment("/* ignore /* here too */ */1");
-  verify-literal(f, 1, <integer-fragment>);
+  verify-fragment-is-99("/* ignore /* here too */ */99");
+end test;
+
+// DRM: "A single-line comment may appear within a delimited comment;
+// occurrences of slash-star or star-slash within the single line comment are
+// ignored."
+
+define test test-delimited-comment-with-nested-line-comment ()
+  assert-false(read-fragment("/* // */99"));
+  verify-fragment-is-99("/* // */\n*/99");   // 1st */ should be ignored
+  verify-fragment-is-99("/* // /*\n*/99");   // 2nd /* should be ignored
+end test;
+
+define test test-delimited-comment-with-string-nested-comments ()
+  verify-fragment-is-99("/* \"*/\" */99");   // Ignore */ inside string.
+  verify-fragment-is-99("/* \"/*\" */99");   // Ignore /* inside string.
+  verify-fragment-is-99("/* \"//\" */99");   // Ignore // inside string.
+  verify-fragment-is-99("/* \"  \n*/99");    // Incomplete string ended by newline.
 end test;
 
 define suite comments-test-suite ()
   test test-line-comment;
   test test-multi-line-comment;
   test test-nested-multi-line-comment;
+  test test-delimited-comment-with-nested-line-comment;
+  test test-delimited-comment-with-string-nested-comments;
 end suite;

--- a/sources/dfmc/reader/tests/comments-test-suite.dylan
+++ b/sources/dfmc/reader/tests/comments-test-suite.dylan
@@ -1,23 +1,23 @@
 Module: dfmc-reader-test-suite
 License: See License.txt in this distribution for details.
 
-define test line-comment-test ()
+define test test-line-comment ()
   let f = read-fragment("// ignore\n1");
   verify-literal(f, 1, <integer-fragment>);
-end test line-comment-test;
+end test;
 
-define test multi-line-comment-test ()
+define test test-multi-line-comment ()
   let f = read-fragment("/* ignore */1/* ignore again */");
   verify-literal(f, 1, <integer-fragment>);
-end test multi-line-comment-test;
+end test;
 
-define test nested-multi-line-comment-test ()
+define test test-nested-multi-line-comment ()
   let f = read-fragment("/* ignore /* here too */ */1");
   verify-literal(f, 1, <integer-fragment>);
-end test nested-multi-line-comment-test;
+end test;
 
 define suite comments-test-suite ()
-  test line-comment-test;
-  test multi-line-comment-test;
-  test nested-multi-line-comment-test;
-end suite comments-test-suite;
+  test test-line-comment;
+  test test-multi-line-comment;
+  test test-nested-multi-line-comment;
+end suite;

--- a/sources/dfmc/reader/tests/dfmc-reader-test-suite-library.dylan
+++ b/sources/dfmc/reader/tests/dfmc-reader-test-suite-library.dylan
@@ -19,6 +19,8 @@ define module dfmc-reader-test-suite
   use dfmc-common,
     import: { <compilation-record>,
               <interactive-compilation-record> };
+  use format,
+    import: { format-to-string };
   use source-records,
     import: { <interactive-source-record> };
   use streams,

--- a/sources/dfmc/reader/tests/literal-test-suite.dylan
+++ b/sources/dfmc/reader/tests/literal-test-suite.dylan
@@ -5,7 +5,7 @@ define function verify-literal
     (f :: <fragment>, value, required-class)
  => ()
   assert-equal(f.fragment-value, value);
-  assert-true(instance?(f, required-class));
+  assert-instance?(required-class, f);
 end function verify-literal;
 
 define function verify-presentation


### PR DESCRIPTION
3-stage-bootstrap and dfmc-reader-test-suite pass