### PR TITLE
collections: Rename the table macro to tabling

### DIFF
--- a/documentation/library-reference/source/collections/table-extensions.rst
+++ b/documentation/library-reference/source/collections/table-extensions.rst
@@ -344,14 +344,14 @@ from the module *table-extensions*.
 
      .. note:: To empty collections that are not instances of :drm:`<mutable-explicit-key-collection>`, use *size-setter*.
 
-.. macro:: table
+.. macro:: tabling
    :macro-type: Function
    
    Creates a table and populates it with keys and values.
    
    :macrocall:
      .. parsed-literal::
-        table( { `class`, } `key` => `value`, ...)
+        tabling( { `class`, } `key` => `value`, ...)
            
    :parameter class:  An instance of :drm:`<class>`. Optional.
    :parameter key:    An expression.
@@ -367,5 +367,5 @@ from the module *table-extensions*.
    
      .. code-block:: dylan
 
-       let my-table = table("red"=>"stop", "green"=>"go");
-       let my-table = table(<string-table>, "red"=>"stop", "green"=>"go");
+       let my-table = tabling("red"=>"stop", "green"=>"go");
+       let my-table = tabling(<string-table>, "red"=>"stop", "green"=>"go");

--- a/documentation/release-notes/source/2021.1.rst
+++ b/documentation/release-notes/source/2021.1.rst
@@ -82,6 +82,12 @@ testworks Library
 collections Library
 -------------------
 
+* The ``table`` macro has been renamed to ``tabling``. ``table`` is not an
+  unlikely name for a function parameter when writing code that generically
+  operates on tables, and the existence of the ``table`` macro causes a
+  confusing compiler warning for references to that name that aren't in the
+  correct form.
+
 big-integers library
 --------------------
 

--- a/sources/collections/library.dylan
+++ b/sources/collections/library.dylan
@@ -87,7 +87,7 @@ define module table-extensions
       	      remove-all-keys!,
       	      merge-hash-ids },
     export: all;
-  export \table, <case-insensitive-string-table>;
+  export \tabling, <case-insensitive-string-table>;
 end module table-extensions;
 
 define module collections-internals

--- a/sources/collections/table-extensions.dylan
+++ b/sources/collections/table-extensions.dylan
@@ -7,33 +7,34 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 // Table constructor. Syntax:
-//   table(#"red"=>"stop", #"green"=>"go");
-//   table(<string-table>, "red"=>"stop", "green"=>"go");
+//   tabling(#"red"=>"stop", #"green"=>"go");
+//   tabling(<string-table>, "red"=>"stop", "green"=>"go");
 //
-define macro table 
+define macro tabling
 
   // Matches when optional class included.
-  { table(?table-class:expression, ?table-contents) }
-    => { let ht = make(?table-class); ?table-contents; ht; }
+  { tabling(?class:expression, ?contents) }
+    => { let t :: ?class = make(?class); ?contents; t; }
 
   // Matches without optional class.
-  { table(?rest:*) } => { table(<table>, ?rest); }
+  { tabling(?more:*) } => { tabling(<table>, ?more); }
 
-  table-contents:
+  contents:
   { } => { }
   { ?key:expression => ?value:expression, ... }
-    => { ht[?key] := ?value; ... }
-end macro table;
+    => { t[?key] := ?value; ... }
+end macro;
 
 
 // Code is taken from GD, using a superclass of <table> instead of <value-table>.
 define sealed class <case-insensitive-string-table> (<table>)
-end class <case-insensitive-string-table>;
+end class;
 
 define sealed domain make(singleton(<case-insensitive-string-table>));
 define sealed domain initialize(<case-insensitive-string-table>);
 
-define sealed inline method table-protocol (ht :: <case-insensitive-string-table>)
+define sealed inline method table-protocol
+    (table :: <case-insensitive-string-table>)
  => (key-test :: <function>, key-hash :: <function>);
-  values(case-insensitive-equal, case-insensitive-string-hash);
-end method table-protocol;
+  values(case-insensitive-equal, case-insensitive-string-hash)
+end method;

--- a/sources/collections/tests/collections-test-suite.dylan
+++ b/sources/collections/tests/collections-test-suite.dylan
@@ -52,4 +52,6 @@ define suite collections-test-suite ()
   suite bit-vector-test-suite;
   suite bit-set-test-suite;
   test bug-4351;
-end suite collections-test-suite;
+  test test-tabling-macro-without-class;
+  test test-tabling-macro-with-class;
+end suite;

--- a/sources/collections/tests/collections-test-suite.lid
+++ b/sources/collections/tests/collections-test-suite.lid
@@ -13,6 +13,7 @@ Files:     library
            bit-vector-not
            bit-count
            bit-set-tests
+           table-extensions
            collections-test-suite
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.

--- a/sources/collections/tests/table-extensions.dylan
+++ b/sources/collections/tests/table-extensions.dylan
@@ -1,0 +1,21 @@
+Module: collections-test-suite
+
+define test test-tabling-macro-without-class ()
+  assert-no-errors(tabling(), "tabling() with no args");
+
+  let t = tabling(1 => 2, 3 => 4);
+  assert-instance?(<table>, t);
+  assert-equal(2, t.size);
+  assert-equal(2, t[1]);
+  assert-equal(4, t[3]);
+end test;
+
+define test test-tabling-macro-with-class ()
+  assert-no-errors(tabling(<string-table>), "tabling() with class but no keyvals");
+
+  let t = tabling(<string-table>, "a" => 1, "b" => 2);
+  assert-instance?(<string-table>, t);
+  assert-equal(2, t.size);
+  assert-equal(1, t["a"]);
+  assert-equal(2, t["b"]);
+end test;


### PR DESCRIPTION
Having a macro in a frequently used library with a relatively common name, in
this case "table", can result in confusing compiler warnings:

```
catalog.dylan:254.12-14: Serious warning - Unexpected token "::".
                 --
          (table :: <table>, key :: <string>, expected-type :: <type>)
                 --
```

Technically the compiler could assume that something in parameter position MUST
NOT be a macro call, and similar with `let table = ...`, but this provides a
quick workaround.

I'm open to other names. I considered `make-table` as well and chose somewhat
arbitrarily.