### PR TITLE
dylan: make sorted-applicable-methods gf match DRM

### DIFF
--- a/sources/dylan/generic-function.dylan
+++ b/sources/dylan/generic-function.dylan
@@ -685,7 +685,8 @@ end method;
 //// RETURNS APPLICABLE METHODS SORTED IN ORDER OF SPECIFICITY
 ////
 
-define generic sorted-applicable-methods (generic-function, #rest arguments)
+define generic sorted-applicable-methods
+    (generic-function :: <generic-function>, #rest arguments)
  => (ordered-unambiguous :: <sequence>, unordered-ambiguous :: <sequence>);
 
 define method sorted-applicable-methods


### PR DESCRIPTION
Specialize on `<generic-function>`. This fixes the last test failure due to not
matching the specification suite.

part of #1295