### PR TITLE
common-dylan: fix bug in copy-bytes(<vector>, <string>)

### DIFF
--- a/sources/common-dylan/byte-vector.dylan
+++ b/sources/common-dylan/byte-vector.dylan
@@ -92,7 +92,7 @@ define open method copy-bytes
      src :: <string>, src-start :: <integer>, n :: <integer>)
  => ()
   for (i :: <integer> from 0 below n)
-    dst[dst-start + i] := as(<integer>, src[src-start + i])
+    dst[dst-start + i] := src[src-start + i]
   end
 end method;
 

--- a/sources/io/tests/streams.dylan
+++ b/sources/io/tests/streams.dylan
@@ -789,7 +789,7 @@ define test test-stretchy-stream (description: "<string-stream> stretchy vector 
           as(<stretchy-vector>, list(1,2,3,4,5,6))  );
   end;
 
- begin
+  begin
     let v = make(<vector>, size: 3);
     let s = make(<string-stream>, contents: v, direction: #"output");
     write(s, #(1, 2, 3));
@@ -805,7 +805,7 @@ define test test-stretchy-stream (description: "<string-stream> stretchy vector 
     check("test stream with stretchy vector", \=, stream-contents(s),
             as(<stretchy-vector>, list(1,2,3,4,5,6)));
   end;
- begin
+  begin
     let v = make(<vector>, size: 3);
     let s = make(<sequence-stream>, contents: v, direction: #"output");
     write(s, #(1, 2, 3));
@@ -817,6 +817,16 @@ end test;
 
 define test test-<sequence-stream> ()
   test-stream-class(<sequence-stream>, instantiable?: #t);
+end test;
+
+define test test-bug-1360 ()
+  // https://github.com/dylan-lang/opendylan/issues/1360 -- characters were
+  // being converted to integers when written to an underlying <vector>.
+  let v = make(<vector>, size: 5);
+  let stream = make(<sequence-stream>, contents: v, direction: #"output");
+  write(stream, #(1, 2, 3));
+  write(stream, "ABC");
+  assert-equal(#[1, 2, 3, 'A', 'B', 'C'], stream-contents(stream));
 end test;
 
 define test test-<string-stream> ()
@@ -845,6 +855,7 @@ end test;
 
 define suite streams-test-suite ()
   test test-<sequence-stream>;
+  test test-bug-1360;
   test test-<string-stream>;
   test test-<byte-string-stream>;
   test test-<wrapper-stream>;


### PR DESCRIPTION
`write(<sequence-stream>, <string>)` ends up calling `copy-bytes(<vector>,
<string>)` when the underlying sequence is a `<vector>`.  `copy-bytes` isn't
documented, but I infer from the implementations that it is misnamed and should
be called `copy-elements` or `copy-sequence-into!`, and my fix makes that
assumption. That is, that it isn't just intended to copy bytes.

```
Before:
test-bug-1360 failed
  #[1, 2, 3, 'A', 'B', 'C'] = stream-contents(stream) failed [#[1, 2, 3, 'A', 'B', 'C'] and #[1, 2, 3, 65, 66, 67] are not =.  element 3 is the first non-matching element]

After:
test-bug-1360 passed in 0.000216 seconds with 26016 bytes allocated.
  #[1, 2, 3, 'A', 'B', 'C'] = stream-contents(stream) passed
```

Fixes #1360