### PR TITLE
common-dylan: add two tests for string <-> number functions

### DIFF
--- a/sources/common-dylan/library.dylan
+++ b/sources/common-dylan/library.dylan
@@ -24,6 +24,10 @@ define library common-dylan
     simple-format,
     byte-vector,
     transcendentals;
+
+  // For the test suite only.
+  export
+    common-dylan-internals;
 end library common-dylan;
 
 define module simple-profiling
@@ -307,4 +311,8 @@ define module common-dylan-internals
   use simple-profiling;
   use simple-timers;
   use simple-format;
+
+  // Exports for the test suite only.
+  export
+    character-to-integer;
 end module common-dylan-internals;

--- a/sources/common-dylan/tests/common-dylan-test-suite.lid
+++ b/sources/common-dylan/tests/common-dylan-test-suite.lid
@@ -5,6 +5,7 @@ Target-Type:  dll
 Files: library
        variables
        classes
+       format-tests
        functions
        macros
        streams

--- a/sources/common-dylan/tests/format-tests.dylan
+++ b/sources/common-dylan/tests/format-tests.dylan
@@ -1,0 +1,32 @@
+Module: common-dylan-test-suite
+
+define test test-character-to-integer ()
+  for (char in "0123456789",
+       code from 0)
+    assert-equal(code, character-to-integer(char),
+                 format-to-string("code for %c is %d", char, code));
+  end;
+  for (char in "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+       code from 10)
+    assert-equal(code, character-to-integer(char),
+                 format-to-string("code for %c is %d", char, code));
+    assert-equal(code, character-to-integer(as-lowercase(char)),
+                 format-to-string("code for %c is %d", as-lowercase(char), code));
+  end;
+end test;
+
+define test test-string-to-machine-word ()
+  local method mword (int)
+          as(<machine-word>, int)
+        end;
+  assert-signals(<error>, string-to-machine-word(""));
+  assert-signals(<error>, string-to-machine-word("G"));
+
+  let (value, epos) = string-to-machine-word("123G");
+  assert-equal(mword(#x123), value);
+  assert-equal(3, epos);
+
+  assert-equal(mword(#x123), string-to-machine-word("G0123G", start: 1));
+  assert-equal(mword(#x12), string-to-machine-word("G0123G", start: 1, end: 4));
+  assert-equal(mword(#x9abcdef), string-to-machine-word("9abcdef"));
+end test;

--- a/sources/common-dylan/tests/library.dylan
+++ b/sources/common-dylan/tests/library.dylan
@@ -22,6 +22,7 @@ define module common-dylan-test-suite
     import: { encode-single-float,
               encode-double-float,
               <abstract-integer> };
+  use common-dylan-internals;
   use common-extensions;
   use streams-protocol;
   use locators-protocol;


### PR DESCRIPTION
test-string-to-machine-word
test-character-to-integer