### PR TITLE
Remove link to empty search results page

### DIFF
--- a/documentation/library-reference/source/index.rst
+++ b/documentation/library-reference/source/index.rst
@@ -36,8 +36,4 @@ It also documents Dylan language extensions and the LID file format.
    t-lists/index
    win32/index
 
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`search`
+:ref:`Full Index <genindex>`


### PR DESCRIPTION
There's no point in having a link to this (empty) page since the only way you can search is via the widget in the left nav.