### PR TITLE
Remove description: option from all tests

### DIFF
--- a/sources/common-dylan/tests/threads/thread-variables.dylan
+++ b/sources/common-dylan/tests/threads/thread-variables.dylan
@@ -59,7 +59,7 @@ define method wait-for-resources ()
 end method;
 
 
-define test dynamic-binds-test (description: "Test dynamic bindings")
+define test dynamic-binds-test ()
   let *lock* = make(<lock>);
   let n = 10;
   let iterations = 10;

--- a/sources/common-dylan/tests/threads/threads.dylan
+++ b/sources/common-dylan/tests/threads/threads.dylan
@@ -10,7 +10,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 // Create a single thread and then join it. Make sure it returns the correct
 // thread object and return values.
 //
-define test single-thread-join(description: "join-thread (single thread)")
+define test single-thread-join ()
   let thread = make (<thread>,
                      name: "join test",
                      function: method () sleep(10); values(1,2,3) end);
@@ -25,7 +25,7 @@ end test;
 //////////
 // Test join-thread when given a vector of thread objects to join.
 //
-define test multiple-thread-join(description: "join-thread (multiple threads)")
+define test multiple-thread-join ()
   let n = 10;
   let thread-maker
     = method (i :: <integer>) => (thread :: <thread>)
@@ -56,9 +56,10 @@ end test;
 //////////
 // Make sure current-thread returns the correct thread object.
 //
-define test current-thread-test(description: "current-thread")
-  let thread = make(<thread>, name: "current-thread test",
-                              function: method() current-thread() end);
+define test current-thread-test ()
+  let thread = make(<thread>,
+                    name: "current-thread test",
+                    function: method() current-thread() end);
   let (rthread, result) = join-thread(thread);
   check-true("returns correct thread object", thread == result);
 end test;
@@ -67,15 +68,15 @@ end test;
 //////////
 // Just run thread-yield.
 //
-define test yield-test(description: "thread-yield")
+define test yield-test ()
   check-no-errors("thread-yield works",
-                 begin
-                   thread-yield();
-                 end);
+                  begin
+                    thread-yield();
+                  end);
 end test;
 
 
-define suite threads-suite (description: "Threads")
+define suite threads-suite ()
   test single-thread-join;
   test multiple-thread-join;
   test current-thread-test;

--- a/sources/corba/tests/dylan/client/constant-client.dylan
+++ b/sources/corba/tests/dylan/client/constant-client.dylan
@@ -16,7 +16,7 @@ define method close-enough? (x, y)
   (abs(x - y) / abs(x)) < $epsilon
 end method;
 
-define test constant-integer-test (description: "Test integer constants")
+define test constant-integer-test ()
   check-equal("Value of MIN_SHORT", $MIN-SHORT, -32768);
   check-equal("Value of MAX_SHORT", $MAX-SHORT, 32767);
   check-equal("Value of MIN_USHORT", $MIN-USHORT, 0);
@@ -30,7 +30,7 @@ define test constant-integer-test (description: "Test integer constants")
   check-equal("Value of HEXADECIMAL_INTEGER", $HEXADECIMAL-INTEGER-2, #xABCDEF);
 end test;
 
-define test constant-character-test (description: "Test character constants")
+define test constant-character-test ()
   check-equal("Value of SPACE", $SPACE, ' ');
   check-equal("Value of UNDERSCORE", $UNDERSCORE, '_');
   check-equal("Value of DIGIT0", $DIGIT0, '0');
@@ -53,12 +53,12 @@ define test constant-character-test (description: "Test character constants")
   check-equal("Value of HEXADECIMAL_NUMBER_2", $HEXADECIMAL-NUMBER-2, '\<12>');
 end test;
 
-define test constant-boolean-test (description: "Test boolean constants")
+define test constant-boolean-test ()
   check-equal("Value of MY_TRUE", $MY-TRUE, #t);
   check-equal("Value of MY_FALSE", $MY-FALSE, #f);
 end test;
 
-define test constant-string-test (description: "Test string constants")
+define test constant-string-test ()
   check-equal("Value of EMPTY_STRING", $EMPTY-STRING, "");
   check-equal("Value of NAME", $NAME, "Keith");
   check-equal("Value of CONCATENATED_STRINGS", $CONCATENATED-STRINGS, "First part+Second part");
@@ -66,7 +66,7 @@ define test constant-string-test (description: "Test string constants")
 // TODO: Add check for: const string CONCATENATED_STRINGS_2 = "\xA" "B";
 end test;
 
-define test constant-float-test (description: "Test float and double constants")
+define test constant-float-test ()
   check-equal("Value of ZERO_FLOAT", $ZERO-FLOAT, 0.0);
   check-equal("Value of WEE_FLOAT", $WEE-FLOAT, 1.175494s-30);
   check-equal("Value of BIG_FLOAT", $BIG-FLOAT, 3.4028236s+30);
@@ -81,7 +81,7 @@ define test constant-float-test (description: "Test float and double constants")
   check-equal("Value of DOUBLE_EXPR2", $DOUBLE-EXPR2, 0.0d0);
 end test;
 
-define test constant-expression-test (description: "Test constant expressions")
+define test constant-expression-test ()
   check-equal("Value of UNARY_PLUS", $UNARY-PLUS, 2);
   check-equal("Value of UNARY_MINUS", $UNARY-MINUS, -3);
   check-equal("Value of BINARY_MINUS", $BINARY-MINUS, -1);

--- a/sources/dylan/apple-dylan-test-suite/test-array.dylan
+++ b/sources/dylan/apple-dylan-test-suite/test-array.dylan
@@ -66,7 +66,7 @@ define test aref-setter-1 ()
   check-equal("t = \"dbc\"", t, "dbc");
 end test;
 
-define test dimensions-type (description: "")
+define test dimensions-type ()
   check("instance of function?", instance?, dimensions, <function>);
   check("instance of generic function?", instance?, dimensions, <generic-function>);
 end test;
@@ -89,4 +89,4 @@ define suite test-array-suite ()
  test aref-setter-1;
  test dimensions-type;
  test dimensions-1;
-end suite; 
+end suite;

--- a/sources/dylan/apple-dylan-test-suite/test-class2.dylan
+++ b/sources/dylan/apple-dylan-test-suite/test-class2.dylan
@@ -9,8 +9,8 @@ Modified by: Shri Amit(amit) &
 	     James Kirsch(jkirsch)
 Date: August 24 1996
 Summary: Converted to new testworks protocol
-Copyright: (c) 1996 Functional Objects, Inc. 
-           All rights reserved.  
+Copyright: (c) 1996 Functional Objects, Inc.
+           All rights reserved.
 ----------------------------------------------*/
 
 // chapter 11. Classes
@@ -45,7 +45,7 @@ define test make-<class> ()
   let wclass3
     = make(<class>, superclasses: <object>.list, slots: *widget-slots-spec*);
   every?(method (wclass)
-           check("", instance?(wclass, <class>));	
+           check("", instance?(wclass, <class>));
            let i = make(wclass);
            // No init-keywords
            check("", \=, i.widget-x, 0);
@@ -102,7 +102,7 @@ end test;
 // this is where we'll check out the class heterarchy, too.
 
 define test instance?-0 ()
-  check-true("", every?(method (c)		
+  check-true("", every?(method (c)
                           instance?(make, c)
                         end method,
                         list(<object>, <function>, <generic-function>)));

--- a/sources/dylan/apple-dylan-test-suite/test-class3.dylan
+++ b/sources/dylan/apple-dylan-test-suite/test-class3.dylan
@@ -9,8 +9,8 @@ Modified by: Shri Amit(amit) &
 	     James Kirsch(jkirsch)
 Date: August 24 1996
 Summary: Converted to new testworks protocol
-Copyright: (c) 1996 Functional Objects, Inc. 
-           All rights reserved.  
+Copyright: (c) 1996 Functional Objects, Inc.
+           All rights reserved.
 ----------------------------------------------*/
 
 define test type-survive-assignment-1 ()
@@ -29,8 +29,8 @@ end test;
 
 define test type-survive-assignment-2 ()
   check-condition
-    ("", <error>, 
-     method (n :: <integer>) 
+    ("", <error>,
+     method (n :: <integer>)
        if (n < 0)
 	 n := #f
        end if;
@@ -50,7 +50,7 @@ define test subtype?-type ()
   check("", instance?, subtype?, <function>);
 end test;
 
-define test subtype?-0 (description: "indirectly")
+define test subtype?-0 ()
   check-true("", subtype?(<dtest-test-subclass>, <dtest-test-class>));
   check-true("", ~subtype?(<dtest-test-class>, <dtest-test-subclass>));
   check-true("", subtype?(<sequence>, <collection>));
@@ -72,7 +72,7 @@ end test;
 
 define test all-superclasses-0 ()
   check-equal("", <object>.all-superclasses, <object>.list);
-  let c = <dtest-test-class>.all-superclasses;   
+  let c = <dtest-test-class>.all-superclasses;
   check-equal("", c.size, 2);
   check-equal("", c.first, <dtest-test-class>);
   check-equal("", c.second, <object>);
@@ -177,14 +177,14 @@ define suite test-class-suite ()
   test instance?-20;
   test instance?-22;
   test instance?-23;
-  test as-type;  
+  test as-type;
   test subtype?-type;
   test subtype?-0;
   test object-class-type;
   test object-class-0;
   test all-superclasses-type;
   test all-superclasses-0;
-  test direct-subclasses-type; 
+  test direct-subclasses-type;
   test direct-subclasses-0;
   test singleton-type;
   test singleton-0;
@@ -192,7 +192,3 @@ define suite test-class-suite ()
   test type-survive-assignment-2;
   test type-survive-assignment-3;
 end suite;
-
-
-
-

--- a/sources/dylan/apple-dylan-test-suite/test-collection.dylan
+++ b/sources/dylan/apple-dylan-test-suite/test-collection.dylan
@@ -9,10 +9,10 @@ Modified by: Shri Amit(amit) &
 	     James Kirsch(jkirsch)
 Date: August 24 1996
 Summary: Converted to new testworks protocol
-Copyright: (c) 1996 Functional Objects, Inc. 
-           All rights reserved.  
+Copyright: (c) 1996 Functional Objects, Inc.
+           All rights reserved.
 ----------------------------------------------*/
- 
+
  // Chapter 12. Collections
  // collection operations
 
@@ -21,38 +21,46 @@ Copyright: (c) 1996 Functional Objects, Inc.
    check-true("", instance?(size, <generic-function>));
  end test size-type;
 
- define test size-0 (description: "Size on list objects")
+// Size on list objects
+ define test size-0 ()
    check-equal("", list(1, 2, 3, 4).size, 4);
  end test size-0;
 
- define test size-1 (description: "Size on empty-lists")
+// Size on empty-lists
+ define test size-1 ()
    check-equal("", size(#()), 0);
    check-equal("", list().size, 0);
  end test size-1;
 
- define test size-2 (description: "Size on range objects")
+// Size on range objects
+ define test size-2 ()
    check-true("", ~range(from: 3, by: 3).size);
    check-equal("", range(from: 1, below: 11, by: 2).size, 5);
    check-equal("", range(from: 1, to: 11, by: 2).size, 6);
  end test size-2;
 
- define test size-3 (description: "size on deque objects")
+// size on deque objects
+ define test size-3 ()
    check-equal("", deque-instance(1, 2, 3, 4, 5).size, 5);
  end test size-3;
 
- define test size-4 (description: "size on table objects")
+// size on table objects
+ define test size-4 ()
    check-equal("", table-instance(#(1, 2), #(3, 4), #(5, 6)).size, 3);
  end test size-4;
 
- define test size-5 (description: "on stretchy-vectors")
+// on stretchy-vectors
+ define test size-5 ()
    check-equal("", stretchy-vector-instance(1, 2, 3, 4, 5).size, 5);
  end test size-5;
 
- define test size-6 (description: "Size on simple-object-vector objects")
+// Size on simple-object-vector objects
+ define test size-6 ()
    check-equal("", vector(1, 2, 3).size, 3);
  end test size-6;
 
- define test size-7 (description: "size on byte-string objects")
+// size on byte-string objects
+ define test size-7 ()
    check-equal("", size("now "), 4);
  end test size-7;
 
@@ -62,7 +70,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
    check-true("", instance?(size-setter, <generic-function>));
  end test size-setter-type;
 
- define test size-setter-1 (description: "deques")
+// deques
+ define test size-setter-1 ()
      let my-deque = make(<deque>, size: 5, fill: 10);
      my-deque.size := 10;
      check-equal("", my-deque.size, 10);
@@ -71,12 +80,13 @@ Copyright: (c) 1996 Functional Objects, Inc.
      check-equal("", my-deque.size, 3);
  end test size-setter-1;
 
- define test size-setter-2 (description: "stretchy-vectors")
+// stretchy-vectors
+ define test size-setter-2 ()
    begin
      let my-sv = make(<stretchy-vector>, size: 5, fill: 10);
      my-sv.size := 10;
      check-equal("", my-sv.size, 10);
-   end; 
+   end;
    begin
        let my-sv = make(<stretchy-vector>, size: 5, fill: 10);
        my-sv.size := 3;
@@ -90,21 +100,21 @@ Copyright: (c) 1996 Functional Objects, Inc.
    check-true("", instance?(type-for-copy, <generic-function>));
  end test type-for-copy-type;
 
- define test type-for-copy-0
- (description: "of a sequence, should be a subclass of <sequence>")
+// of a sequence, should be a subclass of <sequence>
+ define test type-for-copy-0 ()
    let r = range(from: 2, to: 4);
    check-true("", instance?(r, <sequence>) & subtype?(r.type-for-copy, <sequence>));
  end test type-for-copy-0;
 
- define test type-for-copy-1 
-  (description: "of an explicit-key-collection, should be a subclass of <e-k-c>")
+// of an explicit-key-collection, should be a subclass of <e-k-c>
+ define test type-for-copy-1 ()
    let t = make(<table>);
    check-true("", instance?(t, <explicit-key-collection>));
    check-true("", subtype?(t.type-for-copy, <explicit-key-collection>));
  end test type-for-copy-1;
 
- define test type-for-copy-3 
-   (description: "of bot <e-k-c> and <sequence>, be a subclass of <e-k-c> and <seq>")
+// of bot <e-k-c> and <sequence>, be a subclass of <e-k-c> and <seq>
+ define test type-for-copy-3 ()
    let v = make(<vector>);
    check-true("", instance?(v, <explicit-key-collection>));
    check-true("", instance?(v, <sequence>));
@@ -116,37 +126,45 @@ Copyright: (c) 1996 Functional Objects, Inc.
    check-true("", instance?(empty?, <generic-function>));
  end test empty?-type;
 
- define test empty?-0  (description: "empty? on lists")
+// empty? on lists
+ define test empty?-0  ()
    check-true("", ~empty?(#(#"a", #"b", #"c", #"d")));
  end test empty?-0;
 
- define test empty?-1 (description: "empty? on empty-lists")
+// empty? on empty-lists
+ define test empty?-1 ()
    check-true("", empty?(#()));
  end test empty?-1;
 
- define test empty?-2 (description: "empy? on ranges")
+// empy? on ranges
+ define test empty?-2 ()
    check-true("", ~range(from: 1, to: 11, by: 2).empty?);
  end test empty?-2;
 
- define test empty?-3 (description: "emtpy? on deques")
+// emtpy? on deques
+ define test empty?-3 ()
    check-true("", deque-instance().empty? & ~deque-instance(1, 2, 3).empty?);
  end test empty?-3;
 
- define test empty?-4 (description: "empty? on tables")
+// empty? on tables
+ define test empty?-4 ()
    check-true("", ~table-instance(#(1, 2), #(2, 3)).empty?);
    check-true("", table-instance().empty?);
  end test empty?-4;
 
- define test empty?-5 (description: "empty? on stretchy-vectors")
+// empty? on stretchy-vectors
+ define test empty?-5 ()
    check-true("", ~stretchy-vector-instance(1, 2, 3).empty?);
  end test empty?-5;
 
- define test empty?-6 (description: "empty on vectors")
+// empty on vectors
+ define test empty?-6 ()
    check-true("", vector().empty?);
    check-equal("", vector(1, 2, 3).empty?, #f);
  end test empty?-6;
 
- define test empty?-7 (description: "empty? on strings")
+// empty? on strings
+ define test empty?-7 ()
    check-true("", empty?(""));
    check-true("", ~empty?("now is the time"));
  end test empty?-7;
@@ -155,7 +173,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
    check-true("", instance?(do, <generic-function>));
  end test do-type;
 
- define test do-0 (description: "do returns #f")
+// do returns #f
+ define test do-0 ()
    check-true("", ~do(method (a, b)
 	pair(a, b.list);
        end method,
@@ -163,7 +182,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
        #(1, 2, 3, 4)));
  end test do-0;
 
- define test do-1 (description: "do doesn't run if empty list")
+// do doesn't run if empty list
+ define test do-1 ()
    check-equal("", begin
      let x = 0;
      do(method (a)
@@ -174,7 +194,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
 	    end, 0);
  end test do-1;
 
- define test do-2 (description: "with more than one collection")
+// with more than one collection
+ define test do-2 ()
    check-equal("", begin
      let sum = 0;
      do(method (a, b)
@@ -190,7 +211,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
    check-true("", instance?(map, <generic-function>));
  end test map-type;
 
- define test map-0 (description: "List")
+// List
+ define test map-0 ()
    check-equal("", map(method (x)
 			x * -1;
                         end method,
@@ -198,7 +220,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
     		#(-1, -2, -3, -4));
  end test map-0;
 
- define test map-1 (description: "Empty-List")
+// Empty-List
+ define test map-1 ()
    check-equal("", map(method (x)
 	 x * -1;
        end method,
@@ -206,7 +229,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
    #());
  end test map-1;
 
- define test map-2 (description: "Range")
+// Range
+ define test map-2 ()
    check-equal("", map(method (x)
 	 x * -1;
        end method,
@@ -214,7 +238,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
    #(-1, -2, -3, -4));
  end test map-2;
 
- define test map-3 (description: "Deque")
+// Deque
+ define test map-3 ()
    check-equal("", map(method (x)
 	 x * -1;
        end method,
@@ -222,7 +247,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
     deque-instance(-1, -2, -3));
  end test map-3;
 
- define test map-4 (description: "Table")
+// Table
+ define test map-4 ()
    check-equal("", map(method (x)
 	 x * -1;
        end method,
@@ -230,7 +256,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
     table-instance(#(1, -2), #(2, -3)));
  end test map-4;
 
- define test map-5 (description: "Stretchy-vector")
+// Stretchy-vector
+ define test map-5 ()
    check-equal("", map(method (x)
 	 x * -1;
        end method,
@@ -238,7 +265,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
     stretchy-vector-instance(-1, -2, -3));
  end test map-5;
 
- define test map-6 (description: "Simple-object-vector")
+// Simple-object-vector
+ define test map-6 ()
    check-equal("", map(method (x)
 	 x * -1;
        end method,
@@ -246,7 +274,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
     vector(-1, -2, -3));
  end test map-6;
 
- define test map-7 (description: "String")
+// String
+ define test map-7 ()
    check-equal("", map(method (x)
 	 x;
        end method,
@@ -254,8 +283,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
     "ABC");
  end test map-7;
 
- define test map-8 
-   (description: "returns a collection whose value is an inst of type-for-copy val")
+// returns a collection whose value is an inst of type-for-copy val
+ define test map-8 ()
    let s = list(1, 2, 3, 4);
    check-true("", instance?
      (map(method (x)
@@ -265,7 +294,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
       s.type-for-copy));
  end test map-8;
 
- define test map-9 (description: "creates a new collection")
+// creates a new collection
+ define test map-9 ()
    let s = list(1, 2, 3, 4);
    let new-s
      = map(method (x)
@@ -275,7 +305,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
    check-true("", \= (s, new-s));
  end test map-9;
 
- define test map-10 (description: "more than one collection arg")
+// more than one collection arg
+ define test map-10 ()
    check-equal("", map(\+, #(100, 200, 300, 400), #(1, 2, 3, 4)),
 	    #(101, 202, 303, 404));
    check-equal("", map(method (x)
@@ -289,7 +320,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
       #('1', '0', '1', '0'));
  end test map-10;
 
- define test map-11 (description: "with bind-exit")
+// with bind-exit
+ define test map-11 ()
    check-equal("", do(method (seq :: <sequence>)
      block (exit)
        map(method (item)
@@ -307,7 +339,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
    check-true("", instance?(map-as, <generic-function>));
  end test map-as-type;
 
- define test map-as-0 (description: "List")
+// List
+ define test map-as-0 ()
    check-equal("", map-as
      (<list>,
       method (x)
@@ -317,7 +350,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
    #(-1, -2, -3, -4));
  end test map-as-0;
 
- define test map-as-1 (description: "Empty-List")
+// Empty-List
+ define test map-as-1 ()
    check-equal("", map-as
      (<list>,
       method (x)
@@ -327,7 +361,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
      #());
  end test map-as-1;
 
- define test map-as-2 (description: "Range")
+// Range
+ define test map-as-2 ()
    check-equal("", map-as
      (<list>,
       method (x)
@@ -337,7 +372,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
     #(-1, -2, -3, -4));
  end test map-as-2;
 
- define test map-as-3 (description: "Deque")
+// Deque
+ define test map-as-3 ()
    check-equal("", map-as
      (<deque>,
       method (x)
@@ -347,7 +383,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
     deque-instance(-1, -2, -3));
  end test map-as-3;
 
- define test map-as-4 (description: "Table")
+// Table
+ define test map-as-4 ()
    check-equal("", map-as
      (<table>,
       method (x)
@@ -357,7 +394,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
     table-instance(#(1, -2), #(2, -3)));
  end test map-as-4;
 
- define test map-as-5 (description: "Stretchy-vector")
+// Stretchy-vector
+ define test map-as-5 ()
    check-equal("", map-as
      (<stretchy-vector>,
       method (x)
@@ -367,7 +405,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
     stretchy-vector-instance(-1, -2, -3));
  end test map-as-5;
 
- define test map-as-6 (description: "Simple-object-vector")
+// Simple-object-vector
+ define test map-as-6 ()
    check-equal("", map-as
      (<simple-object-vector>,
       method (x)
@@ -377,7 +416,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
     vector(-1, -2, -3));
  end test map-as-6;
 
- define test map-as-7 (description: "String")
+// String
+ define test map-as-7 ()
    check-equal("", map-as
      (<string>,
       method (x)
@@ -387,7 +427,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
     "ABC");
  end test map-as-7;
 
- define test map-as-8 (description: "new collection")
+// new collection
+ define test map-as-8 ()
    let s = #('a', 'b');
    check-true("", \~=(map-as
        (<byte-string>,
@@ -397,10 +438,11 @@ Copyright: (c) 1996 Functional Objects, Inc.
 	s), s));
  end test map-as-8;
 
- define test map-as-9 (description: "various coercions")
+// various coercions
+ define test map-as-9 ()
      let l = map-as(<list>, curry(\+, 1), range(below: 5));
-     check-true("", instance?(l, <list>)); 
-     check-equal("", l, #(1, 2, 3, 4, 5)); 
+     check-true("", instance?(l, <list>));
+     check-equal("", l, #(1, 2, 3, 4, 5));
      let v = map-as(<vector>, \+, #(100, 100, 200, 200), #(1, 2, 3, 4));
      check-true("", instance?(v, <vector>));
      check-equal("", v, #[101, 102, 203, 204]);
@@ -415,7 +457,7 @@ Copyright: (c) 1996 Functional Objects, Inc.
 		end if
 	      end method,
 	      #(1, 2, 3, 4));
-     check-true("", instance?(s, <string>)); 
+     check-true("", instance?(s, <string>));
      check-equal("", s, "1010");
  end test map-as-9;
 
@@ -423,13 +465,15 @@ Copyright: (c) 1996 Functional Objects, Inc.
    check-true("", instance?(map-into, <generic-function>));
  end test map-into-type;
 
- define test map-into-0 (description: "the simple cases")
+// the simple cases
+ define test map-into-0 ()
      let col = #(1, 0, 3, 0);
      map-into (col, zero?, col);
      check-equal("", col, #(#f, #t, #f, #t));
  end test map-into-0;
 
- define test map-into-1 (description: "List")
+// List
+ define test map-into-1 ()
    let var = #(1, 2, 3, 4, 5);
    check-equal("", map-into
      (var,
@@ -447,7 +491,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
      var);
  end test map-into-1;
 
- define test map-into-2 (description: "Empty-List")
+// Empty-List
+ define test map-into-2 ()
    let var = #();
    check-equal("", map-into
      (var,
@@ -465,7 +510,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
        var);
  end test map-into-2;
 
- define test map-into-3 (description: "Range")
+// Range
+ define test map-into-3 ()
    let var = #(1, 2, 3, 4, 5);
    check-equal("", map-into
      (var,
@@ -483,7 +529,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
       var);
  end test map-into-3;
 
- define test map-into-4 (description: "Deque")
+// Deque
+ define test map-into-4 ()
    let var = deque-instance(1, 2, 3, 4);
    check-equal("", map-into
      (var,
@@ -501,7 +548,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
       var);
  end test map-into-4;
 
- define test map-into-5 (description: "Table")
+// Table
+ define test map-into-5 ()
    let var = table-instance(#(1, 2), #(2, 3));
    check-equal("", map-into
      (var,
@@ -519,7 +567,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
       var);
  end test map-into-5;
 
-define test map-into-6 (description: "Stretchy-vector")
+// Stretchy-vector
+define test map-into-6 ()
   let var = stretchy-vector-instance(1, 2, 3);
   check-equal("", map-into
     (var,

--- a/sources/dylan/apple-dylan-test-suite/test-collection2.dylan
+++ b/sources/dylan/apple-dylan-test-suite/test-collection2.dylan
@@ -9,11 +9,12 @@ Modified by: Shri Amit(amit) &
 	     James Kirsch(jkirsch)
 Date: August 24 1996
 Summary: Converted to new testworks protocol
-Copyright: (c) 1996 Functional Objects, Inc. 
-           All rights reserved.  
+Copyright: (c) 1996 Functional Objects, Inc.
+           All rights reserved.
 ----------------------------------------------*/
 
-define test map-into-7 (description: "Simple-object-vector")
+// Simple-object-vector
+define test map-into-7 ()
   let var = vector(1, 2, 3);
   check-equal("", map-into
     (var,
@@ -31,7 +32,8 @@ define test map-into-7 (description: "Simple-object-vector")
      var);
 end test map-into-7;
 
-define test map-into-8 (description: "String")
+// String
+define test map-into-8 ()
   let var = "ABC";
   check-equal("", map-into
     (var,
@@ -49,13 +51,15 @@ define test map-into-8 (description: "String")
      var);
 end test map-into-8;
 
-define test map-into-9 (description: "with #rest collections")
+// with #rest collections
+define test map-into-9 ()
     let t = #(100, 100, 200, 200);
     map-into(t, \+, t, #(1, 2, 3, 4));
     check-equal("", t, #(101, 102, 203, 204));
 end test map-into-9;
 
-define test map-into-11 (description: "not a new collection")
+// not a new collection
+define test map-into-11 ()
   let col = #(1, 0, 3, 0);
   check-equal("", col, map-into(col, zero?, col));
 end test map-into-11;
@@ -64,7 +68,8 @@ define test any?-type ()
   check-true("", instance?(any?, <generic-function>));
 end test any?-type;
 
-define test any?-0 (description: "list")
+// list
+define test any?-0 ()
   check-equal("", any?(method (e)
          if (e > 5)
            e;
@@ -81,7 +86,8 @@ define test any?-0 (description: "list")
     #f);
 end test any?-0;
 
-define test any?-1 (description: "empty-list")
+// empty-list
+define test any?-1 ()
   check-equal("", any?(method (e)
          if (e > 5)
            e;
@@ -93,7 +99,8 @@ define test any?-1 (description: "empty-list")
    #f);
 end test any?-1;
 
-define test any?-2 (description: "range")
+// range
+define test any?-2 ()
   check-equal("", any?(method (e)
          if (e > 5)
            e;
@@ -114,7 +121,8 @@ define test any?-2 (description: "range")
      #f);
 end test any?-2;
 
-define test any?-3 (description: "deque")
+// deque
+define test any?-3 ()
   check-equal("", any?(method (e)
          if (e > 5)
            e;
@@ -135,7 +143,8 @@ define test any?-3 (description: "deque")
      #f);
 end test any?-3;
 
-define test any?-4 (description: "table")
+// table
+define test any?-4 ()
   check-equal("", any?(method (e)
          if (e > 5)
            e;
@@ -156,7 +165,8 @@ define test any?-4 (description: "table")
      #f);
 end test any?-4;
 
-define test any?-5 (description: "stretchy-vector")
+// stretchy-vector
+define test any?-5 ()
   check-equal("", any?(method (e)
          if (e > 5)
            e;
@@ -177,7 +187,8 @@ define test any?-5 (description: "stretchy-vector")
      #f);
 end test any?-5;
 
-define test any?-6 (description: "simple-object-vector")
+// simple-object-vector
+define test any?-6 ()
   check-equal("", any?(method (e)
          if (e > 5)
            e;
@@ -198,7 +209,8 @@ define test any?-6 (description: "simple-object-vector")
      #f);
 end test any?-6;
 
-define test any?-7 (description: "string")
+// string
+define test any?-7 ()
   check-equal("", any?(method (e)
          if (e = 'c')
            "Yes";
@@ -219,12 +231,14 @@ define test any?-7 (description: "string")
      #f);
 end test any?-7;
 
-define test any?-8 (description: "multiple collections")
+// multiple collections
+define test any?-8 ()
   check-true("", any?(\>, #(1, 2, 3, 4), #(5, 4, 3, 2)));
 end test any?-8;
 
 /* commented out by amit - look at ~amit/dylan/lib/test-suites/issues
-define test any?-9 (description: "with #rest collections")
+// with #rest collections
+define test any?-9 ()
   check-equal("", any?(method (x, y)
          if (instance?(x, <character>) & instance?(y, <vector>))
            pair(x, y);
@@ -237,7 +251,8 @@ define test any?-9 (description: "with #rest collections")
    pair('a', make(<vector>)));
 end test any?-9;
 
-define test any?-10 (description: "only returns 1st value")
+// only returns 1st value
+define test any?-10 ()
     let (a, b)
       = any?(method (x, y)
                if (instance?(x, <character>) & instance?(y, <vector>))
@@ -252,8 +267,9 @@ define test any?-10 (description: "only returns 1st value")
 end test any?-10;
 */
 
-define test any?-11 (description: "Stops on first true return")
-  
+// Stops on first true return
+define test any?-11 ()
+
     let var = 0;
     any?(method (x)
            if ((var := x) = 4)
@@ -270,7 +286,8 @@ define test every?-type ()
   check-true("", instance?(every?, <generic-function>));
 end test every?-type;
 
-define test every?-0 (description: "list")
+// list
+define test every?-0 ()
   check-true("", every?
     (method (e)
        if (e > -5)
@@ -288,7 +305,8 @@ define test every?-0 (description: "list")
        #(1, 2, 3, 4, 5)));
 end test;
 
-define test every?-1 (description: "empty-list")
+// empty-list
+define test every?-1 ()
   check-equal("", every?
     (method (e)
        if (e > 5)
@@ -301,7 +319,8 @@ define test every?-1 (description: "empty-list")
    #t);
 end test every?-1;
 
-define test every?-2 (description: "range")
+// range
+define test every?-2 ()
   check-equal("", every?
     (method (e)
        if (e > -10)
@@ -324,7 +343,8 @@ define test every?-2 (description: "range")
      #f);
 end test every?-2;
 
-define test every?-3 (description: "deque")
+// deque
+define test every?-3 ()
   check-equal("", every?
     (method (e)
        if (e > -5)
@@ -347,7 +367,8 @@ define test every?-3 (description: "deque")
      #f);
 end test every?-3;
 
-define test every?-4 (description: "table")
+// table
+define test every?-4 ()
   check-equal("", every?
     (method (e)
        if (e > -5)
@@ -370,7 +391,8 @@ define test every?-4 (description: "table")
      #f);
 end test every?-4;
 
-define test every?-5 (description: "stretchy-vector")
+// stretchy-vector
+define test every?-5 ()
   check-equal("", every?
     (method (e)
        if (e > -5)
@@ -393,7 +415,8 @@ define test every?-5 (description: "stretchy-vector")
      #f);
 end test every?-5;
 
-define test every?-6 (description: "simple-object-vector")
+// simple-object-vector
+define test every?-6 ()
   check-equal("", every?
     (method (e)
        if (e > -5)
@@ -416,7 +439,8 @@ define test every?-6 (description: "simple-object-vector")
      #f);
 end test every?-6;
 
-define test every?-7 (description: "string")
+// string
+define test every?-7 ()
   check-equal("", every?
     (method (e)
        e = 'c';
@@ -435,7 +459,8 @@ define test every?-7 (description: "string")
      #f);
 end test every?-7;
 
-define test every?-8 (description: "with #rest collections")
+// with #rest collections
+define test every?-8 ()
   check-true("", ~every?
      (method (x, y)
         if (instance?(x, <character>) & instance?(y, <vector>))
@@ -458,9 +483,10 @@ define test every?-8 (description: "with #rest collections")
        #(99, 6, 4, #[], 2)));
 end test every?-8;
 
-define test every?-9 (description: "Stops on first false return")
+// Stops on first false return
+define test every?-9 ()
     let var = 0;
-    check-equal("", 
+    check-equal("",
      begin
       every?
       (method (x)
@@ -480,38 +506,46 @@ define test reduce-type ()
   check-true("", instance?(reduce, <generic-function>));
 end test reduce-type;
 
-define test reduce-0 (description: "list")
+// list
+define test reduce-0 ()
   let high-score = 10;
   check-equal("", reduce(\+, 0, list(1, 2, 3, 4)), 10);
   check-equal("", reduce(max, high-score, #(3, 1, 4, 1, 5, 9)), 10);
   check-equal("", reduce(max, high-score, #(3, 12, 9, 8, 8, 6)), 12);
 end test reduce-0;
 
-define test reduce-1 (description: "empty-list")
+// empty-list
+define test reduce-1 ()
   check-equal("", reduce(\+, 0, #()), 0);
 end test reduce-1;
 
-define test reduce-2 (description: "range")
+// range
+define test reduce-2 ()
   check-equal("", reduce(\+, 0, range(from: -5, below: 5)), -5);
 end test reduce-2;
 
-define test reduce-3 (description: "deque")
+// deque
+define test reduce-3 ()
   check-equal("", reduce(\+, 0, deque-instance(1, 2, 3, 4, 5)), 15);
 end test reduce-3;
 
-define test reduce-4 (description: "table")
+// table
+define test reduce-4 ()
   check-equal("", reduce(\+, 0, table-instance(#(1, 2), #(3, 4), #(5, 6))), 12);
 end test reduce-4;
 
-define test reduce-5 (description: "stretchy-vector")
+// stretchy-vector
+define test reduce-5 ()
   check-equal("", reduce(\+, 0, stretchy-vector-instance(1, 2, 3, 4, 5)), 15);
 end test reduce-5;
 
-define test reduce-6 (description: "simple-object-vector")
+// simple-object-vector
+define test reduce-6 ()
   check-equal("", reduce(\+, 0, vector(1, 2, 3, 4, 5)), 15);
 end test reduce-6;
 
-define test reduce-7 (description: "string")
+// string
+define test reduce-7 ()
   check-equal("", reduce
     (method (l, c)
        pair(c, l);
@@ -527,37 +561,45 @@ define test reduce1-type ()
   check-true("", instance?(reduce1, <generic-function>));
 end test reduce1-type;
 
-define test reduce1-0 (description: "simple cases")
+// simple cases
+define test reduce1-0 ()
   check-true("", #t);
 end test reduce1-0;
 
-define test reduce1-1 (description: "list")
+// list
+define test reduce1-1 ()
   let high-score = 10;
   check-equal("", reduce1(\+, list(1, 2, 3, 4)), 10);
   check-equal("", reduce1(max, list(high-score, 3, 1, 4, 1, 5, 9)), 10);
 end test reduce1-1;
 
-define test reduce1-2 (description: "range")
+// range
+define test reduce1-2 ()
   check-equal("", reduce1(\+, range(from: -5, below: 5)), -5);
 end test reduce1-2;
 
-define test reduce1-3 (description: "deque")
+// deque
+define test reduce1-3 ()
   check-equal("", reduce1(\+, deque-instance(1, 2, 3, 4, 5)), 15);
 end test reduce1-3;
 
-define test reduce1-4 (description: "table")
+// table
+define test reduce1-4 ()
   check-equal("", reduce1(\+, table-instance(#(1, 2), #(3, 4), #(5, 6))), 12);
 end test reduce1-4;
 
-define test reduce1-5 (description: "stretchy-vector")
+// stretchy-vector
+define test reduce1-5 ()
   check-equal("", reduce1(\+, stretchy-vector-instance(1, 2, 3, 4, 5)), 15);
 end test reduce1-5;
 
-define test reduce1-6 (description: "simple-object-vector")
+// simple-object-vector
+define test reduce1-6 ()
   check-equal("", reduce1(\+, vector(1, 2, 3, 4, 5)), 15);
 end test reduce1-6;
 
-define test reduce1-7 (description: "string")
+// string
+define test reduce1-7 ()
   check-equal("", reduce1
     (method (l, c)
        pair(c, l);
@@ -566,8 +608,8 @@ define test reduce1-7 (description: "string")
        pair('o', pair('l', pair('l', pair('e', 'H')))));
 end test reduce1-7;
 
-define test reduce1-8
-  (description: "this should work like reduce w foo as init-val and empty list")
+// this should work like reduce w foo as init-val and empty list
+define test reduce1-8 ()
   check-equal("", reduce1(\+, #(#"foo")), #"foo");
 end test reduce1-8;
 
@@ -577,41 +619,49 @@ end test member?-type;
 
 // note -- must return a boolean, see design change note #16
 
-define test member?-0 (description: "list")
+// list
+define test member?-0 ()
   check-equal("", member?(5, list(1, 2, 3, 4, 5, 6)), #t);
   check-true("", ~member?(5, list(1, 2, 3, 4)));
 end test member?-0;
 
-define test member?-1 (description: "empty-list")
+// empty-list
+define test member?-1 ()
   check-true("", ~member?(5, #()));
 end test member?-1;
 
-define test member?-2 (description: "range")
+// range
+define test member?-2 ()
   check-equal("", member?(5, range(from: -5, below: 6)), #t);
   check-true("", ~member?(5, range(from: -5, below: 5)));
 end test member?-2;
 
-define test member?-3 (description: "deque")
+// deque
+define test member?-3 ()
   check-equal("", member?(5, deque-instance(1, 2, 3, 4, 5, 6)), #t);
   check-true("", ~member?(5, deque-instance(1, 2, 3, 4)));
 end test member?-3;
 
-define test member?-4 (description: "deque")
+// deque
+define test member?-4 ()
   check-equal("", member?(6, table-instance(#(1, 2), #(3, 4), #(5, 6))), #t);
   check-true("", ~member?(5, table-instance(#(1, 2), #(3, 4), #(5, 6))));
 end test member?-4;
 
-define test member?-5 (description: "stretchy-vector")
+// stretchy-vector
+define test member?-5 ()
   check-equal("", member?(6, stretchy-vector-instance(1, 2, 3, 4, 5, 6)), #t);
   check-true("", ~member?(5, stretchy-vector-instance(1, 2, 3, 4)));
 end test member?-5;
 
-define test member?-6 (description: "simple-object-vector")
+// simple-object-vector
+define test member?-6 ()
   check-equal("", member?(6, vector(1, 2, 3, 4, 5, 6)), #t);
   check-true("", ~member?(5, vector(1, 2, 3, 4)));
 end test member?-6;
 
-define test member?-7 (description: "string")
+// string
+define test member?-7 ()
   check-equal("", member?('c', "abcdef"), #t );
   check-true("", ~member?('c', "abdef"));
 end test member?-7;

--- a/sources/dylan/apple-dylan-test-suite/test-collection3.dylan
+++ b/sources/dylan/apple-dylan-test-suite/test-collection3.dylan
@@ -9,15 +9,17 @@ Modified by: Shri Amit(amit) &
 	     James Kirsch(jkirsch)
 Date: August 24 1996
 Summary: Converted to new testworks protocol
-Copyright: (c) 1996 Functional Objects, Inc. 
-           All rights reserved.  
+Copyright: (c) 1996 Functional Objects, Inc.
+           All rights reserved.
 ----------------------------------------------*/
 
-define test member?-8 (description: "test defaults to id?")
+// test defaults to id?
+define test member?-8 ()
   check-true("", ~member?(#[2], #[#[1], #[2], #[3]]));
 end test member?-8;
 
-define test member?-9 (description: "with other tests")
+// with other tests
+define test member?-9 ()
   check-true("", member?(#[2], #[#[1], #[2], #[3]], test: \=));
   check-true("", ~member?(0, range(from: 0, below: 6), test: \>));
   check-true("", member?(1, range(from: 0, below: 6), test: \>));
@@ -26,7 +28,8 @@ define test member?-9 (description: "with other tests")
   check-true("", member?('a', #[3, 5, 'b', 7, 'a']));
 end test member?-9;
 
-define test member?-10 (description: "test may be non-commutative")
+// test may be non-commutative
+define test member?-10 ()
   let error = #f;
   check-true("", member?
     (1, #('a', 'b'),
@@ -43,62 +46,72 @@ define test find-key-type ()
   check-true("", instance?(find-key, <generic-function>))
 end test find-key-type;
 
-define test find-key-0 (description: "list")
+// list
+define test find-key-0 ()
   let var = list(1, 2, 3, 4, 4);
   check-equal("", 4, var[find-key(var, curry(\==, 4))] & even?(var[find-key(var, even?)]));
   check-equal("", find-key(#(#()), empty?), 0);
   check-equal("", find-key(#(#(#())), empty?), #f);
 end test find-key-0;
 
-define test find-key-1 (description: "empty-list")
+// empty-list
+define test find-key-1 ()
   check-equal("", find-key(#(), empty?), #f);
 end test find-key-1;
 
-define test find-key-2 (description: "range")
+// range
+define test find-key-2 ()
     let var = range(from: 1, below: 6, by: 3);
     check-true("", even?(var[find-key(var, even?)]));
- 
+
   check-equal("", find-key(range(from: 1, below: 6, by: 2), even?), #f);
 end test find-key-2;
 
-define test find-key-3 (description: "deque")
+// deque
+define test find-key-3 ()
     let var = deque-instance(1, 2, 3, 4, 5);
   check-true("", even?(var[find-key(var, even?)]));
   check-equal("", find-key(deque-instance(1, 3, 5), even?), #f);
 end test find-key-3;
 
-define test find-key-4 (description: "table")
+// table
+define test find-key-4 ()
     let var = table-instance(#(1, 2), #(3, 4), #(5, 6));
   check-true("",  even?(var[find-key(var, even?)]));
   check-equal("", find-key(table-instance(#(1, 1), #(3, 3), #(5, 5)), even?), #f);
 end test find-key-4;
 
-define test find-key-5 (description: "stretchy-vector")
+// stretchy-vector
+define test find-key-5 ()
     let var = stretchy-vector-instance(1, 2, 3, 4, 5);
   check-true("",  even?(var[find-key(var, even?)]));
 
   check-equal("", find-key(stretchy-vector-instance(1, 3, 5), even?), #f);
 end test find-key-5;
 
-define test find-key-6 (description: "simple-object-vector")
- 
+// simple-object-vector
+define test find-key-6 ()
+
     let var = vector(1, 2, 3, 4, 5);
   check-true("",  even?(var[find-key(var, even?)]));
   check-equal("", find-key(vector(1, 3, 5), even?), #f);
 end test find-key-6;
 
-define test find-key-7 (description: "string")
+// string
+define test find-key-7 ()
 
     let var = "abcdefgh";
     check-equal("", 'c', var[find-key(var, curry(\=, 'c'))]);
   check-equal("", find-key("abdefgh", curry(\=, 'c')), #f);
 end test find-key-7;
 
-define test find-key-8 (description: "skip arg")
+// skip arg
+define test find-key-8 ()
   check-equal("", 5, find-key(list(1, 2, 3, 4, 5, 6), even?.curry, skip: 2));
 end test find-key-8;
 
-define test find-key-9 (description: "failure")
+// failure
+define test find-key-9 ()
   check-equal("", #f, find-key(list(1, 2, 3, 4, 5, 6), curry(\<, 9)));
   check-equal("", "Can't find the key",
      find-key
@@ -112,7 +125,8 @@ define test replace-elements!-type ()
   check-true("", instance?(replace-elements!, <generic-function>));
 end test replace-elements!-type;
 
-define test replace-elements!-0 (description: "list")
+// list
+define test replace-elements!-0 ()
   check-equal("", replace-elements!
     (#(1, 2, 3, 4, 5),
      even?,
@@ -122,7 +136,8 @@ define test replace-elements!-0 (description: "list")
    #(1, 3, 3, 5, 5));
 end test replace-elements!-0;
 
-define test replace-elements!-1 (description: "empty-list")
+// empty-list
+define test replace-elements!-1 ()
   check-equal("", replace-elements!
     (#(),
      even?,
@@ -132,7 +147,8 @@ define test replace-elements!-1 (description: "empty-list")
    #());
 end test replace-elements!-1;
 
-define test replace-elements!-2 (description: "deque")
+// deque
+define test replace-elements!-2 ()
   check-equal("", replace-elements!
     (deque-instance(1, 2, 3, 4, 5),
      even?,
@@ -142,7 +158,8 @@ define test replace-elements!-2 (description: "deque")
    deque-instance(1, 3, 3, 5, 5));
 end test replace-elements!-2;
 
-define test replace-elements!-3 (description: "table")
+// table
+define test replace-elements!-3 ()
   check-equal("", replace-elements!
     (table-instance(#(1, 2), #(3, 4), #(5, 6)),
      even?,
@@ -152,7 +169,8 @@ define test replace-elements!-3 (description: "table")
    table-instance(#(1, 3), #(3, 5), #(5, 7)));
 end test replace-elements!-3;
 
-define test replace-elements!-4 (description: "stretchy-vector")
+// stretchy-vector
+define test replace-elements!-4 ()
   check-equal("", replace-elements!
     (stretchy-vector-instance(1, 2, 3, 4, 5),
      even?,
@@ -162,7 +180,8 @@ define test replace-elements!-4 (description: "stretchy-vector")
    stretchy-vector-instance(1, 3, 3, 5, 5));
 end test replace-elements!-4;
 
-define test replace-elements!-5 (description: "simple-object-vector")
+// simple-object-vector
+define test replace-elements!-5 ()
   check-equal("", replace-elements!
     (vector(1, 2, 3, 4, 5),
      even?,
@@ -172,7 +191,8 @@ define test replace-elements!-5 (description: "simple-object-vector")
    vector(1, 3, 3, 5, 5));
 end test replace-elements!-5;
 
-define test replace-elements!-6 (description: "string")
+// string
+define test replace-elements!-6 ()
   check-equal("", replace-elements!
     ("abandon hope!",
      method (c)
@@ -184,7 +204,8 @@ define test replace-elements!-6 (description: "string")
    "zbzndon hope!");
 end test replace-elements!-6;
 
-define test replace-elements!-7 (description: "with count arg")
+// with count arg
+define test replace-elements!-7 ()
   check-equal("", replace-elements!
     (#(1, 2, 3, 4, 5, 6),
      odd?,
@@ -195,45 +216,55 @@ define test replace-elements!-7 (description: "with count arg")
    #(2, 2, 6, 4, 5, 6));
 end test replace-elements!-7;
 
-define test fill!-0 (description: "list")
+// list
+define test fill!-0 ()
   check-equal("", fill!(#(1, 2, 3, 4), 3), #(3, 3, 3, 3));
 end test fill!-0;
 
-define test fill!-1 (description: "empty-list")
+// empty-list
+define test fill!-1 ()
   check-equal("", fill!(#(), 4), #());
 end test fill!-1;
 
-define test fill!-2 (description: "deque")
+// deque
+define test fill!-2 ()
   check-equal("", fill!(deque-instance(#"a", #"b", #"c", #"d"), 4), deque-instance(4, 4, 4, 4));
 end test fill!-2;
 
-define test fill!-3 (description: "table")
+// table
+define test fill!-3 ()
   check-equal("", fill!(table-instance(#(#"a", #"b"), #(#"c", #"d")), 4), table-instance(#(#"a", 4), #(#"c", 4)));
 end test fill!-3;
 
-define test fill!-4 (description: "stretchy-vector")
+// stretchy-vector
+define test fill!-4 ()
   check-equal("", fill!(stretchy-vector-instance(#"a", #"b", #"c", #"d"), 4), stretchy-vector-instance(4, 4, 4, 4));
 end test fill!-4;
 
-define test fill!-5 (description: "simple-object-vector")
+// simple-object-vector
+define test fill!-5 ()
   check-equal("", fill!(vector(#"a", #"b", #"c", #"d"), 4), vector(4, 4, 4, 4));
 end test fill!-5;
 
-define test fill!-6 (description: "string")
+// string
+define test fill!-6 ()
   check-equal("", fill!("abcdefgh", 'x'), "xxxxxxxx");
   check-equal("", fill!("", 'x'), "");
 end test fill!-6;
 
-define test fill!-7 (description: "with start: arg")
+// with start: arg
+define test fill!-7 ()
   check-equal("", fill!("abcdefgh", 'x', start: 3), "abcxxxxx");
 end test fill!-7;
 
-define test fill!-8 (description: "with end: arg")
+// with end: arg
+define test fill!-8 ()
     let t = "abcdefgh";
     check-equal("", fill!(t, 'x', end: 2), "xxcdefgh");
 end test fill!-8;
 
-define test fill!-9 (description: "with start: and end: args")
+// with start: and end: args
+define test fill!-9 ()
   check-equal("", fill!(#[#"a", #"b", #"c", #"d"], 1, start: 1, end: 3), #[#"a", 1, 1, #"d"]);
   check-equal("", fill!("abcdefgh", 'x', start: 3, end: 5), "abcxxfgh");
   check-equal("", fill!(#(), #"x", start: 0, end: 0), #());
@@ -241,7 +272,8 @@ end test fill!-9;
 
 // KJP: end: 3 -> 0
 
-define test fill!-10 (description: "alters mutable-collection")
+// alters mutable-collection
+define test fill!-10 ()
   let s = "abcdefgh";
   check-equal("", fill!(s, 'x'), "xxxxxxxx" );
   check-equal("", fill!(s, 'x'), s);
@@ -251,7 +283,8 @@ define test element-type ()
   check-true("", instance?(element, <generic-function>));
 end test element-type;
 
-define test element-0 (description: "simple cases")
+// simple cases
+define test element-0 ()
   check-equal("", deque-instance(1, 2, 3, 4)[2], 3);
   check-equal("", stretchy-vector-instance(1, 2, 3, 4)[2], 3);
   check-equal("", vector(1, 2, 3, 4)[2], 3);
@@ -260,7 +293,8 @@ define test element-0 (description: "simple cases")
   check-equal("", #(99, 98, 97, 96, 95)[4], 95);
 end test element-0;
 
-define test element-1 (description: "with default")
+// with default
+define test element-1 ()
   check-true("", empty?(element(deque-instance(1, 2, 3, 4), 7, default: deque-instance())));
   check-equal("", element(stretchy-vector-instance(1, 2, 3, 4), 6, default: #()), #());
   check-equal("", element(vector(1, 2, 3, 4), 8, default: #t), #t);
@@ -268,7 +302,7 @@ define test element-1 (description: "with default")
       (table-instance(#(1, #"a"), #(2, #"b"), #(3, #"c")), 87, default: #"d"), #"d");
   check-equal("", element("Now is the time", 100, default: "no"), "no");
   check-equal("", element(#(99, 98, 97, 96, 95), 5, default: #f), #f);
- 
+
       let a = "foobar";
     check-equal("", apply(aref, list(a, 3)), a[3]);
     check-equal("", apply(aref, list(a, 3)), 'b');
@@ -291,88 +325,95 @@ end test element-setter-0;
 
 // These do not exhaustively test all possible collections
 
-define test element-setter-list1
-  (description: "list: index too low")
+// list: index too low
+define test element-setter-list1 ()
   check-condition("", <error>, list(1, 2, 3)[-1] := 0);
 end test element-setter-list1;
 
-define test element-setter-list2
-  (signal: <error>, description: "list: index too high")
+// list: index too high
+define test element-setter-list2 ()
   check-condition("", <error>, list(1, 2, 3)[5] := 5);
 end test element-setter-list2;
 
-define test element-setter-list3
-  (signal: <error>, description: "improper list")
+// improper list
+define test element-setter-list3 ()
   check-condition("", <error>, pair(1, 2)[1] := #"a");
 end test element-setter-list3;
 
-define test element-setter-vector1
-  (signal: <error>, description: "vector: index too low")
+// vector: index too low
+define test element-setter-vector1 ()
   check-condition("", <error>, vector(1, 2, 3)[-1] := 0);
 end test element-setter-vector1;
 
-define test element-setter-vector2
-  (signal: <error>, description: "vector: index too high")
+// vector: index too high
+define test element-setter-vector2 ()
   check-condition("", <error>, vector(1, 2, 3)[5] := 5);
 end test element-setter-vector2;
 
-define test element-setter-string1
-  (signal: <error>, description: "string: index too low")
+// string: index too low
+define test element-setter-string1 ()
   let s = "foo";
   check-condition("", <error>, s[-1] := 'a');
 end test element-setter-string1;
 
-define test element-setter-string2
-  (signal: <error>, description: "string: index too high")
+// string: index too high
+define test element-setter-string2 ()
   let s = "foo";
   check-condition("", <error>, s[5] := 'a');
 end test element-setter-string2;
 
-define test element-setter-string3
-  (signal: <error>, description: "string: not a char")
+// string: not a char
+define test element-setter-string3 ()
   let s = "foo";
   check-condition("", <error>, s[1] := #"a");
 end test element-setter-string3;
 
 // element, page 124
 
-define test element1-0 (description: "list")
+// list
+define test element1-0 ()
   let c = #(1, 2, 3, 4);
   check-equal("", c[0], 1);
   check-equal("", element(c, 99, default: #t), #t);
 end test element1-0;
 
-define test element1-1 (description: "range")
+// range
+define test element1-1 ()
   let c = range(from: 1, below: 6);
   check-equal("", c[0], 1);
   check-equal("", element(c, 99, default: #t), #t);
 end test element1-1;
 
-define test element1-2 (description: "deque")
+// deque
+define test element1-2 ()
   let c = deque-instance(1, 2, 3, 4);
   check-equal("", c[0], 1);
   check-equal("", element(c, 99, default: #t), #t);
 end test element1-2;
 
-define test element1-3 (description: "table")
+// table
+define test element1-3 ()
   let c = table-instance(#(1, 2), #(3, 4));
   check-equal("", c[3], 4 );
   check-equal("", element(c, 99, default: #t), #t);
 end test element1-3;
 
-define test element1-4 (description: "stretchy-vector")
+// stretchy-vector
+define test element1-4 ()
   let c = stretchy-vector-instance(1, 2, 3, 4);
   check-equal("", c[0], 1 );
   check-equal("", element(c, 99, default: #t), #t);
 end test element1-4;
 
-define test element1-5 (description: "simple-object-vector")
+// simple-object-vector
+define test element1-5 ()
   let c = vector(1, 2, 3, 4);
   check-equal("", c[0], 1);
   check-equal("", element(c, 99, default: #t), #t);
 end test element1-5;
 
-define test element1-6 (description: "string")
+// string
+define test element1-6 ()
   let c = "1234";
   check-equal("", c[0], '1' );
   //---*** Triggers compiler crash:
@@ -429,9 +470,9 @@ define suite test-collection-suite ()
   test size-setter-1;
   test size-setter-2;
   test type-for-copy-type;
-  test type-for-copy-0; 
+  test type-for-copy-0;
   test type-for-copy-1;
-  test type-for-copy-3; 
+  test type-for-copy-3;
   test empty?-type;
   test empty?-0;
   test empty?-1;
@@ -458,7 +499,7 @@ define suite test-collection-suite ()
   test map-9;
   test map-10;
   test map-11;
-  test map-as-type; 
+  test map-as-type;
   test map-as-0;
   test map-as-1;
   test map-as-2;
@@ -472,7 +513,7 @@ define suite test-collection-suite ()
   test map-into-type;
   test map-into-0;
   test map-into-1;
-  test map-into-2; 
+  test map-into-2;
   test map-into-3;
   test map-into-4;
   test map-into-5;
@@ -495,7 +536,7 @@ define suite test-collection-suite ()
 //  test any?-10; or test-collection2.dylan
   test any?-11;
   test every?-type;
-  test every?-0; 
+  test every?-0;
   test every?-1;
   test every?-2;
   test every?-3;
@@ -566,7 +607,7 @@ define suite test-collection-suite ()
   test fill!-7;
   test fill!-8;
   test fill!-9;
-  test fill!-10; 
+  test fill!-10;
   test element-type;
   test element-0;
   test element-1;

--- a/sources/dylan/apple-dylan-test-suite/test-comparison.dylan
+++ b/sources/dylan/apple-dylan-test-suite/test-comparison.dylan
@@ -8,50 +8,55 @@ Copyright: (c) 1993 Apple Computer, Inc.
 Modified by: Shri Amit(amit)
 Date: August 24 1996
 Summary: Converted to new testworks protocol
-Copyright: (c) 1996 Functional Objects, Inc. 
-           All rights reserved.  
+Copyright: (c) 1996 Functional Objects, Inc.
+           All rights reserved.
 ----------------------------------------------*/
 
-define test id?-type (description: "")
-  check("", instance?, \==, <function>); 
+define test id?-type ()
+  check("", instance?, \==, <function>);
   check("", method(a, b) ~instance?(a, b) end, \==, <generic-function>);
 end test id?-type;
 
-define test id?-0 (description: "Simple cases")
+// Simple cases
+define test id?-0 ()
   check-equal("", #f, #f);
   check-equal("", 3, 3);
   check-equal("", #"foo", #"foo");
   check-equal("", #(), #());
-  check-equal("", #"abc", #"abc"); 
+  check-equal("", #"abc", #"abc");
 end test id?-0;
 
 // It's not clear whether literal constants are id?
 //  (not (id? '(1 2 3) '(1 2 3)))
 //  (not (id? "abc" "abc"))
 
-define test id?-1 (description: "#rest args")
+// #rest args
+define test id?-1 ()
   check-true("", #t == #t & #t == #t);
   check-true("", #f == even?(3) & ~(#(1, 2, 3) == #(1, 2, 3)));
 end test id?-1;
 
-define test equal-type (description: "")
+define test equal-type ()
   check-true("", instance?(\=, <function>));
   check-true("", instance?(\=, <generic-function>));
 end test equal-type;
 
-define test equal-0 (description: "Numeric cases")
-  check-true("", 1 + 2 = 5 - 2);  
+// Numeric cases
+define test equal-0 ()
+  check-true("", 1 + 2 = 5 - 2);
   check-true("", 1 + 2 = 3);
   check-true("", 3 = 3);
   check-true("", ~(3 = 4));
 //  check-true("<ratio> is undefined in emulator", {RATIO instance} = {RATIO instance});
 end test equal-0;
 
-define test equal-complex (description: "= on complex numbers")
+// = on complex numbers
+define test equal-complex ()
   check-true("", complex-instance() = complex-instance());
 end test equal-complex;
 
-define test a=-1 (description: "collections")
+// collections
+define test a=-1 ()
   check-true("", "abc" = "abc" & "abc" = "abc");
   check-true("", ~("abc" = "aBc" & "abc" = "abc"));
   check-true("", list(#"a", #"b", #"c") = list(#"a", #"b", #"c"));
@@ -60,7 +65,7 @@ define test a=-1 (description: "collections")
   check-false("", list(#"a", #"z", #"c") = list(#"a", #"b", #"c"));
   check-true("", stretchy-vector-instance(1, 2, 3) = stretchy-vector-instance(1, 2, 3));
   check-true("", stretchy-vector-instance(1, 2, 3) = stretchy-vector-instance(1, 2, 3));
-  check-true("", ~(stretchy-vector-instance(1, 2, 3) = stretchy-vector-instance(1, 999, 3)));  
+  check-true("", ~(stretchy-vector-instance(1, 2, 3) = stretchy-vector-instance(1, 999, 3)));
   check-true("", stretchy-vector-instance(1, 2, 3) = stretchy-vector-instance(1, 2, 3));
   check-true("", vector(1, 2, 3)
      = vector(1, 2, 3));
@@ -89,21 +94,24 @@ define test a=-1 (description: "collections")
   // check-false("", \& = \& & \& = =hash);
 end test a=-1;
 
-define test a=-type (description: "")
+define test a=-type ()
   check-true("", instance?(\&=, <function>));
   check-false("", instance?(\&=, <generic-function>));
 end test a=-type;
 
-define test qw (description: "Numeric cases")
+// Numeric cases
+define test qw ()
   check-true("", 3 ~= 4);
 //  check-true("<ratio> is yet undefined", {RATIO instance} ~= {RATIO instance});
 end test;
 
-define test p=-complex (description: "/= on complex numbers")
+// ~= on complex numbers
+define test p=-complex ()
   check-true("", complex-instance(real: 5, imag: 2) ~= complex-instance(real: 5, imag: 3));
 end test;
 
-define test p=-1 (description: "collections")
+// collections
+define test p=-1 ()
   check-true("", "abc" = "abc");
   check-true("", "abc" ~= "aBc");
   check-true("", list(#"a", #"z", #"c") ~= list(#"a", #"b", #"c"));
@@ -120,35 +128,39 @@ define test p=-1 (description: "collections")
   // check-true("", \& ~= =hash);
 end test p=-1;
 
-define test p=-2 (description: "symbols - not case sensitive")
+// symbols - not case sensitive
+define test p=-2 ()
   check-true("", #"foo" = #"FOO" & #"FOo" = #"foO");
 end test;
 
-define test binary=-type (description: "")
+define test binary=-type ()
   check-true("", instance?(binary=, <generic-function>));
 end test binary=-type;
 
-define test binary= (description: "")
-  check-true("", ~binary=(1, 2));  
+define test binary= ()
+  check-true("", ~binary=(1, 2));
   check-true("", binary=(#(1, 2, 3), #(1, 2, 3)));
 end test binary=;
 
-define test p=hash-type (description: "")
+define test p=hash-type ()
   check-true("", instance?(=hash, <generic-function>));
 end test;
 
-define test p=hash (description: "Numeric cases")
+// Numeric cases
+define test p=hash ()
   check-true("", =hash(1 + 2) = =hash(5 - 2));
   check-true("", =hash(3) = =hash(3));
 //  check-true("<ratio> is undefined", =hash({RATIO instance}) = =hash({RATIO instance}));
 end test;
 
-define test =hash-complex (description: "=hash on complex")
+// =hash on complex
+define test =hash-complex ()
   check-equal("", complex-instance(real: 3, imag: 2).=hash,
   complex-instance(real: 3, imag: 2).=hash);
 end test =hash-complex;
 
-define test =hash-1 (description: "collections")
+// collections
+define test =hash-1 ()
   check-true("", =hash("abc") = =hash("abc"));
   check-true("", list(#"a", #"b", #"c").=hash = list(#"a", #"b", #"c").=hash);
   check-equal("", stretchy-vector-instance(1, 2, 3).=hash,
@@ -165,11 +177,12 @@ define test =hash-1 (description: "collections")
   // check-true("", \&.=hash = \&.=hash);
 end test =hash-1;
 
-define test less-than-type (description: "")
+define test less-than-type ()
   check-true("", instance?(\<, <function>) & ~instance?(\<, <generic-function>));
 end test less-than-type;
 
-define test q (description: "Numeric cases")
+// Numeric cases
+define test q ()
   check-true("", 1 + 2 < 15 - 4);
   check-true("", 3 < 5);
   check-true("", 3 < 5);
@@ -177,7 +190,8 @@ define test q (description: "Numeric cases")
 //  check-true("<ratio> undefined", {RATIO instance} < {RATIO instance});
 end test q;
 
-define test less-than-1 (description: "strings, without knowing underlying char set")
+// strings, without knowing underlying char set
+define test less-than-1 ()
   check-true("", "prefix" < "prefix is less than");
   check-true("", if ('a' < 'c')
       "aaa" < "ccc"
@@ -186,18 +200,20 @@ define test less-than-1 (description: "strings, without knowing underlying char 
     end if);
 end test less-than-1;
 
-define test greater-than-type (description: "")
+define test greater-than-type ()
   check-true("", instance?(\>, <function>) & ~instance?(\>, <generic-function>));
 end test greater-than-type;
 
-define test w> (description: "Numeric cases")
+// Numeric cases
+define test w> ()
   check-true("", 15 - 4 > 1 + 2);
   check-true("", 5 > 3);
   check-true("", (9 > 5 & 9 > 3));
 //  check-true("<ratio> undefined", {RATIO instance} > {RATIO instance});
 end;
 
-define test greater-than-1 (description: "strings, without knowing underlying char set")
+// strings, without knowing underlying char set
+define test greater-than-1 ()
   check-true("", "prefix is less than" > "prefix");
   check-true("", if ('a' > 'c')
       "aaa" > "ccc"
@@ -206,11 +222,11 @@ define test greater-than-1 (description: "strings, without knowing underlying ch
     end if);
 end test greater-than-1;
 
-define test binary<-type (description: "")
+define test binary<-type ()
   check-true("", instance?(binary<, <generic-function>));
 end test binary<-type;
 
-define test binary< (description: "")
+define test binary< ()
   check-true("", binary<(1, 2));
 end test binary<;
 

--- a/sources/dylan/apple-dylan-test-suite/test-condition.dylan
+++ b/sources/dylan/apple-dylan-test-suite/test-condition.dylan
@@ -8,14 +8,15 @@ Copyright: (c) 1993 Apple Computer, Inc.
 Modified by: Shri Amit(amit)
 Date: August 24 1996
 Summary: Converted to new testworks protocol
-Copyright: (c) 1996 Functional Objects, Inc. 
-           All rights reserved.  
+Copyright: (c) 1996 Functional Objects, Inc.
+           All rights reserved.
 ----------------------------------------------*/
 
 // Chapter 13. Conditions
 
 
-define test condition-classes (description: "see if they exist")
+// see if they exist
+define test condition-classes ()
   check-true("", every?
     (rcurry(instance?, <class>),
      list(<condition>,
@@ -30,8 +31,9 @@ define test condition-classes (description: "see if they exist")
 //          <abort>)));
 end test condition-classes;
 
+// check superclasses for each condition class
 define test condition-classes-hierarchy
-  (description: "check superclasses for each condition class")
+  ()
   check-true("", every?
     (method (x)
        every?(curry(subtype?, x.first), x.tail)
@@ -49,7 +51,7 @@ define test condition-classes-hierarchy
           list(<restart>, <condition>))));
 end test condition-classes-hierarchy;
 
-define test simple-error-slots (description: "")
+define test simple-error-slots ()
   let e
     = make(<simple-error>,
            format-string: "This is a test.",
@@ -58,12 +60,12 @@ define test simple-error-slots (description: "")
   check-true("", #(1, 2, 3) = e.condition-format-arguments);
 end test simple-error-slots;
 
-define test type-error-slots (description: "")
+define test type-error-slots ()
   let e = make(<type-error>, value: 7, type: <string>);
   check-true("", 7 = e.type-error-value & <string> = e.type-error-expected-type);
 end test type-error-slots;
 
-define test simple-warning-slots (description: "")
+define test simple-warning-slots ()
   let e
     = make(<simple-warning>,
            format-string: "This is a test.",
@@ -72,8 +74,8 @@ define test simple-warning-slots (description: "")
   check-true("", #(1, 2, 3) = e.condition-format-arguments);
 end test simple-warning-slots;
 
-define test restart-slots
-  (description: "condition: is accepted by <restart>, but ignored for now")
+// condition: is accepted by <restart>, but ignored for now
+define test restart-slots ()
   let e = make(<simple-restart>, condition: #f);
   check-true("", instance?(e, <restart>));
 end test restart-slots;
@@ -88,18 +90,21 @@ end class <test-error>;
 // While making instances of <simple-error> and <simple-warning>
 // the slot format-string seems to be unbound.
 
-define test signal-1 (description: "signal")
+// signal
+define test signal-1 ()
   check-condition("", <error>, signal(make(<test-condition>)));
 end test signal-1;
 
-define test signal-2 (description: "simple-error")
-  check-condition("", <simple-error>, 
+// simple-error
+define test signal-2 ()
+  check-condition("", <simple-error>,
 		  signal(make(<test-error>, format-string: "Just testing.")));
 end test signal-2;
 
-define test signal-3 (description: "simple-warning")
-  check-condition("", <error>, 
-		  signal(make(<simple-warning>, 
+// simple-warning
+define test signal-3 ()
+  check-condition("", <error>,
+		  signal(make(<simple-warning>,
 			      format-string: "Just testing.")))
 end test signal-3;
 
@@ -115,61 +120,67 @@ end method default-handler;
 // be caught by the default-handler for <catcher-test-condition>
 //
 
-define test signal-4
-  (description: "default handler called by default")
+// default handler called by default
+define test signal-4 ()
   check-true("", signal(make(<catcher-test-condition>)) = #"catcher");
 end test signal-4;
 
 // Are signal and error really supposed to return true here???
 
-define test signal-5 (description: "string, no args")
+// string, no args
+define test signal-5 ()
   check-condition("", <simple-warning>, signal("Just testing."));
 end test signal-5;
 
-define test signal-6
-  (description: "string, some args")
+// string, some args
+define test signal-6 ()
   check-condition("", <simple-error>, signal("Just testing.", 1, 2, 3));
 end test signal-6;
 
-define test error-1 (description: "")
+define test error-1 ()
   check-condition("", <test-error>, error(make(<test-error>)));
 end test error-1;
 
-define test error-2 (description: "string, no args")
+// string, no args
+define test error-2 ()
   check-condition("", <error>, error("Just testing."));
 end test error-2;
 
-define test error-3 (description: "string, some args")
+// string, some args
+define test error-3 ()
   check-condition("", <simple-error>, error("Just testing.", 1, 2, 3));
 end test error-3;
 
-define test cerror-1 (description: "")
-  check-condition("", <test-error>, 
+define test cerror-1 ()
+  check-condition("", <test-error>,
 		  cerror("Restart description", make(<test-error>)));
 end test cerror-1;
 
-define test cerror-2 (description: "string, no args")
+// string, no args
+define test cerror-2 ()
   check-condition("", <simple-error>,
 		  cerror("Restart description", "Just testing."));
 end test cerror-2;
 
-define test cerror-3 (description: "string, some args")
+// string, some args
+define test cerror-3 ()
   check-condition("", <simple-error>,
 		  cerror("Restart description", "Just testing.", 1, 2, 3));
 end test cerror-3;
 
-define test check-type-0 (description: "")
+define test check-type-0 ()
   check-condition("", <type-error>, check-type(3, <string>));
 end test check-type-0;
 
 // This is because abort is undefined!!
-//define test abort-0 (description: "")
+//define test abort-0 ()
 //  check-condition("", <abort>, abort());
 //end test abort-0;
 
 // Handler-bind
 /*
-define test handler-bind (description: "No condition to handle")
+// No condition to handle
+define test handler-bind ()
   let (result1, result2, result3)
     = begin
         let handler <simple-error> = method (c, h)
@@ -183,14 +194,16 @@ end test handler-bind;
 
  I dont understand what is being attempted here
 
-define test handler-bind-1 (description: "#f if no forms")
+// #f if no forms
+define test handler-bind-1 ()
   check-false("", let handler <simple-error> = method (c, h)
                                     list(c, h)
                                   end method);
 end test handler-bind-1;
 
 
-define test handler-bind-2 (description: "With condition to handle")
+// With condition to handle
+define test handler-bind-2 ()
   let (result1, result2)
     = begin
         let handler <simple-error> = method (c, h)
@@ -205,7 +218,8 @@ end test handler-bind-2;
 
 // next-handler
 
-define test handler-bind-3 (description: "call the handler in the function")
+// call the handler in the function
+define test handler-bind-3 ()
 
     let handler <simple-error> = method (c, h)
                                    #"outer"
@@ -213,11 +227,12 @@ define test handler-bind-3 (description: "call the handler in the function")
     let handler <simple-error> = method (c, d)
                                    d()
                                  end method;
-  check-equal("", signal(make(<simple-error>)),  
+  check-equal("", signal(make(<simple-error>)),
   #"outer");
 end test handler-bind-3;
 
-define test handler-bind-4 (description: "check test arg")
+// check test arg
+define test handler-bind-4 ()
   check-true("", begin
     let handler <simple-error> = method (c, h)
                                    #"outer"
@@ -258,8 +273,8 @@ end test handler-bind-4;
 
 // handler-case
 
-define test handler-case
-  (description: "signal with string signals simple-warning")
+// signal with string signals simple-warning
+define test handler-case ()
   check-true("", block ()
     signal("hey!")
   exception (<simple-error>)
@@ -276,7 +291,8 @@ define test handler-case
   = #"<simple-warning>");
 end test handler-case;
 
-define test handler-case-1 (description: "but signal can signal anything")
+// but signal can signal anything
+define test handler-case-1 ()
   check-true("", block ()
     signal(make(<simple-restart>))
   exception (<simple-error>)
@@ -293,8 +309,8 @@ define test handler-case-1 (description: "but signal can signal anything")
   = #"<simple-restart>");
 end test handler-case-1;
 
-define test handler-case-2
-  (description: "error with string signals simple-error")
+// error with string signals simple-error
+define test handler-case-2 ()
   check-true("", block ()
     error("hey!")
   exception (<simple-error>)
@@ -311,7 +327,8 @@ define test handler-case-2
   = #"<simple-error>");
 end test handler-case-2;
 
-define test handler-case-3 (description: "but error can signal anything")
+// but error can signal anything
+define test handler-case-3 ()
   check-true("", block ()
     error(make(<type-error>))
   exception (<simple-error>)
@@ -328,8 +345,8 @@ define test handler-case-3 (description: "but error can signal anything")
   = #"<type-error>");
 end test handler-case-3;
 
-define test handler-case-4
-  (description: "cerror with string signals simple-error")
+// cerror with string signals simple-error
+define test handler-case-4 ()
   check-true("", block ()
     cerror("restart", "hey!")
   exception (<simple-error>)
@@ -346,7 +363,8 @@ define test handler-case-4
   = #"<simple-error>");
 end test handler-case-4;
 
-define test handler-case-5 (description: "but cerror can signal anything")
+// but cerror can signal anything
+define test handler-case-5 ()
   check-true("", block ()
     error(make(<abort>))
   exception (<simple-error>)
@@ -363,8 +381,8 @@ define test handler-case-5 (description: "but cerror can signal anything")
   = #"<abort>");
 end test handler-case-5;
 
-define test handler-case-6
-  (description: "check-type with string signals type-error")
+// check-type with string signals type-error
+define test handler-case-6 ()
   check-true("", block ()
     check-type("restart", <integer>)
   exception (<simple-error>)
@@ -381,7 +399,8 @@ define test handler-case-6
   = #"<type-error>");
 end test handler-case-6;
 
-define test handler-case-7 (description: "abort")
+// abort
+define test handler-case-7 ()
   check-true("", block ()
     abort()
   exception (<simple-error>)
@@ -400,8 +419,8 @@ end test handler-case-7;
 
 // default handler
 
-define test default-handler-1
-  (description: "this should return #f and also print a warning")
+// this should return #f and also print a warning
+define test default-handler-1 ()
   check-true("", #f
   = make(<simple-warning>,
          format-string: "This warning is part of the test suite, please ignore.").default-handler);
@@ -410,20 +429,21 @@ end test default-handler-1;
 // <simple-restart> should be able to have default-handler
 // called upon it as <condition> is one of its superclasses
 //
-define test default-handler-2 (signal: <error>, description: "")
+define test default-handler-2 (signal: <error>, )
   check-true("", make(<simple-restart>).default-handler);
 end test default-handler-2;
 
 // restart-query
 
-define test restart-query
-  (description: "there is a default handler for <restart>")
+// there is a default handler for <restart>
+define test restart-query ()
   check-true("", make(<simple-restart>).restart-query); //  do nothing | #t
 end test restart-query;
 
 // do-handler
 
-define test do-handler (description: "check the args to do-handlers")
+// check the args to do-handlers
+define test do-handler ()
   let all-handlers-info = #();
   let handler-fcn
     = method (condition, next-handler)
@@ -457,7 +477,8 @@ define test do-handler (description: "check the args to do-handlers")
      all-handlers-info));
 end test do-handler;
 
-define test do-handler-2 (description: "most recent first, both done")
+// most recent first, both done
+define test do-handler-2 ()
   let all-handlers-info = #();
   let inner-handler-fcn
     = method (condition, next-handler)
@@ -516,7 +537,7 @@ end test do-handler-2;
 // instantiable condition-types.
 //
 
-define test return-allowed? (description: "")
+define test return-allowed? ()
   check-true("", every?
     (method (instantiable-error-type)
        let result = make(instantiable-error-type).return-allowed?;
@@ -533,7 +554,7 @@ end test return-allowed?;
 // instantiable condition-types.
 //
 
-define test return-description (description: "")
+define test return-description ()
   check-true("", every?
     (method (instantiable-error-type)
        let condition = make(instantiable-error-type);
@@ -564,7 +585,7 @@ define suite test-condition-suite ()
   test simple-warning-slots;
   test restart-slots;
   test signal-1;
-  test signal-2;  
+  test signal-2;
   test signal-3;
   test signal-4;
   test signal-5;
@@ -584,7 +605,7 @@ define suite test-condition-suite ()
 //  test handler-bind-4;
 //  test handler-case;
 //  test handler-case-1;
-//  test handler-case-2; 
+//  test handler-case-2;
 //  test handler-case-3;
 //  test handler-case-4;
 //  test handler-case-5;

--- a/sources/dylan/apple-dylan-test-suite/test-control.dylan
+++ b/sources/dylan/apple-dylan-test-suite/test-control.dylan
@@ -8,27 +8,28 @@ Copyright: (c) 1993 Apple Computer, Inc.
 Modified by: Shri Amit(amit)
 Date: August 24 1996
 Summary: Converted to new testworks protocol
-Copyright: (c) 1996 Functional Objects, Inc. 
-           All rights reserved.  
+Copyright: (c) 1996 Functional Objects, Inc.
+           All rights reserved.
 ----------------------------------------------*/
 
 // Chapter 8. Conditionals, Flow of Control, and Evaluation
 
-define test truth (description: "")
+define test truth ()
   check-true("", #t = #t & ~(#t = #f) & #"a" & 0 & #() & #t);
 end test truth;
 
 // not sure what this is supposed to be -it acts weird
 
-define test not-type-0 (description: "")
+define test not-type-0 ()
   check-true("", instance?(\~, <function>));
 end test not-type-0;
 
-define test not-0 (description: "")
+define test not-0 ()
   check-true("", ~(~100) & ~100 = #f & ~(~#()) & ~#f & ~#t = #f);
 end test not-0;
 
-define test if-0 (description: "Simple cases - true")
+// Simple cases - true
+define test if-0 ()
   check-true("", if (#t)
     #"true"
   else
@@ -65,7 +66,8 @@ define test if-0 (description: "Simple cases - true")
     = 0);
 end test if-0;
 
-define test if-1 (description: "Simple cases false")
+// Simple cases false
+define test if-1 ()
   check-true("", if (#f)
     #"true"
   else
@@ -80,7 +82,8 @@ define test if-1 (description: "Simple cases false")
     = #"false");
 end test if-1;
 
-define test if-2 (description: "Dylan is not lisp!")
+// Dylan is not lisp!
+define test if-2 ()
   check-true("", if (#())
     #"true"
   else
@@ -89,7 +92,8 @@ define test if-2 (description: "Dylan is not lisp!")
   = #"true");
 end test if-2;
 
-define test when-0 (description: "Simple cases - true")
+// Simple cases - true
+define test when-0 ()
   check-true("", if (#t)
     #"ok"
   end if
@@ -132,7 +136,8 @@ define test when-0 (description: "Simple cases - true")
     = 0);
 end test when-0;
 
-define test when-1 (description: "Simple cases - false")
+// Simple cases - false
+define test when-1 ()
   check-true("", if (#f)
     1;
     2;
@@ -147,12 +152,14 @@ define test when-1 (description: "Simple cases - false")
     = #f);
 end test when-1;
 
-define test when-2 (description: "If no forms, #f is returned")
+// If no forms, #f is returned
+define test when-2 ()
   check("", \=, begin if (#t) #(); end if; end, #());
   check("", \=, begin if (3 < 2) #(); end if; end, #f);
 end test when-2;
 
-define test unless-0 (description: "Simple cases - true")
+// Simple cases - true
+define test unless-0 ()
   check-true("", unless (#t)
     1;
     2;
@@ -189,7 +196,8 @@ define test unless-0 (description: "Simple cases - true")
     = 0);
 end test unless-0;
 
-define test unless-1 (description: "Simple cases - false")
+// Simple cases - false
+define test unless-1 ()
   check-true("", unless (#f)
     #"ok"
   end unless
@@ -204,7 +212,8 @@ define test unless-1 (description: "Simple cases - false")
     = #"ok");
 end test unless-1;
 
-define test unless-2 (description: "If no forms, #f is returned")
+// If no forms, #f is returned
+define test unless-2 ()
   check-true("", unless (#t)
     #()
   end unless
@@ -215,7 +224,8 @@ define test unless-2 (description: "If no forms, #f is returned")
     = #());
 end test unless-2;
 
-define test cond-0 (description: "Simple cases")
+// Simple cases
+define test cond-0 ()
   check-true("", if (2 < 2)
     "2 less than 2"
   elseif (3 > 3)
@@ -238,7 +248,8 @@ define test cond-0 (description: "Simple cases")
     = "none of above");
 end test cond-0;
 
-define test cond-1 (description: "Remaining tests not evaluated")
+// Remaining tests not evaluated
+define test cond-1 ()
  check-true("", begin
     let x = 0;
     if (100 = 100)
@@ -251,7 +262,8 @@ define test cond-1 (description: "Remaining tests not evaluated")
   = 0);
 end test cond-1;
 
-define test cond-2 (description: "Returns #f if no test evals to true")
+// Returns #f if no test evals to true
+define test cond-2 ()
   check-false("", if (2 = 3)
 		    #f
 		  elseif (#t = #f)
@@ -259,8 +271,8 @@ define test cond-2 (description: "Returns #f if no test evals to true")
 		  end);
 end test cond-2;
 
-define test cond-3
-  (description: "No consequents, returns 1st value of test case")
+// No consequents, returns 1st value of test case
+define test cond-3 ()
   check-true("", begin
     let (a, b, c)
       = if (3 = 2)
@@ -274,7 +286,8 @@ define test cond-3
   = #(3, #f, #f));
 end test cond-3;
 
-define test cond-4 (description: "Returns all values from last consequent")
+// Returns all values from last consequent
+define test cond-4 ()
   check-true("", begin
     let (a, b, c)
       = if (3 = 2)
@@ -290,7 +303,8 @@ define test cond-4 (description: "Returns all values from last consequent")
   = #(9, 8, 7));
 end test cond-4;
 
-define test cond-5 (description: "Some devious boundaries")
+// Some devious boundaries
+define test cond-5 ()
   check-true("", if (#t)
     #"always-true"
   end if
@@ -354,7 +368,8 @@ define test cond-5 (description: "Some devious boundaries")
     = #());
 end test cond-5;
 
-define test case-0 (description: "Simple cases.")
+// Simple cases.
+define test case-0 ()
   check-true("", select (3 + 2)
     1 =>;
     2 =>;
@@ -391,7 +406,8 @@ define test case-0 (description: "Simple cases.")
     end
 end test case-0;
 
-define test case-1 (description: "If no consequents, #f")
+// If no consequents, #f
+define test case-1 ()
   check-true("", select (1 + 1)
     1 =>;
     2 =>;
@@ -409,7 +425,8 @@ define test case-1 (description: "If no consequents, #f")
     = #f);
 end test case-1;
 
-define test case-2 (description: "multiple values return")
+// multiple values return
+define test case-2 ()
   check-true("", begin
     let (a, b, c)
       = select (3 + 2)
@@ -425,7 +442,8 @@ define test case-2 (description: "multiple values return")
   = #(4, 5, 6));
 end test case-2;
 
-define test case-3 (description: "Some cases")
+// Some cases
+define test case-3 ()
   check-true("", select (999)
     1, 2, 999 =>
       #"ok"
@@ -466,7 +484,8 @@ define test case-3 (description: "Some cases")
     = #"ok");
 end test case-3;
 
-define test select-0 (description: "Simple cases")
+// Simple cases
+define test select-0 ()
   check-true("", select (10 + 5 by \<)
     12, 12 + 1 =>
       "12 or 13";
@@ -518,7 +537,8 @@ define test select-0 (description: "Simple cases")
     = #"ok");
 end test select-0;
 
-define test select-1 (description: "If no consequents, #f")
+// If no consequents, #f
+define test select-1 ()
   check-true("", select (1 + 1 by \=)
     1 =>;
     3 - 1 =>;
@@ -546,16 +566,19 @@ define test select-1 (description: "If no consequents, #f")
   /* (not (select 999 instance? (#t))) */
 end test select-1;
 
-define test or-0 (description: "Simple cases")
-  check-true("", (1 | 2 | 3) = 1); 
+// Simple cases
+define test or-0 ()
+  check-true("", (1 | 2 | 3) = 1);
   check-true("", (even?(3) | zero?(2) | 0) = 0);
 end test or-0;
 
-define test or-1 (description: "None true, return #f")
+// None true, return #f
+define test or-1 ()
   check-true("", (even?(3) | odd?(2) | zero?(-1)) = #f);
 end test or-1;
 
-define test or-2 (description: "Nothing evaled after one returns true")
+// Nothing evaled after one returns true
+define test or-2 ()
   check-true("", begin
     let x = 0;
     #f | 1 | (x := 999);
@@ -566,7 +589,8 @@ end test or-2;
 
 // This looks quite buggy...this should work, looks okay to me
 //
-define test or-3 (description: "Multiple values before last, 1st val returned")
+// Multiple values before last, 1st val returned
+define test or-3 ()
   check-true("", (values(1, 2, 3) | #t) = 1);
   check-true("", begin
       let (a, b, c) = values(1, 2, 3) | #f;
@@ -575,7 +599,8 @@ define test or-3 (description: "Multiple values before last, 1st val returned")
     = #(1, #f, #f));
 end test or-3;
 
-define test or-4 (description: "Multiple values in last, all vals returned")
+// Multiple values in last, all vals returned
+define test or-4 ()
   check-true("", begin
     let (a, b, c) = #f | values(1, 2, 3);
     list(a, b, c)
@@ -589,18 +614,19 @@ define test or-4 (description: "Multiple values in last, all vals returned")
     = #(1, 2, 3));
 end test or-4;
 
-define test or-5
-  (description: "1st value only thing that matters to judge truth")
+// 1st value only thing that matters to judge truth
+define test or-5 ()
   check-true("", (even?(1) | values(#f, #t) | 3) = 3);
 end test or-5;
 
-define test and-0 (description: "Simple cases")
-  check-true("", (1 & 2 & 3) = 3); 
+// Simple cases
+define test and-0 ()
+  check-true("", (1 & 2 & 3) = 3);
   check-true("", (1 & 2 & even?(3)) = #f);
 end test and-0;
 
-define test and-1
-  (description: "Multiple values as last form returns all vals")
+// Multiple values as last form returns all vals
+define test and-1 ()
   check-true("", begin
     let (a, b, c) = 1 & 2 & values(1, #f, 3);
     list(a, b, c)
@@ -610,8 +636,8 @@ end test and-1;
 
 // This looks quite buggy...test should work, looks okay to me
 //
-define test and-2
-  (description: "1st value only thing that matters to judge truth")
+// 1st value only thing that matters to judge truth
+define test and-2 ()
   check-true("", begin
     let (a, b, c) = values(1, #f, 3) & 1 & 2;
     list(a, b, c);
@@ -620,7 +646,8 @@ define test and-2
   check-true("", (odd?(1) & values(#f, #t) & 3) = #f);
 end test and-2;
 
-define test and-3 (description: "Things past 1st false don't get evaled")
+// Things past 1st false don't get evaled
+define test and-3 ()
   check-true("", begin
     let x = 0;
     values(1, #f) & values(#f, 1) & (x := 999);
@@ -629,13 +656,15 @@ define test and-3 (description: "Things past 1st false don't get evaled")
   = 0);
 end test and-3;
 
-define test begin-0 (description: "No forms, return #f")
+// No forms, return #f
+define test begin-0 ()
   check-true("", begin
   end
   = #f);
 end test begin-0;
 
-define test begin-1 (description: "Returns last form")
+// Returns last form
+define test begin-1 ()
   check-true("", begin
     1;
     2;
@@ -652,8 +681,8 @@ define test begin-1 (description: "Returns last form")
     = #"anything");
 end test begin-1;
 
-define test begin-2
-  (description: "Not just skipping to the last form, I hope?")
+// Not just skipping to the last form, I hope?
+define test begin-2 ()
   check-true("", begin
     let x = 0;
     begin
@@ -666,8 +695,8 @@ define test begin-2
   = 3);
 end test begin-2;
 
-define test begin-3
-  (description: "If last form is multiple values, return them all")
+// If last form is multiple values, return them all
+define test begin-3 ()
   check-true("", begin
     let (a, b)
       = begin
@@ -680,7 +709,8 @@ define test begin-3
   = #(#"step3", #"step4"));
 end test begin-3;
 
-define test for-0 (description: "Simple cases")
+// Simple cases
+define test for-0 ()
   check-true("", begin
     let v = 0;
     for (i from 10 to 0 by -1)
@@ -707,7 +737,8 @@ define test for-0 (description: "Simple cases")
     = #(9, 8, 7, 6, 5, 4, 3, 2, 1, 0));
 end test for-0;
 
-define test for-1 (description: "Multiple vars")
+// Multiple vars
+define test for-1 ()
   check-true("", begin
     let i = 0;
     let j = 0;
@@ -741,8 +772,8 @@ define test for-1 (description: "Multiple vars")
     = 100);
 end test for-1;
 
-define test for-2
-  (description: "doesn't do it the first time if end-test initially true")
+// doesn't do it the first time if end-test initially true
+define test for-2 ()
   check-true("", begin
     let v = 0;
     for (i from 0, j from 10 by -1, until: i < j)
@@ -753,7 +784,8 @@ define test for-2
   = 0);
 end test for-2;
 
-define test for-3 (description: "multiple return forms, do all, return last")
+// multiple return forms, do all, return last
+define test for-3 ()
   check-true("", begin
     let v = 0;
     let w = 0;
@@ -769,7 +801,8 @@ define test for-3 (description: "multiple return forms, do all, return last")
   = #(#"last", 100));
 end test for-3;
 
-define test for-4 (description: "multiple values return")
+// multiple values return
+define test for-4 ()
   check-true("", begin
     let v = 0;
     let w = 0;
@@ -788,7 +821,8 @@ end test for-4;
 
 // !@#$ JB used to be 10 100
 
-define test for-5 (description: "Some boundary cases")
+// Some boundary cases
+define test for-5 ()
 //  check-true("", for (until: #f)
 //  end for
 //  = #f);
@@ -810,7 +844,8 @@ end test for-5;
 /// !@#$ JB all for-each's are very disfunctional
 
 /* check issues
-define test for-each (description: "simple case")
+// simple case
+define test for-each ()
   check("", \=, 2, do (method (s :: <sequence>)
     block (return)
       for (number in s)
@@ -823,7 +858,8 @@ define test for-each (description: "simple case")
     #(5, 3, 2, 4, 7)));
 end test for-each;
 */
-define test for-each-1 (description: "Multiple returns")
+// Multiple returns
+define test for-each-1 ()
   check-true("", begin
     let x = 0;
     list(block (return)
@@ -839,7 +875,8 @@ define test for-each-1 (description: "Multiple returns")
   = #(4, 100));
 end test for-each-1;
 
-define test for-each-2 (description: "Multiple values return")
+// Multiple values return
+define test for-each-2 ()
   check-true("", begin
     let (a, b)
       = block (return)
@@ -854,7 +891,8 @@ define test for-each-2 (description: "Multiple values return")
   = #(4, 4));
 end test for-each-2;
 
-define test for-each-3 (description: "Never true, return #f")
+// Never true, return #f
+define test for-each-3 ()
   check-true("", block (return)
     for (number in #(5, 3, 9, 9, 7))
       if (number.even?)
@@ -865,7 +903,8 @@ define test for-each-3 (description: "Never true, return #f")
   = #f);
 end test for-each-3;
 
-define test for-each-4 (description: "One runs out first, return #f")
+// One runs out first, return #f
+define test for-each-4 ()
   check-true("", block (return)
     for (number1 in #(5, 3, 9, 2), number2 in #(1, 2, 3))
       if (number1.even?)
@@ -922,7 +961,8 @@ end test for-each-4;
    '(500 1000 #t)))
 */
 
-define test while-0 (description: "simple")
+// simple
+define test while-0 ()
   check-true("", begin
     let v = 0;
     let n = 10;
@@ -935,7 +975,8 @@ define test while-0 (description: "simple")
   = 55);
 end test while-0;
 
-define test while-1 (description: "initially false test, never eval body")
+// initially false test, never eval body
+define test while-1 ()
   check-true("", begin
     let v = 1;
     let n = 10;
@@ -948,7 +989,8 @@ define test while-1 (description: "initially false test, never eval body")
   = 1);
 end test while-1;
 
-define test while-2 (description: "While returns #f")
+// While returns #f
+define test while-2 ()
   check-true("", begin
     let v = 0;
     let n = 10;
@@ -960,7 +1002,8 @@ define test while-2 (description: "While returns #f")
   = #f);
 end test while-2;
 
-define test until-0 (description: "simple")
+// simple
+define test until-0 ()
   check-true("", begin
     let v = 0;
     let n = 10;
@@ -973,7 +1016,8 @@ define test until-0 (description: "simple")
   = 55);
 end test until-0;
 
-define test until-1 (description: "initially negative test")
+// initially negative test
+define test until-1 ()
   check-true("", begin
     let v = 0;
     let n = 10;
@@ -986,7 +1030,8 @@ define test until-1 (description: "initially negative test")
   = 0);
 end test until-1;
 
-define test until-2 (description: "until returns #f")
+// until returns #f
+define test until-2 ()
   check-true("", begin
     let v = 0;
     let n = 10;
@@ -998,7 +1043,8 @@ define test until-2 (description: "until returns #f")
   = #f);
 end test until-2;
 
-define test bind-exit-0 (description: "Simple")
+// Simple
+define test bind-exit-0 ()
   check-true("", begin
     let seq = #(1, 3, 5, 2, 7, 9, 10);
     block (exit)
@@ -1015,7 +1061,8 @@ define test bind-exit-0 (description: "Simple")
   = 2);
 end test bind-exit-0;
 
-define test bind-exit-1 (description: "Normal return")
+// Normal return
+define test bind-exit-1 ()
   check-true("", begin
     let seq = #(1, 3, 5, 7, 9);
     block (exit)
@@ -1032,13 +1079,15 @@ define test bind-exit-1 (description: "Normal return")
   = #(1, 3, 5, 7, 9));
 end test bind-exit-1;
 
-define test bind-exit-2 (description: "no forms, #f returned")
+// no forms, #f returned
+define test bind-exit-2 ()
   check-true("", block (exit)
   end block
   = #f);
 end test bind-exit-2;
 
-define test bind-exit-3 (description: "exit proc accepts any number of args")
+// exit proc accepts any number of args
+define test bind-exit-3 ()
   check-true("", begin
     let seq = #(1, 3, 5, 2, 7, 9);
     let (a, b, c)
@@ -1057,7 +1106,8 @@ define test bind-exit-3 (description: "exit proc accepts any number of args")
   = #(2, #t, 4));
 end test bind-exit-3;
 
-define test bind-exit-4 (description: "exit proc is a first-class value")
+// exit proc is a first-class value
+define test bind-exit-4 ()
   check-true("", block (exit)
     local method e (f :: <function>)
             map(method (item)
@@ -1074,7 +1124,8 @@ define test bind-exit-4 (description: "exit proc is a first-class value")
   = 2);
 end test bind-exit-4;
 
-define test unwind-protect-0 (description: "Simple case")
+// Simple case
+define test unwind-protect-0 ()
   check-true("", begin
     let v = 0;
     block (exit)
@@ -1088,8 +1139,8 @@ define test unwind-protect-0 (description: "Simple case")
   = 1);
 end test unwind-protect-0;
 
-define test unwind-protect-1
-  (description: "If normal exit, returns vals returned by protected-form")
+// If normal exit, returns vals returned by protected-form
+define test unwind-protect-1 ()
   check-true("", begin
     let v = 0;
     block (exit)
@@ -1101,18 +1152,20 @@ define test unwind-protect-1
   = 99);
 end test unwind-protect-1;
 
-define test quote-control-0 (description: "Simple case")
+// Simple case
+define test quote-control-0 ()
   check-equal("", #(#"+", 1, 2), #(#"+", 1, 2));
 end test quote-control-0;
 
-define test apply-0 (description: "Simple cases")
+// Simple cases
+define test apply-0 ()
   check-equal("", apply(\+, 1, #(2, 3)), 6);
   check-equal("", apply(list(\+, \*, \/, \-).second, 1, 2, #(3, 4)), 24);
 end test apply-0;
 
 define suite test-control-suite ()
   test truth;
-  test not-type-0; 
+  test not-type-0;
   test not-0;
   test if-0;
   test if-1;
@@ -1137,7 +1190,7 @@ define suite test-control-suite ()
   test select-1;
   test or-0;
   test or-1;
-  test or-2; 
+  test or-2;
   test or-3;
   test or-4;
   test or-5;

--- a/sources/dylan/apple-dylan-test-suite/test-defines.dylan
+++ b/sources/dylan/apple-dylan-test-suite/test-defines.dylan
@@ -8,11 +8,11 @@ Copyright: (c) 1993 Apple Computer, Inc.
 Modified by: Shri Amit(amit)
 Date: August 24 1996
 Summary: Converted to new testworks protocol
-Copyright: (c) 1996 Functional Objects, Inc. 
-           All rights reserved.  
+Copyright: (c) 1996 Functional Objects, Inc.
+           All rights reserved.
 ----------------------------------------------*/
 
-define test defines (description: "")
+define test defines ()
   check("", instance?, deque-instance, <function>);
   check("", instance?, <dtest-test-class>, <class>);
   check-equal("", test-variable, 99);
@@ -22,30 +22,32 @@ end test defines;
 
 define constant dlb-1 :: <integer> = 10;
 
-define test define-like-bind-1
-  (description: "Type declarations are allowed in define")
+// Type declarations are allowed in define
+define test define-like-bind-1 ()
   check-equal("", dlb-1, 10);
 end test define-like-bind-1;
 
 // This should have raised a condition, should not be able
 // to set! dlb-1 once it has been declared an integer
 //
-define test define-like-bind-1a
-  (description: "enforce declarations")
+// enforce declarations
+define test define-like-bind-1a ()
   check-condition("", <type-error>,  dlb-1 := "not an integer");
 end test define-like-bind-1a;
 
 define constant (dlb-2a, dlb-2b, dlb-2c) = values(1, 2, 3);
 
-define test define-like-bind-2 (description: "multiple-values define")
-  check-equal("", dlb-2a, 1); 
+// multiple-values define
+define test define-like-bind-2 ()
+  check-equal("", dlb-2a, 1);
   check-equal("", dlb-2b, 2);
   check-equal("", dlb-2c, 3);
 end test define-like-bind-2;
 
 define constant (dlb-3a, dlb-3b, dlb-3c) = values(1);
 
-define test define-like-bind-3 (description: "multivalues default to #f")
+// multivalues default to #f
+define test define-like-bind-3 ()
   check-equal("", dlb-3a, 1);
   check-equal("", dlb-3b, #f);
   check-equal("", dlb-3c, #f);
@@ -53,7 +55,8 @@ end test define-like-bind-3;
 
 define constant (dlb-4a, dlb-4b, #rest dlb-4r) = values(1, 2, 3, 4, 5, 6, 7);
 
-define test define-like-bind-4 (description: "multivalues with #rest")
+// multivalues with #rest
+define test define-like-bind-4 ()
   check-equal("", dlb-4a, 1);
   check-equal("", dlb-4b, 2);
   check("", instance?, dlb-4r, <sequence>);
@@ -64,11 +67,12 @@ end test define-like-bind-4;
 define constant (dlb-5a :: <integer>, dlb-5b :: <integer>)
   = values(1, 2, 3, 4, 5, 6, 7);
 
-define test define-like-bind-5 (description: "discard extra values")
+// discard extra values
+define test define-like-bind-5 ()
   check-equal("", dlb-5a, 1);
   check-equal("", dlb-5b, 2);
 end test define-like-bind-5;
- 
+
 define suite test-defines-suite ()
   test defines;
   test define-like-bind-1;
@@ -78,5 +82,3 @@ define suite test-defines-suite ()
   test define-like-bind-4;
   test define-like-bind-5;
 end suite;
-
-

--- a/sources/dylan/apple-dylan-test-suite/test-deque.dylan
+++ b/sources/dylan/apple-dylan-test-suite/test-deque.dylan
@@ -8,19 +8,20 @@ Copyright: (c) 1993 Apple Computer, Inc.
 Modified by: Shri Amit(amit)
 Date: August 24 1996
 Summary: Converted to new testworks protocol
-Copyright: (c) 1996 Functional Objects, Inc. 
-           All rights reserved.  
+Copyright: (c) 1996 Functional Objects, Inc.
+           All rights reserved.
 ----------------------------------------------*/
 
 // operations on deque
 
-define test push-type (description: "")
+define test push-type ()
   check("", instance?, push, <generic-function>);
 end test push-type;
 
 // this tests push & pop
 
-define test push-0 (description: "simple cases")
+// simple cases
+define test push-0 ()
   let d = make(<deque>);
   let t = d.size;
   check-true("", push(d, #"sym") == d);
@@ -34,23 +35,23 @@ define test push-0 (description: "simple cases")
  check-equal("", d1[0], #"d");
 end test push-0;
 
-define test pop-type (description: "")
+define test pop-type ()
   check("", instance?, pop, <generic-function>);
 end test pop-type;
 
-define test pop-0 (description: "")
+define test pop-0 ()
   let d = make(<deque>);
   let t = 0;
   map(curry(push, d), #(#"a", #"b", #"c", #"d"));
   t := d.size;
   begin
       let p = d.pop;
-      check-equal("", p, #"d"); 
+      check-equal("", p, #"d");
       check-equal("", d.size, t - 1);
   end
 end test pop-0;
 
-define test push-pop (description: "")
+define test push-pop ()
   let d = make(<deque>);
   push(d, 99);
   let p = d.pop;
@@ -58,24 +59,24 @@ define test push-pop (description: "")
   check-true("", d.empty?);
 end test push-pop;
 
-define test push-last-pop-last-type (description: "")
+define test push-last-pop-last-type ()
   check("", instance?, push-last, <generic-function>);
   check("", instance?, pop-last, <generic-function>);
 end test push-last-pop-last-type;
 
-define test pop-last-0 (description: "")
+define test pop-last-0 ()
   let d = make(<deque>);
   let t = 0;
   map(curry(push, d), #(#"a", #"b", #"c", #"d"));
   t := d.size;
   begin
       let p = d.pop-last;
-      check-equal("", p, #"a"); 
+      check-equal("", p, #"a");
       check-equal("", d.size, t - 1);
     end;
 end test pop-last-0;
 
-define test push-last-pop-last (description: "")
+define test push-last-pop-last ()
   let d = make(<deque>);
   push-last(d, 99);
   let p = d.pop-last;
@@ -85,7 +86,7 @@ end test push-last-pop-last;
 
 // add!
 
-define test add!-deque (description: "")
+define test add!-deque ()
   let t = make(<deque>);
   check-equal("", add!(t, 99), t);
   check-equal("",  t.size, 1);
@@ -94,12 +95,13 @@ end test add!-deque;
 
 // remove! (deque)
 
-define test remove!-deque (description: "with test: and count:")
+// with test: and count:
+define test remove!-deque ()
     let d = deque-instance(1, 2, 3, 4);
     let nd = remove!(d, 2);
-    check-true("", ~member?(2, nd)); 
+    check-true("", ~member?(2, nd));
     check-true("",  member?(1, nd));
-    check-true("",  member?(3, nd)); 
+    check-true("",  member?(3, nd));
     check-true("",  member?(4, nd));
     let d = deque-instance(1, 2, 3, 4);
     let nd = remove!(d, 2, test: \>=, count: 2);
@@ -111,11 +113,11 @@ end test remove!-deque;
 
 // previous-state (deque)
 
-define test previous-state-0 (description: "")
+define test previous-state-0 ()
   check("", instance?, previous-state, <generic-function>);
 end test previous-state-0;
 
-define test previous-state-deque (description: "")
+define test previous-state-deque ()
   let d = make(<deque>);
   map(method (item)
         push(d, item)

--- a/sources/dylan/apple-dylan-test-suite/test-function.dylan
+++ b/sources/dylan/apple-dylan-test-suite/test-function.dylan
@@ -8,13 +8,14 @@ Copyright: (c) 1993 Apple Computer, Inc.
 Modified by: Shri Amit(amit)
 Date: August 24 1996
 Summary: Converted to new testworks protocol
-Copyright: (c) 1996 Functional Objects, Inc. 
-           All rights reserved.  
+Copyright: (c) 1996 Functional Objects, Inc.
+           All rights reserved.
 ----------------------------------------------*/
 
 // Chapter 10. Functions
 
-define test method-0 (description: "does it return a <method>?")
+// does it return a <method>?
+define test method-0 ()
   check("", instance?,
      method (a, b)
        1 + 2
@@ -22,7 +23,8 @@ define test method-0 (description: "does it return a <method>?")
      <method>);
 end test \method-0;
 
-define test method-1 (description: "Does it do something reasonable")
+// Does it do something reasonable
+define test method-1 ()
   check-equal("", method (a, b)
     a + b
   end (4, 5),
@@ -37,10 +39,10 @@ define test method-1 (description: "Does it do something reasonable")
    , 9);
 end test method-1;
 
-define test bind-methods-0 (description: "") 
+define test bind-methods-0 ()
 check("", \=, #(1, 2, 3, 4, 5),
   do (method (s :: <sequence>)
-    local method plus-rev (seq1) 
+    local method plus-rev (seq1)
        map(\+, seq1, seq1.reverse)
     end method plus-rev;
     local method same-element? (seq2 :: <sequence>)
@@ -83,7 +85,8 @@ end;
 // Something seems to be wrong with add-method
 // wonder why this is not working
 
-define test ambiguous-method-1 (description: "unambiguous calls")
+// unambiguous calls
+define test ambiguous-method-1 ()
   let type1 = limited(<integer>, min: 1, max: 10);
   let type2 = limited(<integer>, min: 0, max: 7);
   let f = make(<generic-function>);
@@ -107,8 +110,8 @@ define test ambiguous-method-1 (description: "unambiguous calls")
   check-equal("", f(5), #"five");
 end test ambiguous-method-1;
 
-define test ambiguous-method-2
-  (signal: <error>, description: "error on ambiguous method")
+// error on ambiguous method
+define test ambiguous-method-2 ()
   let type1 = limited(<integer>, min: 1, max: 10);
   let type2 = limited(<integer>, min: 0, max: 7);
   let f = make(<generic-function>);
@@ -132,28 +135,28 @@ end test ambiguous-method-2;
 
 // add-method (86)
 
-define test add-method-type (description: "")
+define test add-method-type ()
   check("", instance?, add-method, <generic-function>);
 end test add-method-type;
 
-define test sorted-applicable-methods-type (description: "")
+define test sorted-applicable-methods-type ()
   check("", instance?, sorted-applicable-methods, <generic-function>);
 end test sorted-applicable-methods-type;
 
 // freeze-methods
 // generic-function-methods
 
-define test generic-function-methods-0 (description: "")
+define test generic-function-methods-0 ()
   check-true("", ~deque-instance.generic-function-methods.empty?);
 end test generic-function-methods-0;
 
-define test generic-function-methods-type (description: "")
+define test generic-function-methods-type ()
   check("", instance?, generic-function-methods, <generic-function>);
 end test generic-function-methods-type;
 
 // function-arguments
 
-define test function-arguments-0 (description: "")
+define test function-arguments-0 ()
   check-equal("", function-arguments
     (method (a, b)
        list(a, b)
@@ -161,11 +164,11 @@ define test function-arguments-0 (description: "")
   2);
 end test function-arguments-0;
 
-define test function-arguments-1 (disabled: #t, #"description", "")
+define test function-arguments-1 (/* disabled: #t */)
   begin
     let (req-no, rest-bool, kwd-seq) = withdraw.function-arguments;
-    check-equal("", req-no, 2); 
-    check-equal("", rest-bool, #t); 
+    check-equal("", req-no, 2);
+    check-equal("", rest-bool, #t);
     check-equal("", kwd-seq, #(#"passwd"));
   end
 end test function-arguments-1;
@@ -174,25 +177,25 @@ end test function-arguments-1;
 
 // applicable-method?
 
-define test applicable-method?-type (description: "")
+define test applicable-method?-type ()
   check("", instance?, applicable-method?, <function>);
 end test applicable-method?-type;
 
 // find-method
 
-define test find-method-type (description: "")
+define test find-method-type ()
   check("", instance?, find-method, <function>);
 end test find-method-type;
 
 // method-specializers
 
-define test method-specializers-type (description: "")
+define test method-specializers-type ()
   check("", instance?, method-specializers, <generic-function>);
 end test method-specializers-type;
 
 // remove-method
 
-define test remove-method-type (description: "")
+define test remove-method-type ()
   check("", instance?, remove-method, <function>);
 end test remove-method-type;
 
@@ -210,7 +213,7 @@ define suite test-function-suite ()
   test generic-function-methods-type;
   test function-arguments-0;
   test function-arguments-1;
-  test applicable-method?-type; 
+  test applicable-method?-type;
   test find-method-type;
   test method-specializers-type;
   test remove-method-type;

--- a/sources/dylan/apple-dylan-test-suite/test-intro-mop.dylan
+++ b/sources/dylan/apple-dylan-test-suite/test-intro-mop.dylan
@@ -8,8 +8,8 @@ Copyright: (c) 1993 Apple Computer, Inc.
 Modified by: Shri Amit(amit)
 Date: August 24 1996
 Summary: Converted to new testworks protocol
-Copyright: (c) 1996 Functional Objects, Inc. 
-           All rights reserved.  
+Copyright: (c) 1996 Functional Objects, Inc.
+           All rights reserved.
 ----------------------------------------------*/
 
 // Chapter 6: Introduction to Functions and Classes
@@ -25,7 +25,7 @@ define class t-c (<object>)
 end class t-c;
 
 define class t-subc1 (t-c)
-  slot password :: <string>, setter: set-password, 
+  slot password :: <string>, setter: set-password,
 		init-keyword: password:;
 end class t-subc1;
 
@@ -86,7 +86,7 @@ define constant cust3
          limit: 800,
          password: "7654321");
 
-define test slot-operations (description: "")
+define test slot-operations ()
   check-true("", 180 = withdraw(cust1, 30, passwd: "Nickson"));
   check-true("", 250 = withdraw(cust2, 50));
   check-true("", 320 = deposit(cust2, 70));
@@ -101,7 +101,7 @@ define test slot-operations (description: "")
   check-true("", cust3.balance = 1980);
 end test slot-operations;
 
-define test method-type (description: "")
+define test method-type ()
   check-false("", subtype?(<method>, <generic-function>));
 
 // This is most likely a bug as <g-f> is of type <function>
@@ -109,7 +109,8 @@ define test method-type (description: "")
   check-false("", subtype?(<generic-function>, <method>));
 end test method-type;
 
-define test method-syntax-0 (description: "simple method syntax")
+// simple method syntax
+define test method-syntax-0 ()
   check-true("", method (a :: <number>, b :: <number>)
     list(a - b, a + b)
   end method
@@ -122,7 +123,8 @@ define test method-syntax-0 (description: "simple method syntax")
     = 42);
 end test method-syntax-0;
 
-define test method-syntax-1 (description: "with keys")
+// with keys
+define test method-syntax-1 ()
   check-true("",method (x, #key y = 3)
     x * (y + 5)
   end method
@@ -165,7 +167,8 @@ define test method-syntax-1 (description: "with keys")
     = #(10, 20, 30));
 end test method-syntax-1;
 
-define test method-syntax-2 (description: "default of keyword is #f")
+// default of keyword is #f
+define test method-syntax-2 ()
   check-true("",method (a, b, #key c, d)
     list(a, b, c, d)
   end method
@@ -173,7 +176,8 @@ define test method-syntax-2 (description: "default of keyword is #f")
   = #(10, 20, #f, #f));
 end test method-syntax-2;
 
-define test method-syntax-3 (description: "method should return a <method>")
+// method should return a <method>
+define test method-syntax-3 ()
   check-true("",instance?
     (method (x, y)
        x + y
@@ -181,7 +185,8 @@ define test method-syntax-3 (description: "method should return a <method>")
      <method>));
 end test method-syntax-3;
 
-define test method-syntax-4 (description: "with #rest")
+// with #rest
+define test method-syntax-4 ()
   check-true("",method (a, #rest b)
     list(a, b)
   end method
@@ -204,7 +209,8 @@ define test method-syntax-4 (description: "with #rest")
     = #(#(), 10, 20));
 end test method-syntax-4;
 
-define test method-syntax-5 (description: "#key and #rest")
+// #key and #rest
+define test method-syntax-5 ()
   check-true("",method (#rest all, #key fee, fi)
     list(all, fee, fi)
   end method
@@ -217,9 +223,9 @@ define test method-syntax-5 (description: "#key and #rest")
     = #(1, #(#"a", 2, #"b", 3), 2, 3));
 end test method-syntax-5;
 
-define test symbol? (description: "")
+define test symbol? ()
   check-false("", instance?(#"a", <symbol>));
-  check-true("", instance?(foo: <symbol>)); 
+  check-true("", instance?(foo: <symbol>));
   check-false("", instance?(3, <symbol>));
 end test symbol?;
 
@@ -229,11 +235,13 @@ define method test-plus (x, y) => (total :: <integer>)
   x + y
 end method test-plus;
 
-define test result-type-1 (description: "test-plus")
+// test-plus
+define test result-type-1 ()
   check-true("",25 = test-plus(22, 3));
 end test result-type-1;
 
-define test result-type-1a (description: "bind method")
+// bind method
+define test result-type-1a ()
   let foo
     = method (x, y) => (total :: <integer>)
         x + y
@@ -241,7 +249,8 @@ define test result-type-1a (description: "bind method")
   check-true("",25 = foo(22, 3));
 end test result-type-1a;
 
-define test result-type-1b (description: "bind-methods")
+// bind-methods
+define test result-type-1b ()
   local method foo (x, y) => (total :: <integer>)
           x + y
         end method foo;
@@ -255,13 +264,14 @@ end test result-type-1b;
 // because the expression returns and instance of RATIO and
 // from the previous test-suites we saw that RATIO was not
 // implemented
-//
-define test result-type-2
-  (description: "should always return integer")
+
+// should always return integer
+define test result-type-2 ()
   check-condition("", <error>, test-plus(22, 1 / 2));
 end test result-type-2;
 
-define test result-type-2a (description: "bind method")
+// bind method
+define test result-type-2a ()
   let foo
     = method (x, y) => (total :: <integer>)
         x + y
@@ -269,7 +279,8 @@ define test result-type-2a (description: "bind method")
   check-condition("", <error>, foo(22, 1 / 2));
 end test result-type-2a;
 
-define test result-type-2b (description: "bind-methods")
+// bind-methods
+define test result-type-2b ()
   local method foo (x, y) => (total :: <integer>)
           x + y
         end method foo;
@@ -282,12 +293,14 @@ define method rtype-3-fcn (#rest a)
   apply(values, a)
 end method rtype-3-fcn;
 
-define test result-type-3 (description: "return multiple values")
+// return multiple values
+define test result-type-3 ()
   let (a, b, c, d) = rtype-3-fcn(1, 2, 3, 4);
   check-true("",a  = 1 & b = 2 & c = 3 & d = 4);
 end test result-type-3;
 
-define test result-type-3a (description: "bind method")
+// bind method
+define test result-type-3a ()
   let foo
     = method (#rest a)
         apply(values, a)
@@ -296,7 +309,8 @@ define test result-type-3a (description: "bind method")
   check-true("",a = 1 & b = 2 & c = 3 & d = 4);
 end test result-type-3a;
 
-define test result-type-3b (description: "bind-methods")
+// bind-methods
+define test result-type-3b ()
   local method foo (#rest a)
           apply(values, a)
         end method foo;
@@ -313,12 +327,13 @@ define method rtype-4-fcn (#rest a)
   apply(values, a)
 end method rtype-4-fcn;
 
-define test result-type-4
-  (description: "have to return just integers")
+// have to return just integers
+define test result-type-4 ()
   check-condition("", <error>, rtype-4-fcn(1, 2, 3, "string"));
 end test result-type-4;
 
-define test result-type-4a (description: "bind method")
+// bind method
+define test result-type-4a ()
   let foo
     = method (#rest a)
         apply(values, a)
@@ -326,7 +341,8 @@ define test result-type-4a (description: "bind method")
   check-condition("", <type-error>, foo(1, 2, 3, "string"));
 end test result-type-4a;
 
-define test result-type-4b (description: "bind-methods")
+// bind-methods
+define test result-type-4b ()
   local method foo (#rest a)
           apply(values, a)
         end method foo;
@@ -344,11 +360,12 @@ end method rtype-5-fcn;
 // that is a NULL and so it does not match against
 // #f ??
 
-define test result-type-5 (description: "")
+define test result-type-5 ()
   check-true("", rtype-5-fcn() = #(1, 2, #f));
 end test result-type-5;
 
-define test result-type-5a (description: "bind method")
+// bind method
+define test result-type-5a ()
   let foo
     = method () => (x, y, z)
         values(1, 2)
@@ -357,7 +374,8 @@ define test result-type-5a (description: "bind method")
   check-true("",result = #(1, 2, #f));
 end test result-type-5a;
 
-define test result-type-5b (description: "bind-methods")
+// bind-methods
+define test result-type-5b ()
   local method foo () => (x, y, z)
           values(1, 2)
         end method foo;
@@ -374,11 +392,12 @@ define method rtype-6-fcn (foo :: <integer>)
   values(1, 2)
 end method rtype-6-fcn;
 
-define test result-type-6 (description: "")
+define test result-type-6 ()
   check-condition("", <type-error>, rtype-6-fcn(1));
 end test result-type-6;
 
-define test result-type-6a (description: "bind method")
+// bind method
+define test result-type-6a ()
   let foo
     = method () => (x :: <integer>, y :: <integer>, z :: <integer>)
         values(1, 2)
@@ -386,7 +405,8 @@ define test result-type-6a (description: "bind method")
   check-condition("", <error>, foo(1));
 end test result-type-6a;
 
-define test result-type-6b (description: "bind-methods")
+// bind-methods
+define test result-type-6b ()
   local method foo () => (x :: <integer>, y :: <integer>, z :: <integer>)
           values(1, 2)
         end method foo;
@@ -399,8 +419,8 @@ end test result-type-6b;
 
 define generic gfun-test-1 (a, b) => (c :: <integer>, d :: <integer>);
 
-define test generic-fcn-values-1a
-  (description: "can't add a method with #rest return vals if the gf doesn't have them")
+// can't add a method with #rest return vals if the gf doesn't have them
+define test generic-fcn-values-1a ()
   check-condition("", <error>,
 		  add-method(gfun-test-1,
 			     method
@@ -410,8 +430,8 @@ define test generic-fcn-values-1a
 			     end method));
 end test generic-fcn-values-1a;
 
-define test generic-fcn-values-1b
-  (description: "can't add a method with different number of required return vals")
+// can't add a method with different number of required return vals
+define test generic-fcn-values-1b ()
   check-condition("", <error>,
 		  add-method(gfun-test-1,
 			     method (a, b) => (c :: <integer>)
@@ -419,20 +439,20 @@ define test generic-fcn-values-1b
 			     end method));
 end test generic-fcn-values-1b;
 
-define test generic-fcn-values-1c
-  (description: "can't add a method with different number of required return vals")
+// can't add a method with different number of required return vals
+define test generic-fcn-values-1c ()
   check-condition("", <error>,
 		  add-method(gfun-test-1,
 			     method
 				 (a, b)
-			      => (c :: <integer>, d :: <integer>, 
+			      => (c :: <integer>, d :: <integer>,
 				  e :: <integer>)
 			       values(a + b, 2, 3)
 			     end method));
 end test generic-fcn-values-1c;
 
-define test generic-fcn-values-1d
-  (description: "can't add a method returning types which are not subtypes")
+// can't add a method returning types which are not subtypes
+define test generic-fcn-values-1d ()
   check-condition("", <error>,
 		  add-method(gfun-test-1,
 			     method (a, b) => (c, d)
@@ -440,9 +460,9 @@ define test generic-fcn-values-1d
 			     end method));
 end test generic-fcn-values-1d;
 
-define test generic-fcn-values-1e
-  (description: "can't add a method returning types which are not subtypes")
-  check-condition("", <error>, 
+// can't add a method returning types which are not subtypes
+define test generic-fcn-values-1e ()
+  check-condition("", <error>,
 		  add-method(gfun-test-1,
 			     method (a, b) => (c :: <integer>, d :: <string>)
 			       values(a, b)
@@ -456,9 +476,9 @@ define generic gfun-test-2 (a, b) => (c :: <integer>, #rest d);
 // This should theoretically work because the method creates
 // and instance of <method> and gfun-test-2 is defined as
 // generic..dunno what is up with this?
-//
-define test generic-fcn-values-2a
-  (description: "permitted, but not required, to add methods which have #rest")
+
+// permitted, but not required, to add methods which have #rest
+define test generic-fcn-values-2a ()
     add-method (gfun-test-2,
        method (a == #"test1", b) => (c :: <integer>, d :: <integer>, #rest e)
          values(1, b, 3, 4, 5)
@@ -469,11 +489,11 @@ define test generic-fcn-values-2a
        end method);
     let (c1, d1, e1) = gfun-test-2(#"test1", 7);
     let (c2, d2, e2) = gfun-test-2(#"test2", 7);
-    check-true("", list(c1, d1, e1) = #(1, 7, 3)); 
+    check-true("", list(c1, d1, e1) = #(1, 7, 3));
     check-true("", list(c2, d2, e2) = #(2, 7, #f));
 end test generic-fcn-values-2a;
 
-define suite test-intro-mop-suite () 
+define suite test-intro-mop-suite ()
   test slot-operations;
   test method-type;
   test method-syntax-0;

--- a/sources/dylan/apple-dylan-test-suite/test-iteration.dylan
+++ b/sources/dylan/apple-dylan-test-suite/test-iteration.dylan
@@ -8,17 +8,18 @@ Copyright: (c) 1993 Apple Computer, Inc.
 Modified by: Shri Amit(amit)
 Date: August 24 1996
 Summary: Converted to new testworks protocol
-Copyright: (c) 1996 Functional Objects, Inc. 
-           All rights reserved.  
+Copyright: (c) 1996 Functional Objects, Inc.
+           All rights reserved.
 ----------------------------------------------*/
 
 // iteration protocol, page 122
 
-define test initial-state-type (description: "")
+define test initial-state-type ()
   check-true("", instance?(initial-state, <generic-function>));
 end test initial-state-type;
 
-define test initial-state-empty-collections (description: "empty collections")
+// empty collections
+define test initial-state-empty-collections ()
   check-true("", every?
     (method (class)
        #f = make(class).initial-state
@@ -34,25 +35,27 @@ define test initial-state-empty-collections (description: "empty collections")
           <deque>)));
 end test initial-state-empty-collections;
 
-define test initial-state-range (description: "empty range")
+// empty range
+define test initial-state-range ()
   check-true("", #f = make(<range>, size: 0).initial-state);
 end test initial-state-range;
 
 // This returns as an instance of <test> looks buggy
 //
-define test final-state-type (description: "")
+define test final-state-type ()
   check-true("", instance?(final-state, <generic-function>));
 end test final-state-type;
 
-define test final-state (description: "vector, deque")
+// vector, deque
+define test final-state ()
   check-false("", #f = deque-instance(1, 2, 3).final-state);
   check-false("", #f = vector(1, 2, 3).final-state);
   check-false("", #f = vector(1, 2, 3).final-state);
   check-false("", #f = final-state("abc"));
 end test final-state;
 
-define test final-state-1
-  (description: "gets the last elt of various collections the hard way")
+// gets the last elt of various collections the hard way
+define test final-state-1 ()
   check-true("", every?
     (method (x)
        let elt = x.first;
@@ -65,12 +68,12 @@ define test final-state-1
           list('c', "abc"))));
 end test final-state-1;
 
-define test next-state-0 (description: "")
+define test next-state-0 ()
   check-true("", instance?(next-state, <generic-function>));
 end test next-state-0;
 
-define test iteration-protocol
-  (description: "gets the 3rd elt of various collections the hard way")
+// gets the 3rd elt of various collections the hard way
+define test iteration-protocol ()
   check-true("", every?
     (method (x)
        let elt = x.first;
@@ -88,8 +91,8 @@ define test iteration-protocol
           list(9, range(from: 7, size: 3)))));
 end test iteration-protocol;
 
-define test next-previous-state
-  (description: "gets the 2nd elt using next-state and previous-state")
+// gets the 2nd elt using next-state and previous-state
+define test next-previous-state ()
   check-true("", every?
     (method (x)
        let elt = x.first;
@@ -108,8 +111,8 @@ define test next-previous-state
           list('b', "abc"))));
 end test next-previous-state;
 
-define test final-previous-state
-  (description: "gets the 2nd elt using final-state and previous-state")
+// gets the 2nd elt using final-state and previous-state
+define test final-previous-state ()
   check-true("", every?
     (method (x)
        let elt = x.first;
@@ -123,11 +126,11 @@ define test final-previous-state
           list('b', "abc"))));
 end test final-previous-state;
 
-define test current-element-0 (description: "")
+define test current-element-0 ()
   check-true("", instance?(current-element, <generic-function>));
 end test current-element-0;
 
-define test copy-state (description: "")
+define test copy-state ()
   check-true("", instance?(copy-state, <generic-function>));
 end test copy-state;
 

--- a/sources/dylan/apple-dylan-test-suite/test-keyword-symbol.dylan
+++ b/sources/dylan/apple-dylan-test-suite/test-keyword-symbol.dylan
@@ -8,27 +8,28 @@ Copyright: (c) 1993 Apple Computer, Inc.
 Modified by: Shri Amit(amit)
 Date: August 24 1996
 Summary: Converted to new testworks protocol
-Copyright: (c) 1996 Functional Objects, Inc. 
-           All rights reserved.  
+Copyright: (c) 1996 Functional Objects, Inc.
+           All rights reserved.
 ----------------------------------------------*/
 
 // Chapter 15. Keywords and Symbols
 // keyword is self-evaluating
 
-define test keyword-symbol-names (description: "")
+define test keyword-symbol-names ()
   check-true("", #"foo" = #"foo");
   check-true("", "FOO" = map(as-uppercase, as(<string>, #"foo")));
   check-true("", "FOO" = map(as-uppercase, as(<string>, #"foo")));
 end test keyword-symbol-names;
 
-define test as-symbol-keyword (description: "as <symbol>")
+// as <symbol>
+define test as-symbol-keyword ()
   check-true("", #"foo" == as(<symbol>, byte-string-instance('F', 'o', 'o')));
   check-true("",  #"foo" == as(<symbol>, byte-string-instance('f', 'O', 'O')));
   check-true("",  #"foo" == as(<symbol>, byte-string-instance('f', 'o', 'o')));
   check-true("",  #"foo" == as(<symbol>, byte-string-instance('F', 'O', 'O')));
 end test as-symbol-keyword;
 
-define suite test-keyword-symbol-suite () 
+define suite test-keyword-symbol-suite ()
   test keyword-symbol-names;
   test as-symbol-keyword;
 end;

--- a/sources/dylan/apple-dylan-test-suite/test-list.dylan
+++ b/sources/dylan/apple-dylan-test-suite/test-list.dylan
@@ -8,20 +8,20 @@ Copyright: (c) 1993 Apple Computer, Inc.
 Modified by: Shri Amit(amit)
 Date: August 24 1996
 Summary: Converted to new testworks protocol
-Copyright: (c) 1996 Functional Objects, Inc. 
-           All rights reserved.  
+Copyright: (c) 1996 Functional Objects, Inc.
+           All rights reserved.
 ----------------------------------------------*/
 
 // Operations on Lists
 // pair
 
-define test pair-type (description: "")
+define test pair-type ()
   check-true("", instance?(pair, <function>));
   check-false("", instance?(pair, <generic-function>));
 end test pair-type;
 
 /* pair not implemented in the emulator
-define test pair-0 (description: "")
+define test pair-0 ()
   check-true("", pair(1, 2) = #(1 . 2));
   check-true("", pair(#"a", #(#"b", #"c")) = #(#"a", #"b", #"c"));
   check-true("", pair(#(), #(#"b", #"c")) = #(#(), #"b", #"c"));
@@ -31,12 +31,12 @@ define test pair-0 (description: "")
   check-true("", pair(#"a", pair(#"b", pair(#"c", #()))) = #(#"a", #"b", #"c"));
 end test pair-0;
 */
-define test list-type (description: "")
+define test list-type ()
   check-true("", instance?(list, <function>));
   check-false("", instance?(list, <generic-function>));
 end test list-type;
 
-define test list-0 (description: "")
+define test list-0 ()
  check-true("",  list(1, 2, 3) = #(1, 2, 3));
   check-true("", list() = #());
   check-true("", list(#"a") = #(#"a"));
@@ -44,7 +44,7 @@ define test list-0 (description: "")
   check-true("", list(#(#"a", #"b"), #()) = #(#(#"a", #"b"), #()));
 end test list-0;
 
-define test list-quote-0 (description: "")
+define test list-quote-0 ()
   check-true("", #"john" = #"john");
       let t
         = #(#"john", #(#"quote", #(#"mary", #(#"quote", #(#"joe", #"cindy")), #"bob")), #(#"quote", #(#"joy")));
@@ -52,10 +52,10 @@ define test list-quote-0 (description: "")
       = #(#(#"quote", #(#"mary", #(#"quote", #(#"joe", #"cindy")), #"bob")), #(#"quote", #(#"joy"))));
   check-true("", t.tail.tail.head = #(#"quote", #(#"joy")));
   check-true("", t.tail.tail.head.head = #"quote");
-  
+
 end test list-quote-0;
 
-define test list-ops-2 (description: "")
+define test list-ops-2 ()
   begin
     local method reuse-pair (x, y, x-y)
             if (x = x-y.head & y = x-y.tail)
@@ -78,7 +78,7 @@ define test list-ops-2 (description: "")
   end
 end test list-ops-2;
 
-define test list-ops-3 (description: "")
+define test list-ops-3 ()
   local method reuse-pair (x, y, x-y)
           if (x = x-y.head & y = x-y.tail)
             x-y
@@ -101,7 +101,7 @@ define test list-ops-3 (description: "")
   check-true("", flatten2(#(#(#"a"), #(#"b", #(#"c"), #"d"))) = #(#"a", #"b", #"c", #"d"));
 end test list-ops-3;
 
-define suite test-list-suite () 
+define suite test-list-suite ()
   test pair-type;
 //  test pair-0;
   test list-type;

--- a/sources/dylan/apple-dylan-test-suite/test-range.dylan
+++ b/sources/dylan/apple-dylan-test-suite/test-range.dylan
@@ -8,8 +8,8 @@ Copyright: (c) 1993 Apple Computer, Inc.
 Modified by: Shri Amit(amit)
 Date: August 24 1996
 Summary: Converted to new testworks protocol
-Copyright: (c) 1996 Functional Objects, Inc. 
-           All rights reserved.  
+Copyright: (c) 1996 Functional Objects, Inc.
+           All rights reserved.
 ----------------------------------------------*/
 
 /// Please read these accompanying files:
@@ -17,7 +17,8 @@ Copyright: (c) 1996 Functional Objects, Inc.
 ///   "setup.dylan"      for information on how to run these tests.
 ///   "legal-info.txt"   for important legal information.
 
-define test range-0 (description: "simple case")
+// simple case
+define test range-0 ()
   check-true("", instance?(range(), <range>));
   check-true("", begin
       let c = #();
@@ -30,23 +31,28 @@ define test range-0 (description: "simple case")
     = #(19, 18, 17, 16, 15, 14, 13, 12, 11, 10));
 end test;
 
-define test range-1 (description: "from: (inclusive) and up-t: (inclusive)")
+// from: (inclusive) and up-t: (inclusive)
+define test range-1 ()
   check-true("", range(from: 0, below: 5) = #(0, 1, 2, 3, 4));
 end test range-1;
 
-define test range-2 (description: "from: defaults to 0")
+// from: defaults to 0
+define test range-2 ()
   check-true("", range(below: 4) = #(0, 1, 2, 3));
 end test range-2;
 
-define test range-3 (description: "to: (inclusive)")
+// to: (inclusive)
+define test range-3 ()
   check-true("", range(to: 4) = #(0, 1, 2, 3, 4));
 end test range-3;
 
-define test range-4 (description: "BY:")
+// BY:
+define test range-4 ()
   check-true("", range(to: 4, by: 2) = #(0, 2, 4));
 end test range-4;
 
-define test range-5 (description: "to:, by:, and size:")
+// to:, by:, and size:
+define test range-5 ()
   check-true("", range(to: 5, by: 2, size: 3) = #(0, 2, 4));
   check-true("", range(to: 6, by: 2, size: 4) = #(0, 2, 4, 6));
   check-true("", range(to: -5, by: -2, size: 3) = #(0, -2, -4));
@@ -61,59 +67,67 @@ end test range-5;
 // member? range
 // only tests features unique to range
 
-define test member?-range (description: "always terminates")
+// always terminates
+define test member?-range ()
   check-false("", member?(-9999, range()) & member?(9999, range()));
 end test member?-range;
 
 // size range
 
-define test size-range (description: "always terminates")
+// always terminates
+define test size-range ()
   check-false("", range().size);
 end test size-range;
 
 // copy-sequence range
 
-define test copy-sequence-range-0
-  (description: "copy-seq on range always returns <range>")
+// copy-seq on range always returns <range>
+define test copy-sequence-range-0 ()
   check-true("", instance?(range(to: 5).copy-sequence, <range>));
 end test copy-sequence-range-0;
 
 // = range
 
-define test equal-range (description: "always terminates")
+// always terminates
+define test equal-range ()
   check-false("", range() = range(from: -5, below: 6));
   check-true("", range() = range());
 end test equal-range;
 
 // reverse range
 
-define test reverse-range (description: "always returns a range")
+// always returns a range
+define test reverse-range ()
   check-true("", instance?(range(from: 1, to: 10, by: 2).reverse, <range>));
 end test reverse-range;
 
-define test reverse-range-1 (description: "non-destructive")
+// non-destructive
+define test reverse-range-1 ()
   check-true("", #t);
 end test reverse-range-1;
 
-define test reverse!-range (description: "always returns a range")
+// always returns a range
+define test reverse!-range ()
   check-true("", instance?(reverse!(range(from: 1, to: 10, by: 2)), <range>));
 end test reverse!-range;
 
 // range-intersection
 
-define test intersection-range (description: "always terminates")
+// always terminates
+define test intersection-range ()
   check-true("", intersection(range(), range()) = range());
   check-true("", intersection(range(from: 0, by: 2), range(from: 0, by: 3))
     = range(from: 0, by: 6));
 end test intersection-range;
 
-define test intersection-range-1 (description: "returns a range")
+// returns a range
+define test intersection-range-1 ()
   check-true("", instance?
     (intersection(range(from: 0, below: 5), range(from: 3, below: 9)), <range>));
   check-true("",instance?(intersection(range(), range(from: -1)), <range>));
 end test intersection-range-1;
 
-define suite test-range-suite () 
+define suite test-range-suite ()
   test range-0;
   test range-1;
   test range-2;

--- a/sources/dylan/apple-dylan-test-suite/test-sequence.dylan
+++ b/sources/dylan/apple-dylan-test-suite/test-sequence.dylan
@@ -8,15 +8,16 @@ Copyright: (c) 1993 Apple Computer, Inc.
 Modified by: Shri Amit(amit)
 Date: August 24 1996
 Summary: Converted to new testworks protocol
-Copyright: (c) 1996 Functional Objects, Inc. 
-           All rights reserved.  
+Copyright: (c) 1996 Functional Objects, Inc.
+           All rights reserved.
 ----------------------------------------------*/
 
-define test add-type (description: "")
+define test add-type ()
   check-true("", instance?(add, <generic-function>));
 end test add-type;
 
-define test add-1 (description: "add")
+// add
+define test add-1 ()
   every?
     (method (s)
        let collection = s.first;
@@ -43,19 +44,20 @@ define test add-1 (description: "add")
                '!')))
 end test add-1;
 
-define test add-2
-  (description: "new sequence shares no structure with sequence")
+// new sequence shares no structure with sequence
+define test add-2 ()
   let s = list(#(#"a", #"b"));
   let new-element = #(#"c", #"d");
   let new-s = add(s, new-element);
   check-false ("", share-struct?(s, new-s));
 end test add-2;
 
-define test add!-type (description: "")
+define test add!-type ()
   check-true("", instance?(add!, <generic-function>));
 end test add!-type;
 
-define test add!-1 (description: "add")
+// add
+define test add!-1 ()
   every?
     (method (s)
        let collection = s.first;
@@ -89,18 +91,19 @@ define test add!-1 (description: "add")
                #f)))
 end test add!-1;
 
-define test add!-position
-  (description: "makes sure new value is at front or end")
+// makes sure new value is at front or end
+define test add!-position ()
   check-true("", add!(list(7, 8, 9), 88).first = 88);
   check-true("", add!(deque-instance(7, 8, 9), 88).first = 88);
   check-true("", add!(stretchy-vector-instance(7, 8, 9), 88).last = 88);
 end test add!-position;
 
-define test add-new-type (description: "")
+define test add-new-type ()
   check-true("", instance?(add-new, <generic-function>));
 end test add-new-type;
 
-define test add-new-1 (description: "add new element")
+// add new element
+define test add-new-1 ()
   every?
     (method (s)
        let collection = s.first;
@@ -127,7 +130,8 @@ define test add-new-1 (description: "add new element")
                '!')))
 end test add-new-1;
 
-define test add-new-2 (description: "add old element")
+// add old element
+define test add-new-2 ()
   every?
     (method (s)
        let collection = s.first;
@@ -168,7 +172,8 @@ define constant caseless=?
 // and new-element as its second argument (p 105)
 //
 
-define test add-new-3 (description: "add new element, using test: argument")
+// add new element, using test: argument
+define test add-new-3 ()
   every?
     (method (s)
        let collection = s.first;
@@ -203,7 +208,8 @@ define test add-new-3 (description: "add new element, using test: argument")
                caseless=?)))
 end test add-new-3;
 
-define test add-new-4 (description: "add old element, using test: argument")
+// add old element, using test: argument
+define test add-new-4 ()
   every?
     (method (s)
        let collection = s.first;
@@ -239,11 +245,12 @@ end test add-new-4;
 
 // add-new!
 
-define test add-new!-type (description: "")
+define test add-new!-type ()
   check-true("", instance?(add-new!, <generic-function>));
 end test add-new!-type;
 
-define test add-new!-1 (description: "add new element")
+// add new element
+define test add-new!-1 ()
   every?
     (method (s)
        let collection = s.first;
@@ -277,7 +284,8 @@ define test add-new!-1 (description: "add new element")
                #f)))
 end test add-new!-1;
 
-define test add-new!-2 (description: "add old element")
+// add old element
+define test add-new!-2 ()
   every?
     (method (s)
        let collection = s.first;
@@ -301,7 +309,8 @@ define test add-new!-2 (description: "add old element")
                'o')))
 end test add-new!-2;
 
-define test add-new!-3 (description: "add new element, using test: argument")
+// add new element, using test: argument
+define test add-new!-3 ()
   every?
     (method (s)
        let collection = s.first;

--- a/sources/dylan/apple-dylan-test-suite/test-sequence2.dylan
+++ b/sources/dylan/apple-dylan-test-suite/test-sequence2.dylan
@@ -8,11 +8,12 @@ Copyright: (c) 1993 Apple Computer, Inc.
 Modified by: Shri Amit(amit)
 Date: August 24 1996
 Summary: Converted to new testworks protocol
-Copyright: (c) 1996 Functional Objects, Inc. 
-           All rights reserved.  
+Copyright: (c) 1996 Functional Objects, Inc.
+           All rights reserved.
 ----------------------------------------------*/
 
-define test add-new!-4 (description: "add old element, using test: argument")
+// add old element, using test: argument
+define test add-new!-4 ()
   every?(method (s)
            let collection = s.first;
            let elements = s.second;
@@ -59,42 +60,50 @@ end test add-new!-4;
 
 // remove
 
-define test remove-type (description: "")
+define test remove-type ()
   check-true("", instance?(remove, <generic-function>));
 end test remove-type;
 
-define test remove-0 (description: "list")
+// list
+define test remove-0 ()
   check-true("", remove(#(1, 2, 4, 1, 3, 4, 5), 4) = #(1, 2, 1, 3, 5));
 end test remove-0;
 
-define test remove-1 (description: "empty-list")
+// empty-list
+define test remove-1 ()
   check-true("", remove(#(), 4) = #());
 end test remove-1;
 
-define test remove-2 (description: "range")
+// range
+define test remove-2 ()
   check-true("", remove(range(from: 1, below: 5), 4) = #(1, 2, 3));
 end test remove-2;
 
-define test remove-3 (description: "deque")
+// deque
+define test remove-3 ()
   check-true("", remove(deque-instance(1, 2, 3, 4, 5), 4) = deque-instance(1, 2, 3, 5));
 end test remove-3;
 
-define test remove-4 (description: "stretchy-vector")
+// stretchy-vector
+define test remove-4 ()
   check-true("", remove(stretchy-vector-instance(1, 2, 3, 4, 5), 4)
   = stretchy-vector-instance(1, 2, 3, 5));
 end test remove-4;
 
-define test remove-5 (description: "simple-object-vector")
+// simple-object-vector
+define test remove-5 ()
   check-true("", remove(vector(1, 2, 3, 4, 5), 4)
   = vector(1, 2, 3, 5));
 end test remove-5;
 
-define test remove-6 (description: "string")
+// string
+define test remove-6 ()
   check-true("", remove("Abandon every hope all ye who enter here!", ' ')
   = "Abandoneveryhopeallyewhoenterhere!");
 end test remove-6;
 
-define test remove-7 (description: "with test: arg")
+// with test: arg
+define test remove-7 ()
   check-true("", remove
     (#(#"a", #"b", #(#"a", #"c"), #"d", #"e", #(#"a", #"c"), #"f"),
      #(#"a", #"c"),
@@ -102,17 +111,19 @@ define test remove-7 (description: "with test: arg")
   = #(#"a", #"b", #"d", #"e", #"f"));
 end test remove-7;
 
-define test remove-8 (description: "with count: arg")
+// with count: arg
+define test remove-8 ()
   check-true("", remove(#(1, 2, 4, 1, 3, 4, 5), 4, count: 1) = #(1, 2, 1, 3, 4, 5));
 end test remove-8;
 
-define test remove-9 (description: "with count: and test: args")
+// with count: and test: args
+define test remove-9 ()
   check-true("", remove("Abandon every hope all ye who enter here!", 'e', test: \&=)
   = "eeeeeeee");
 end test remove-9;
 
-define test remove-10
-  (description: "doesn't modify sequence, & result doesn't share structure")
+// doesn't modify sequence, & result doesn't share structure
+define test remove-10 ()
   let x = #(#"a", #"b");
   let numbers = list(3, 1, 4, 1, x, 9);
   let result = remove(numbers, 1, test: \>, count: 2);
@@ -121,42 +132,50 @@ end test remove-10;
 
 //remove!
 
-define test remove!-type (description: "")
+define test remove!-type ()
   check-true("", instance?(remove!, <generic-function>));
 end test remove!-type;
 
-define test remove!-0 (description: "list")
+// list
+define test remove!-0 ()
   check-true("", remove!(#(1, 2, 4, 1, 3, 4, 5), 4) = #(1, 2, 1, 3, 5));
 end test remove!-0;
 
-define test remove!-1 (description: "empty-list")
+// empty-list
+define test remove!-1 ()
   check-true("", remove!(#(), 4) = #());
 end test remove!-1;
 
-define test remove!-2 (description: "range")
+// range
+define test remove!-2 ()
   check-true("", remove!(range(from: 1, below: 5), 4) = #(1, 2, 3));
 end test remove!-2;
 
-define test remove!-3 (description: "deque")
+// deque
+define test remove!-3 ()
   check-true("", remove!(deque-instance(1, 2, 3, 4, 5), 4) = deque-instance(1, 2, 3, 5));
 end test remove!-3;
 
-define test remove!-4 (description: "stretchy-vector")
+// stretchy-vector
+define test remove!-4 ()
   check-true("", remove!(stretchy-vector-instance(1, 2, 3, 4, 5), 4)
   = stretchy-vector-instance(1, 2, 3, 5));
 end test remove!-4;
 
-define test remove!-5 (description: "simple-object-vector")
+// simple-object-vector
+define test remove!-5 ()
   check-true("", remove!(vector(1, 2, 3, 4, 5), 4)
   = vector(1, 2, 3, 5));
 end test remove!-5;
 
-define test remove!-6 (description: "string")
+// string
+define test remove!-6 ()
   check-true("", remove!("Abandon every hope all ye who enter here!", ' ')
   = "Abandoneveryhopeallyewhoenterhere!");
 end test remove!-6;
 
-define test remove!-7 (description: "with test: arg")
+// with test: arg
+define test remove!-7 ()
   check-true("", remove!
     (#(#"a", #"b", #(#"a", #"c"), #"d", #"e", #(#"a", #"c"), #"f"),
      #(#"a", #"c"),
@@ -164,20 +183,23 @@ define test remove!-7 (description: "with test: arg")
   = #(#"a", #"b", #"d", #"e", #"f"));
 end test remove!-7;
 
-define test remove!-8 (description: "with count: arg")
+// with count: arg
+define test remove!-8 ()
   check-true("", remove!(#(1, 2, 4, 1, 3, 4, 5), 4, count: 1) = #(1, 2, 1, 3, 4, 5));
 end test remove!-8;
 
-define test remove!-9 (description: "with cound: and test: args")
+// with cound: and test: args
+define test remove!-9 ()
   check-true("", remove!("Abandon every hope all ye who enter here!", 'e', test: \&=)
   = "eeeeeeee");
 end test remove!-9;
 
-define test choose-type (description: "")
+define test choose-type ()
   check-true("", instance?(choose, <generic-function>));
 end test choose-type;
 
-define test choose-0 (description: "list")
+// list
+define test choose-0 ()
   check-true("", choose
     (method (e)
        e > 5
@@ -186,7 +208,8 @@ define test choose-0 (description: "list")
   = #(6));
 end test choose-0;
 
-define test choose-1 (description: "empty list")
+// empty list
+define test choose-1 ()
   check-true("", choose
     (method (e)
        e > 5
@@ -195,26 +218,31 @@ define test choose-1 (description: "empty list")
   = #());
 end test choose-1;
 
-define test choose-2 (description: "range")
+// range
+define test choose-2 ()
   check-true("", choose(even?, range(from: 0, below: 8)) = #(0, 2, 4, 6));
 end test choose-2;
 
-define test choose-3 (description: "deque")
+// deque
+define test choose-3 ()
   check-true("", choose(even?, deque-instance(1, 2, 3, 4, 5, 6, 7, 8))
   = deque-instance(2, 4, 6, 8));
 end test choose-3;
 
-define test choose-4 (description: "stretchy-vector")
+// stretchy-vector
+define test choose-4 ()
   check-true("", choose(even?, stretchy-vector-instance(1, 2, 3, 4, 5, 6, 7, 8))
   = stretchy-vector-instance(2, 4, 6, 8));
 end test choose-4;
 
-define test choose-5 (description: "simple-object-vector")
+// simple-object-vector
+define test choose-5 ()
   check-true("", choose(even?, vector(1, 2, 3, 4, 5, 6, 7, 8))
   = vector(2, 4, 6, 8));
 end test choose-5;
 
-define test choose-6 (description: "string")
+// string
+define test choose-6 ()
   check-true("", choose
     (method (c)
        c >= 'a' & c <= 'z'
@@ -227,18 +255,20 @@ define test choose-6 (description: "string")
   check-true("", choose(even?, #(1, 3, 5, 7)) = #());
 end test choose-6;
 
-define test choose-7 (description: "returns *new* sequence")
+// returns *new* sequence
+define test choose-7 ()
   let t = make(<deque>, fill: 9);
   let new-t = choose(odd?, t) = t;
   check-true("", t = new-t);
   check-true("", ~(t == new-t));
 end test choose-7;
 
-define test choose-by-type (description: "")
+define test choose-by-type ()
   check-true("", instance?(choose-by, <generic-function>));
 end test choose-by-type;
 
-define test choose-by-0 (description: "list")
+// list
+define test choose-by-0 ()
   check-true("", choose-by
     (even?,
      #(1, 2, 3, 4, 5, 6, 7, 8),
@@ -246,12 +276,14 @@ define test choose-by-0 (description: "list")
   = #(#"b", #"d", #"f", #"h"));
 end test choose-by-0;
 
-define test choose-by-1 (description: "Empty list")
+// Empty list
+define test choose-by-1 ()
   check-true("", choose-by(even?, #(1, 2, 3, 4), #()) = #());
   check-true("", choose-by(even?, #(), #(1, 2, 3, 4)) = #());
 end test choose-by-1;
 
-define test choose-by-2 (description: "deque")
+// deque
+define test choose-by-2 ()
   check-true("", choose-by
     (even?,
      deque-instance(1, 2, 3, 4, 5, 6, 7, 8),
@@ -259,13 +291,15 @@ define test choose-by-2 (description: "deque")
   = deque-instance(#"b", #"d", #"f", #"h"));
 end test choose-by-2;
 
-define test choose-by-3 (description: "range")
+// range
+define test choose-by-3 ()
   check-true("", choose-by
     (even?, range(from: 0, below: 15), range(from: 0, above: -15, by: -1))
   = #(0, -2, -4, -6, -8, -10, -12, -14));
 end test choose-by-3;
 
-define test choose-by-4 (description: "stretchy-vector")
+// stretchy-vector
+define test choose-by-4 ()
   check-true("", choose-by
     (even?,
      stretchy-vector-instance(1, 2, 3, 4, 5, 6, 7, 8),
@@ -273,7 +307,8 @@ define test choose-by-4 (description: "stretchy-vector")
   = stretchy-vector-instance(#"b", #"d", #"f", #"h"));
 end test choose-by-4;
 
-define test choose-by-5 (description: "simple-object-vector-vector")
+// simple-object-vector-vector
+define test choose-by-5 ()
   check-true("", choose-by
     (even?,
      vector(1, 2, 3, 4, 5, 6, 7, 8),
@@ -282,7 +317,8 @@ define test choose-by-5 (description: "simple-object-vector-vector")
   = vector(#"b", #"d", #"f", #"h"));
 end test choose-by-5;
 
-define test choose-by-6 (description: "string")
+// string
+define test choose-by-6 ()
   check-true("", choose-by
     (method (c)
        c >= 'a' & c <= 'z'
@@ -292,7 +328,8 @@ define test choose-by-6 (description: "string")
   = "This is the right ans");
 end test choose-by-6;
 
-define test choose-by-7 (description: "a few mixed cases")
+// a few mixed cases
+define test choose-by-7 ()
   check-true("", choose-by
     (even?,
      deque-instance(1, 2, 3, 4, 5, 6, 7, 8),
@@ -309,7 +346,8 @@ define test choose-by-7 (description: "a few mixed cases")
     = #(#"b", #"d", #"f"));
 end test choose-by-7;
 
-define test choose-by-8 (description: "returns new sequence")
+// returns new sequence
+define test choose-by-8 ()
   let x = "abcdefgh";
   let result = choose-by(odd?, #(1, 1, 1, 1, 1, 1, 1, 1), x);
  check-true("",  ~(x == result) & x = result);
@@ -317,11 +355,12 @@ end test choose-by-8;
 
 // these test intersection
 
-define test intersection-type (description: "")
+define test intersection-type ()
   check-true("", instance?(intersection, <generic-function>));
 end test intersection-type;
 
-define test intersection-0 (description: "list")
+// list
+define test intersection-0 ()
   begin
     let result
       = intersection
@@ -334,18 +373,20 @@ define test intersection-0 (description: "list")
        #(#"richard", #"edward", #"charles")).empty?);
 end test intersection-0;
 
-define test intersection-1 (description: "empty-list")
+// empty-list
+define test intersection-1 ()
   check-true("", intersection(#(), #()).empty?);
 end test intersection-1;
 
-define test intersection-2
-  (description: "always terminates, even with unbounded ranges")
+// always terminates, even with unbounded ranges
+define test intersection-2 ()
   check-true("", intersection(range(from: 0, by: 2), range(from: 1, by: 2)).empty?);
   check-true("", intersection(range(from: 8, by: 2), range(from: 9, by: 3))
     = range(from: 12, by: 6));
 end test intersection-2;
 
-define test intersection-2a (description: "with test")
+// with test
+define test intersection-2a ()
   let result
     = intersection
         (as(<list>, range(from: 0, by: 2, size: 5)),
@@ -359,7 +400,8 @@ end test intersection-2a;
 // See design note #18
 //
 
-define test intersection-2b (description: "same, but with ranges not lists")
+// same, but with ranges not lists
+define test intersection-2b ()
   let result
     = intersection
         (range(from: 0, by: 2, size: 5),
@@ -370,37 +412,43 @@ define test intersection-2b (description: "same, but with ranges not lists")
   check-true("", every?(rcurry(member?, result), #(0, 2, 4, 6, 8)) & result.size = 5);
 end test intersection-2b;
 
-define test intersection-2c (description: "range, test: =")
+// range, test: =
+define test intersection-2c ()
   check-true("", intersection
     (range(from: 0, by: 2, size: 5), range(from: 6, by: 2, size: 5), test: \=)
   = range(from: 6, by: 2, size: 2));
 end test intersection-2c;
 
-define test intersection-2d (description: "semi-infinite ranges, test: id?")
+// semi-infinite ranges, test: id?
+define test intersection-2d ()
   check-true("", intersection(range(from: 0, by: 2), range(by: 2, to: 10), test: \==)
   = range(from: 0, by: 2, size: 6));
 end test intersection-2d;
 
-define test intersection-3 (description: "deque")
+// deque
+define test intersection-3 ()
   check-true("", intersection(deque-instance(1, 2, 3, 4, 5), deque-instance(4, 6, 8, 10, 12))
   = deque-instance(4));
 end test intersection-3;
 
-define test intersection-4 (description: "stretchy-vector")
+// stretchy-vector
+define test intersection-4 ()
   check-true("", intersection
     (stretchy-vector-instance(1, 2, 3, 4, 5),
      stretchy-vector-instance(4, 6, 8, 10, 12))
   = stretchy-vector-instance(4));
 end test intersection-4;
 
-define test intersection-5 (description: "simple-object-vector")
+// simple-object-vector
+define test intersection-5 ()
   check-true("", intersection
     (vector(1, 2, 3, 4, 5),
      vector(4, 6, 8, 10, 12))
   = vector(4));
 end test intersection-5;
 
-define test intersection-6 (description: "string")
+// string
+define test intersection-6 ()
   let result
     = intersection
         ("When, in the course of human events",
@@ -408,4 +456,3 @@ define test intersection-6 (description: "string")
   check-true("", every?(rcurry(member?, "aehnort "), result));
   check-true("", every?(rcurry(member?, result), "aehnort "));
 end test intersection-6;
-

--- a/sources/dylan/apple-dylan-test-suite/test-sequence3.dylan
+++ b/sources/dylan/apple-dylan-test-suite/test-sequence3.dylan
@@ -8,15 +8,17 @@ Copyright: (c) 1993 Apple Computer, Inc.
 Modified by: Shri Amit(amit)
 Date: August 24 1996
 Summary: Converted to new testworks protocol
-Copyright: (c) 1996 Functional Objects, Inc. 
-           All rights reserved.  
+Copyright: (c) 1996 Functional Objects, Inc.
+           All rights reserved.
 ----------------------------------------------*/
 
-define test intersection-7 (description: "mixed cases")
+// mixed cases
+define test intersection-7 ()
   check-true("", intersection(#('a', 'b', 'z'), "acde") = #('a'));
 end test intersection-7;
 
-define test intersection-8 (description: "test defaults to id?")
+// test defaults to id?
+define test intersection-8 ()
   check-true("", ~("john" == "john"));
   check-true("", intersection
       (#("john", "paul", "george", "ringo"),
@@ -24,8 +26,8 @@ define test intersection-8 (description: "test defaults to id?")
     = #());
 end test intersection-8;
 
-define test intersection-9
-  (description: "with other test:, returns val from 1st seq")
+// with other test:, returns val from 1st seq
+define test intersection-9 ()
   let result
     = intersection
         (range(from: -1, above: -5, by: -1),
@@ -38,11 +40,12 @@ end test intersection-9;
 
 // union
 
-define test union-type (description: "")
+define test union-type ()
   check-true("", instance?(union, <generic-function>));
 end test union-type;
 
-define test union-0 (description: "list")
+// list
+define test union-0 ()
  check-true("", every?
     (method (e)
        member?(e, union(#(#"john", #"paul"), #(#"george", #"edward")))
@@ -50,11 +53,13 @@ define test union-0 (description: "list")
      #(#"john", #"paul", #"george", #"edward")));
 end test union-0;
 
-define test union-1 (description: "empty-list")
+// empty-list
+define test union-1 ()
   check-true("", union(#(), #()).empty?);
 end test union-1;
 
-define test union-2 (description: "range")
+// range
+define test union-2 ()
   check-true("", every?
     (method (e)
        member?
@@ -65,7 +70,8 @@ define test union-2 (description: "range")
      range(from: 0, below: 9)));
 end test union-2;
 
-define test union-3 (description: "deque")
+// deque
+define test union-3 ()
   check-true("", every?
     (method (e)
        member?
@@ -76,7 +82,8 @@ define test union-3 (description: "deque")
      deque-instance(1, 2, 3, 4, 5, 6, 8, 10, 12)));
 end test union-3;
 
-define test union-4 (description: "stretchy-vector")
+// stretchy-vector
+define test union-4 ()
   check-true("", every?
     (method (e)
        member?
@@ -87,7 +94,8 @@ define test union-4 (description: "stretchy-vector")
      stretchy-vector-instance(1, 2, 3, 4, 5, 6, 8, 10, 12)));
 end test union-4;
 
-define test union-5 (description: "simple-object-vector")
+// simple-object-vector
+define test union-5 ()
   check-true("", every?
     (method (e)
        member?
@@ -98,7 +106,8 @@ define test union-5 (description: "simple-object-vector")
      vector(1, 2, 3, 4, 5, 6, 8, 10, 12)));
 end test union-5;
 
-define test union-6 (description: "string")
+// string
+define test union-6 ()
   check-true("", every?
     (method (e)
        member?(e, union("When", ", in the course of human events"))
@@ -106,11 +115,13 @@ define test union-6 (description: "string")
      "When, in the course of human events"));
 end test union-6;
 
-define test union-7 (description: "mixed cases")
+// mixed cases
+define test union-7 ()
   check-true("", every?(member?, union(#(1, 2, 3), #[1, 2, 3, 4, 5]), #(#(5, 4, 3, 2, 1))));
 end test union-7;
 
-define test union-8 (description: "union with test:")
+// union with test:
+define test union-8 ()
   check-true("", union(#(#"a", #"b", #"c", #"d", #"e", #"f"),
         #(#"b", #"c", #"d", #"e", #"f", #"g", #"h"),
         test: \&=)
@@ -119,11 +130,12 @@ end test union-8;
 
 // remove-duplicates
 
-define test remove-duplicates-type (description: "")
+define test remove-duplicates-type ()
   check-true("", instance?(remove-duplicates, <generic-function>));
 end test remove-duplicates-type;
 
-define test remove-duplicates-0 (description: "list")
+// list
+define test remove-duplicates-0 ()
   let platter
     = remove-duplicates
         (#(#"spam", #"eggs", #"spam", #"sausage", #"spam", #"spam", #"spam"));
@@ -131,37 +143,44 @@ define test remove-duplicates-0 (description: "list")
   check-true("", every?(rcurry(member?, platter), #(#"eggs", #"sausage", #"spam")));
 end test remove-duplicates-0;
 
-define test remove-duplicates-1 (description: "range")
+// range
+define test remove-duplicates-1 ()
   check-true("", range(from: 0, below: 5).remove-duplicates = range(from: 0, below: 5));
 end test remove-duplicates-1;
 
-define test remove-duplicates-2 (description: "deque")
+// deque
+define test remove-duplicates-2 ()
   check-true("", deque-instance(1, 2, 3, 4, 5, 4, 3, 2, 1).remove-duplicates
   = deque-instance(1, 2, 3, 4, 5));
 end test remove-duplicates-2;
 
-define test remove-duplicates-3 (description: "stretchy-vector")
+// stretchy-vector
+define test remove-duplicates-3 ()
   check-true("", stretchy-vector-instance(1, 2, 3, 4, 5, 4, 3, 2, 1).remove-duplicates
   = stretchy-vector-instance(1, 2, 3, 4, 5));
 end test remove-duplicates-3;
 
-define test remove-duplicates-4 (description: "simple-object-vector")
+// simple-object-vector
+define test remove-duplicates-4 ()
   check-true("", vector(1, 2, 3, 4, 5, 4, 3, 2, 1).remove-duplicates
   = vector(1, 2, 3, 4, 5));
 end test remove-duplicates-4;
 
-define test remove-duplicates-5 (description: "string")
+// string
+define test remove-duplicates-5 ()
   check-true("", remove-duplicates("Abandon every hope all ye who enter here!")
   = "Abando evryhplwt!");
 end test remove-duplicates-5;
 
-define test remove-duplicates-6 (description: "test defaults to id?")
+// test defaults to id?
+define test remove-duplicates-6 ()
   check-true("", ~("and" == "and"));
   check-true("", remove-duplicates(#("shoes", "and", "ships", "and", "sealingwax"))
     = #("shoes", "and", "ships", "and", "sealingwax"));
 end test remove-duplicates-6;
 
-define test remove-duplicates-7 (description: "with test: arg")
+// with test: arg
+define test remove-duplicates-7 ()
   check-true("", remove-duplicates
     (#(#"spam", #"eggs", #"spam", #"sausage", #"spam", #"spam", #"spam"),
      test: \&=)
@@ -174,7 +193,8 @@ define test remove-duplicates-7 (description: "with test: arg")
     = #(#(#"foo", #(#"quote", #"a")), #(#"bar", '%')));
 end test remove-duplicates-7;
 
-define test remove-duplicates-8 (description: "sequence not modified")
+// sequence not modified
+define test remove-duplicates-8 ()
   let s = list(#"a", #"a", #"p", #"b");
   let result = s.remove-duplicates;
   check-true("", s = list(#"a", #"a", #"p", #"b") & ~share-struct?(s, result));
@@ -182,11 +202,12 @@ end test remove-duplicates-8;
 
 // remove-duplicates!
 
-define test remove-duplicates!-type (description: "")
+define test remove-duplicates!-type ()
   check-true("", instance?(remove-duplicates!, <generic-function>));
 end test remove-duplicates!-type;
 
-define test remove-duplicates!-0 (description: "list")
+// list
+define test remove-duplicates!-0 ()
   let platter
     = remove-duplicates!
         (#(#"spam", #"eggs", #"spam", #"sausage", #"spam", #"spam", #"spam"));
@@ -194,37 +215,44 @@ define test remove-duplicates!-0 (description: "list")
   check-true("", every?(rcurry(member?, platter), #(#"eggs", #"sausage", #"spam")));
 end test remove-duplicates!-0;
 
-define test remove-duplicates!-1 (description: "range")
+// range
+define test remove-duplicates!-1 ()
   check-true("", remove-duplicates!(range(from: 0, below: 5)) = range(from: 0, below: 5));
 end test remove-duplicates!-1;
 
-define test remove-duplicates!-2 (description: "deque")
+// deque
+define test remove-duplicates!-2 ()
   check-true("", remove-duplicates!(deque-instance(1, 2, 3, 4, 5, 4, 3, 2, 1))
   = deque-instance(1, 2, 3, 4, 5));
 end test remove-duplicates!-2;
 
-define test remove-duplicates!-3 (description: "stretchy-vector")
+// stretchy-vector
+define test remove-duplicates!-3 ()
   check-true("", remove-duplicates!(stretchy-vector-instance(1, 2, 3, 4, 5, 4, 3, 2, 1))
   = stretchy-vector-instance(1, 2, 3, 4, 5));
 end test remove-duplicates!-3;
 
-define test remove-duplicates!-4 (description: "simple-object-vector")
+// simple-object-vector
+define test remove-duplicates!-4 ()
   check-true("", remove-duplicates!(vector(1, 2, 3, 4, 5, 4, 3, 2, 1))
   = vector(1, 2, 3, 4, 5));
 end test remove-duplicates!-4;
 
-define test remove-duplicates!-5 (description: "string")
+// string
+define test remove-duplicates!-5 ()
   check-true("", remove-duplicates!("Abandon every hope all ye who enter here!")
   = "Abando evryhplwt!");
 end test remove-duplicates!-5;
 
-define test remove-duplicates!-6 (description: "test defaults to id?")
+// test defaults to id?
+define test remove-duplicates!-6 ()
   check-true("", ~("and" == "and"));
   check-true("", remove-duplicates!(#("shoes", "and", "ships", "and", "sealingwax"))
     = #("shoes", "and", "ships", "and", "sealingwax"));
 end test remove-duplicates!-6;
 
-define test remove-duplicates!-7 (description: "with test: arg")
+// with test: arg
+define test remove-duplicates!-7 ()
   check-true("", remove-duplicates!
     (#(#"spam", #"eggs", #"spam", #"sausage", #"spam", #"spam", #"spam"),
      test: \&=)
@@ -237,35 +265,40 @@ define test remove-duplicates!-7 (description: "with test: arg")
     = #(#(#"foo", #(#"quote", #"a")), #(#"bar", '%')));
 end test remove-duplicates!-7;
 
-define test copy-sequence-type (description: "")
+define test copy-sequence-type ()
   check-true("", instance?(copy-sequence, <generic-function>));
 end test copy-sequence-type;
 
-define test copy-sequence-0 (description: "list")
+// list
+define test copy-sequence-0 ()
   let s = #(#"a", #"b", #"c", #"d");
   let new-s = s.copy-sequence;
   check-true("", new-s = s & ~(new-s == s));
 end test copy-sequence-0;
 
-define test copy-sequence-2 (description: "range")
+// range
+define test copy-sequence-2 ()
   let s = range(from: 0, below: 5);
   let new-s = s.copy-sequence;
   check-true("", new-s = s & ~(new-s == s));
 end test copy-sequence-2;
 
-define test copy-sequence-3 (description: "deque")
+// deque
+define test copy-sequence-3 ()
   let s = deque-instance(1, 2, 3, 4, 5);
   let new-s = s.copy-sequence;
   check-true("", new-s = s & ~(new-s == s));
 end test copy-sequence-3;
 
-define test copy-sequence-4 (description: "stretchy-vector")
+// stretchy-vector
+define test copy-sequence-4 ()
   let s = stretchy-vector-instance(1, 2, 3, 4, 5);
   let new-s = s.copy-sequence;
   check-true("", new-s = s & ~(new-s == s));
 end test copy-sequence-4;
 
-define test copy-sequence-5 (description: "simple-object-vector")
+// simple-object-vector
+define test copy-sequence-5 ()
   check-true("", begin
     let s = vector(1, 2, 3, 4, 5);
     let new-s = s.copy-sequence;
@@ -274,37 +307,43 @@ define test copy-sequence-5 (description: "simple-object-vector")
   check-true("", copy-sequence(#[#"a", #"b", #"c", #"d"]) = #[#"a", #"b", #"c", #"d"]);
 end test copy-sequence-5;
 
-define test copy-sequence-6 (description: "with start:")
+// with start:
+define test copy-sequence-6 ()
   check-true("", copy-sequence(#[#"a", #"b", #"c", #"d"], start: 1) = #[#"b", #"c", #"d"]);
 end test copy-sequence-6;
 
-define test copy-sequence-7 (description: "with end:")
+// with end:
+define test copy-sequence-7 ()
   check-true("", copy-sequence(#(#"a", #"b", #"c", #"d"), end: 3) = #(#"a", #"b", #"c"));
 end test copy-sequence-7;
 
-define test copy-sequence-8 (description: "with start: and end:")
+// with start: and end:
+define test copy-sequence-8 ()
   check-true("", copy-sequence("abcd", start: 1, end: 3) = "bc");
 end test copy-sequence-8;
 
-define test concatenate-as-type (description: "")
+define test concatenate-as-type ()
   check-true("", instance?(concatenate-as, <generic-function>));
 end test concatenate-as-type;
 
-define test concatenate-as-0 (description: "list")
+// list
+define test concatenate-as-0 ()
   let in-1 = list(1, 2, 3, 4, 5);
   let in-2 = list(6, 7, 8, 9, 10);
   let result = concatenate-as(<list>, in-1, in-2);
   check-true("", instance?(result, <list>) & result = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
 end test concatenate-as-0;
 
-define test concatenate-as-1 (description: "range")
+// range
+define test concatenate-as-1 ()
   let in-1 = range(from: 1, below: 6);
   let in-2 = range(from: 6, below: 11);
   let result = concatenate-as(<list>, in-1, in-2);
   check-true("", instance?(result, <list>) & result = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
 end test concatenate-as-1;
 
-define test concatenate-as-2 (description: "deque")
+// deque
+define test concatenate-as-2 ()
   begin
     let in-1 = list(1, 2, 3, 4, 5);
     let in-2 = list(6, 7, 8, 9, 10);
@@ -320,7 +359,8 @@ define test concatenate-as-2 (description: "deque")
     end;
 end test concatenate-as-2;
 
-define test concatenate-as-3 (description: "stretch-vector")
+// stretch-vector
+define test concatenate-as-3 ()
   begin
     let in-1 = list(1, 2, 3, 4, 5);
     let in-2 = list(6, 7, 8, 9, 10);
@@ -336,7 +376,8 @@ define test concatenate-as-3 (description: "stretch-vector")
     end;
 end test concatenate-as-3;
 
-define test concatenate-as-4 (description: "simple-object-vector")
+// simple-object-vector
+define test concatenate-as-4 ()
   begin
     let in-1 = list(1, 2, 3, 4, 5);
     let in-2 = list(6, 7, 8, 9, 10);
@@ -352,7 +393,8 @@ define test concatenate-as-4 (description: "simple-object-vector")
     end;
 end test concatenate-as-4;
 
-define test concatenate-as-5 (description: "more args")
+// more args
+define test concatenate-as-5 ()
   let in-1 = #(1, 2, 3, 4, 5);
   let in-2 = range(from: 6, below: 11);
   let in-3 = deque-instance(10, 9, 8, 7, 6);
@@ -363,46 +405,52 @@ define test concatenate-as-5 (description: "more args")
   check-true("", result = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1));
 end test concatenate-as-5;
 
-define test concatenate-type (description: "")
+define test concatenate-type ()
   check-true("", instance?(concatenate, <generic-function>));
 end test concatenate-type;
 
-define test concatenate-0 (description: "list")
+// list
+define test concatenate-0 ()
   let in-1 = list(1, 2, 3, 4, 5);
   let in-2 = list(6, 7, 8, 9, 10);
   let result = concatenate(in-1, in-2);
   check-true("", result = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
 end test concatenate-0;
 
-define test concatenate-1 (description: "range")
+// range
+define test concatenate-1 ()
   let in-1 = range(from: 1, below: 6);
   let in-2 = range(from: 6, below: 11);
   let result = concatenate(in-1, in-2);
   check-true("", result = range(from: 1, below: 11));
 end test concatenate-1;
 
-define test concatenate-2 (description: "deque")
+// deque
+define test concatenate-2 ()
   let in-1 = deque-instance(1, 2, 3, 4, 5);
   let in-2 = deque-instance(6, 7, 8, 9, 10);
   let result = concatenate(in-1, in-2);
   check-true("", result = deque-instance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
 end test concatenate-2;
 
-define test concatenate-3 (description: "stretch-vector")
+// stretch-vector
+define test concatenate-3 ()
   let in-1 = stretchy-vector-instance(1, 2, 3, 4, 5);
   let in-2 = stretchy-vector-instance(6, 7, 8, 9, 10);
   let result = concatenate(in-1, in-2);
   check-true("", result = stretchy-vector-instance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
 end test concatenate-3;
 
-define test concatenate-4 (description: "simple-object-vector")
+// simple-object-vector
+define test concatenate-4 ()
   let in-1 = vector(1, 2, 3, 4, 5);
   let in-2 = vector(6, 7, 8, 9, 10);
   let result = concatenate(in-1, in-2);
   check-true("", result = vector(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
 end test concatenate-4;
 
-define test concatenate-5 (description: "more args")
+// more args
+define test concatenate-5 ()
   let in-1 = #(1, 2, 3, 4, 5);
   let in-2 = range(from: 6, below: 11);
   let in-3 = deque-instance(10, 9, 8, 7, 6);

--- a/sources/dylan/apple-dylan-test-suite/test-sequence4.dylan
+++ b/sources/dylan/apple-dylan-test-suite/test-sequence4.dylan
@@ -8,53 +8,61 @@ Copyright: (c) 1993 Apple Computer, Inc.
 Modified by: Shri Amit(amit)
 Date: August 24 1996
 Summary: Converted to new testworks protocol
-Copyright: (c) 1996 Functional Objects, Inc. 
-           All rights reserved.  
+Copyright: (c) 1996 Functional Objects, Inc.
+           All rights reserved.
 ----------------------------------------------*/
 
-define test replace-subsequence!-type (description: "")
+define test replace-subsequence!-type ()
   check-true("", instance?(replace-subsequence!, <generic-function>));
 end test replace-subsequence!-type;
 
 // tests replace-subsequence!
 
-define test replace-subsequence!-0 (description: "list")
+// list
+define test replace-subsequence!-0 ()
   check-true("", replace-subsequence!(#(1, 2, 3, 4), #(99, 100, 101, 102))
   = #(99, 100, 101, 102));
 end test replace-subsequence!-0;
 
-define test replace-subsequence!-1 (description: "empty-list")
+// empty-list
+define test replace-subsequence!-1 ()
   check-true("", replace-subsequence!(#(1, 2, 3), #()) = #(1, 2, 3));
 end test replace-subsequence!-1;
 
-define test replace-subsequence!-2 (description: "deque")
+// deque
+define test replace-subsequence!-2 ()
   check-true("", replace-subsequence!
     (deque-instance(1, 3, 5, 7, 9), deque-instance(2, 4, 6, 8))
   = deque-instance(2, 4, 6, 8, 9));
 end test replace-subsequence!-2;
 
-define test replace-subsequence!-4 (description: "simple-object-vector")
+// simple-object-vector
+define test replace-subsequence!-4 ()
   check-true("", replace-subsequence!
     (vector(1, 3, 5, 7, 9),
      vector(2, 4, 6, 8))
   = vector(2, 4, 6, 8, 9));
 end test replace-subsequence!-4;
 
-define test replace-subsequence!-5 (description: "string")
+// string
+define test replace-subsequence!-5 ()
   check-true("", replace-subsequence!("I hate oatmeal", "like") = "likete oatmeal");
 end test replace-subsequence!-5;
 
-define test replace-subsequence!-6 (description: "start: arg")
+// start: arg
+define test replace-subsequence!-6 ()
   check-true("", replace-subsequence!("I hate oatmeal", "like", start: 2) = "I like oatmeal");
 end test replace-subsequence!-6;
 
-define test replace-subsequence!-7 (description: "overwrites seq")
+// overwrites seq
+define test replace-subsequence!-7 ()
   let phrase = "I hate oatmeal";
   let result = replace-subsequence!(phrase, "like", start: 2);
   check-true("", phrase == result);
 end test replace-subsequence!-7;
 
-define test replace-subsequence!-8 (description: "mixed cases")
+// mixed cases
+define test replace-subsequence!-8 ()
   check-true("", replace-subsequence!(#(1, 2, 3), "now") = #('n', 'o', 'w'));
   check-true("", replace-subsequence!(#(#"a", #"b", #"c", #"d"), range(from: 0, below: 4))
     = #(0, 1, 2, 3));
@@ -62,130 +70,154 @@ end test replace-subsequence!-8;
 
 // Design note #15 extends the definition of replace-subsequence!
 
-define test replace-subsequence!-9 (description: "end insertion at beginning")
+// end insertion at beginning
+define test replace-subsequence!-9 ()
   let abcde = list(#"a", #"b", #"c", #"d", #"e");
   abcde := replace-subsequence!(abcde, #(#"x", #"y", #"z"), end: 1);
   check-true("", abcde = #(#"x", #"y", #"z", #"b", #"c", #"d", #"e"));
 end test replace-subsequence!-9;
 
-define test replace-subsequence!-10 (description: "end")
+// end
+define test replace-subsequence!-10 ()
   let abcde = list(#"a", #"b", #"c", #"d", #"e");
   abcde := replace-subsequence!(abcde, #(#"x", #"y", #"z"), start: 2);
   check-true("", abcde = #(#"a", #"b", #"x", #"y", #"z"));
 end test replace-subsequence!-10;
 
-define test replace-subsequence!-11
-  (description: "insert into middle with start and end")
+// insert into middle with start and end
+define test replace-subsequence!-11 ()
   let abcde = list(#"a", #"b", #"c", #"d", #"e");
   abcde := replace-subsequence!(abcde, #(#"x", #"y", #"z"), start: 1, end: 3);
   check-true("", abcde = #(#"a", #"x", #"y", #"z", #"e"));
 end test replace-subsequence!-11;
 
-define test reverse-type (description: "")
+define test reverse-type ()
   check-true("", instance?(reverse, <generic-function>));
 end test reverse-type;
 
-define test reverse-0 (description: "list")
+// list
+define test reverse-0 ()
   check-true("", reverse(#(1, 2, 3, 4)) = #(4, 3, 2, 1));
 end test reverse-0;
 
-define test reverse-1 (description: "empty list")
+// empty list
+define test reverse-1 ()
   check-true("", reverse(#()) = #());
 end test reverse-1;
 
-define test reverse-2 (description: "range")
+// range
+define test reverse-2 ()
   check-true("", range(from: 0, below: 6).reverse = range(from: 5, below: -1, by: -1));
 end test reverse-2;
 
-define test reverse-3 (description: "deque")
+// deque
+define test reverse-3 ()
   check-true("", deque-instance(1, 2, 3, 4).reverse = deque-instance(4, 3, 2, 1));
 end test reverse-3;
 
-define test reverse-4 (description: "stretchy-vector")
+// stretchy-vector
+define test reverse-4 ()
   check-true("", stretchy-vector-instance(1, 2, 3, 4).reverse
   = stretchy-vector-instance(4, 3, 2, 1));
 end test reverse-4;
 
-define test reverse-5 (description: "simple-object-vector")
+// simple-object-vector
+define test reverse-5 ()
   check-true("", vector(1, 2, 3, 4).reverse
   = vector(4, 3, 2, 1));
 end test reverse-5;
 
-define test reverse-6 (description: "string")
+// string
+define test reverse-6 ()
   check-true("", reverse("milk") = "klim");
 end test reverse-6;
 
-define test reverse-7 (description: "returns new seq")
+// returns new seq
+define test reverse-7 ()
   let s = #(1, 2, 3);
   let result = s.reverse;
   check-true("", ~(s == result));
 end test reverse-7;
 
-define test reverse!-type (description: "")
+define test reverse!-type ()
   check-true("", instance?(reverse!, <generic-function>));
 end test reverse!-type;
 
-define test reverse!-0 (description: "list")
+// list
+define test reverse!-0 ()
   check-true("", reverse!(#(1, 2, 3, 4)) = #(4, 3, 2, 1));
 end test reverse!-0;
 
-define test reverse!-1 (description: "empty list")
+// empty list
+define test reverse!-1 ()
   check-true("", reverse!(#()) = #());
 end test reverse!-1;
 
-define test reverse!-2 (description: "range")
+// range
+define test reverse!-2 ()
   check-true("", reverse!(range(from: 0, below: 6)) = range(from: 5, below: -1, by: -1));
 end test reverse!-2;
 
-define test reverse!-3 (description: "deque")
+// deque
+define test reverse!-3 ()
   check-true("", reverse!(deque-instance(1, 2, 3, 4)) = deque-instance(4, 3, 2, 1));
 end test reverse!-3;
 
-define test reverse!-4 (description: "stretchy-vector")
+// stretchy-vector
+define test reverse!-4 ()
   check-true("", reverse!(stretchy-vector-instance(1, 2, 3, 4))
   = stretchy-vector-instance(4, 3, 2, 1));
 end test reverse!-4;
 
-define test reverse!-5 (description: "simple-object-vector")
+// simple-object-vector
+define test reverse!-5 ()
   check-true("", reverse!(vector(1, 2, 3, 4))
   = vector(4, 3, 2, 1));
 end test reverse!-5;
 
-define test reverse!-6 (description: "string")
+// string
+define test reverse!-6 ()
   check-true("", reverse("milk") = "klim");
 end test reverse!-6;
 
-define test sort-type (description: "")
+define test sort-type ()
   check-true("", instance?(sort, <generic-function>));
 end test sort-type;
 
-define test sort-0 (description: "list")
+// list
+define test sort-0 ()
   check-true("", sort(#(1, 9, 2, 8, 3, 7, 4, 6, 5)) = #(1, 2, 3, 4, 5, 6, 7, 8, 9));
 end test sort-0;
 
-define test sort-1 (description: "empty-list")
+// empty-list
+define test sort-1 ()
   check-true("", sort(#()) = #());
 end test sort-1;
 
-define test sort-2 (description: "range")
+// range
+define test sort-2 ()
   check-true("", range(from: 9, below: 0, by: -1).sort = #(1, 2, 3, 4, 5, 6, 7, 8, 9));
 end test sort-2;
 
-define test sort-3 (description: "deque")
+// deque
+define test sort-3 ()
   check-true("", deque-instance(1, 9, 2, 8, 3, 7, 4, 6, 5).sort = #(1, 2, 3, 4, 5, 6, 7, 8, 9));
 end test sort-3;
 
-define test sort-4 (description: "stretchy-vector")
+// stretchy-vector
+define test sort-4 ()
   check-true("", stretchy-vector-instance(1, 9, 2, 8, 3, 7, 4, 6, 5).sort
   = stretchy-vector-instance(1, 2, 3, 4, 5, 6, 7, 8, 9));
 end test sort-4;
 
-define test sort-5 (description: "simple-object-vector")
+// simple-object-vector
+define test sort-5 ()
   check-true("", vector(1, 9, 2, 8, 3, 7, 4, 6, 5).sort
   = vector(1, 2, 3, 4, 5, 6, 7, 8, 9));
 end test sort-5;
 
-define test sort-6 (description: "test")
+// test
+define test sort-6 ()
   check-true("", sort(#(1, 9, 2, 8, 3, 7, 4, 6, 5), test: \>) = #(9, 8, 7, 6, 5, 4, 3, 2, 1));
   check-true("", sort(#(#"a", #"b", #"c", #"d", #"c", #"b", #"a"),
          test: method (a, b)
@@ -199,7 +231,8 @@ define test sort-6 (description: "test")
     = #(#"b", #"b", #"a", #"c", #"d", #"c", #"a"));
 end test sort-6;
 
-define test sort-7 (description: "stability")
+// stability
+define test sort-7 ()
   check-true("", sort(#('z', 'Z', 'Y', 'y', 'x', 'X'),
        test: method (a, b)
                a.as-uppercase < b.as-uppercase
@@ -212,44 +245,52 @@ define test sort-7 (description: "stability")
     = #[#("Beach Boys", "I Get Around"), #("Beatles", "I Want to Hold Your Hand"), #("Carpenters", "Close to You"), #("Mozart", "Eine Kleine Nachtmusik", #(#"k", 525)), #("Rolling Stones", "Brown Sugar"), #("Tokens", "The Lion Sleeps Tonight")]);
 end test sort-7;
 
-define test sort-8 (description: "new seq")
+// new seq
+define test sort-8 ()
   let s = #(1, 2, 3, 4, 5, 6, 7, 8, 9);
   let result = s.sort;
   check-true("", s = result & ~(s == result));
 end test sort-8;
 
-define test sort!-type (description: "")
+define test sort!-type ()
   check-true("", instance?(sort!, <generic-function>));
 end test sort!-type;
 
-define test sort!-0 (description: "list")
+// list
+define test sort!-0 ()
   check-true("", sort!(#(1, 9, 2, 8, 3, 7, 4, 6, 5)) = #(1, 2, 3, 4, 5, 6, 7, 8, 9));
 end test sort!-0;
 
-define test sort!-1 (description: "empty-list")
+// empty-list
+define test sort!-1 ()
   check-true("", sort!(#()) = #());
 end test sort!-1;
 
-define test sort!-2 (description: "range")
+// range
+define test sort!-2 ()
   check-true("", sort!(range(from: 9, below: 0, by: -1)) = #(1, 2, 3, 4, 5, 6, 7, 8, 9));
 end test sort!-2;
 
-define test sort!-3 (description: "deque")
+// deque
+define test sort!-3 ()
   check-true("", sort!(deque-instance(1, 9, 2, 8, 3, 7, 4, 6, 5))
   = #(1, 2, 3, 4, 5, 6, 7, 8, 9));
 end test sort!-3;
 
-define test sort!-4 (description: "stretchy-vector")
+// stretchy-vector
+define test sort!-4 ()
   check-true("", sort!(stretchy-vector-instance(1, 9, 2, 8, 3, 7, 4, 6, 5))
   = stretchy-vector-instance(1, 2, 3, 4, 5, 6, 7, 8, 9));
 end test sort!-4;
 
-define test sort!-5 (description: "simple-object-vector")
+// simple-object-vector
+define test sort!-5 ()
   check-true("", sort!(vector(1, 9, 2, 8, 3, 7, 4, 6, 5))
   = vector(1, 2, 3, 4, 5, 6, 7, 8, 9));
 end test sort!-5;
 
-define test sort!-6 (description: "test")
+// test
+define test sort!-6 ()
   check-true("", sort!(#(1, 9, 2, 8, 3, 7, 4, 6, 5), test: \>) = #(9, 8, 7, 6, 5, 4, 3, 2, 1));
   check-true("", sort!(#(#"a", #"b", #"c", #"d", #"c", #"b", #"a"),
           test: method (a, b)
@@ -263,7 +304,8 @@ define test sort!-6 (description: "test")
     = #(#"b", #"b", #"a", #"c", #"d", #"c", #"a"));
 end test sort!-6;
 
-define test sort!-7 (description: "stability")
+// stability
+define test sort!-7 ()
   check-true("", sort!(#('z', 'Z', 'Y', 'y', 'x', 'X'),
         test: method (a, b)
                 a.as-uppercase < b.as-uppercase
@@ -276,11 +318,11 @@ define test sort!-7 (description: "stability")
     = #[#("Beach Boys", "I Get Around"), #("Beatles", "I Want to Hold Your Hand"), #("Carpenters", "Close to You"), #("Mozart", "Eine Kleine Nachtmusik", #(#"k", 525)), #("Rolling Stones", "Brown Sugar"), #("Tokens", "The Lion Sleeps Tonight")]);
 end test sort!-7;
 
-define test first-type (description: "")
+define test first-type ()
   check-true("", instance?(first, <generic-function>));
 end test first-type;
 
-define test first-0 (description: "simple cases")
+// simple cases
+define test first-0 ()
   check-true("", first(#(1, 2, 3, 4, 5)) = 1 & first(#(), default: #"no") = #"no");
 end test first-0;
-

--- a/sources/dylan/apple-dylan-test-suite/test-sequence5.dylan
+++ b/sources/dylan/apple-dylan-test-suite/test-sequence5.dylan
@@ -8,117 +8,138 @@ Copyright: (c) 1993 Apple Computer, Inc.
 Modified by: Shri Amit(amit)
 Date: August 24 1996
 Summary: Converted to new testworks protocol
-Copyright: (c) 1996 Functional Objects, Inc. 
-           All rights reserved.  
+Copyright: (c) 1996 Functional Objects, Inc.
+           All rights reserved.
 ----------------------------------------------*/
 
-define test first-1 (description: "dotted pair")
+// dotted pair
+define test first-1 ()
   check-true("", pair(#"a", #"b").first = #"a");
 end test first-1;
 
-define test first-2 (description: "range")
+// range
+define test first-2 ()
   check-true("", range(from: 0, below: 9).first = 0);
   check-true("", first(range(from: 0, below: 0), default: #"no") = #"no");
 end test first-2;
 
-define test first-3 (description: "deque")
+// deque
+define test first-3 ()
   check-true("", deque-instance(0, 1, 2, 3, 4).first = 0);
   check-true("", first(deque-instance(), default: #"no") = #"no");
 end test first-3;
 
-define test first-4 (description: "stretchy-vector")
+// stretchy-vector
+define test first-4 ()
   check-true("", stretchy-vector-instance(0, 1, 2, 3, 4).first = 0);
   check-true("", first(stretchy-vector-instance(), default: #"no") = #"no");
 end test first-4;
 
-define test first-5 (description: "simple-object-vector")
+// simple-object-vector
+define test first-5 ()
   check-true("", vector(0, 1, 2, 3, 4).first = 0);
   check-true("", first(vector(), default: #"no") = #"no");
 end test first-5;
 
-define test first-6 (description: "string")
+// string
+define test first-6 ()
   check-true("", first("abcde") = 'a' & first("", default: #"no") = #"no");
 end test first-6;
 
-define test second-type (description: "")
+define test second-type ()
   check-true("", instance?(second, <generic-function>));
 end test second-type;
 
-define test second-0 (description: "simple cases")
+// simple cases
+define test second-0 ()
   check-true("", second(#(1, 2, 3, 4, 5)) = 2 & second(#(), default: #"no") = #"no");
 end test second-0;
 
-define test second-1 (description: "dotted pair")
+// dotted pair
+define test second-1 ()
   check-true("", pair(#"a", pair(#"b", #"c")).second = #"b");
 end test second-1;
 
-define test second-2 (description: "range")
+// range
+define test second-2 ()
   check-true("", range(from: 0, below: 9).second = 1);
   check-true("", second(range(from: 0, below: 0), default: #"no") = #"no");
 end test second-2;
 
-define test second-3 (description: "deque")
+// deque
+define test second-3 ()
   check-true("", deque-instance(0, 1, 2, 3, 4).second = 1);
   check-true("", second(deque-instance(), default: #"no") = #"no");
 end test second-3;
 
-define test second-4 (description: "stretchy-vector")
+// stretchy-vector
+define test second-4 ()
   check-true("", stretchy-vector-instance(0, 1, 2, 3, 4).second = 1);
   check-true("", second(stretchy-vector-instance(), default: #"no") = #"no");
 end test second-4;
 
-define test second-5 (description: "simple-object-vector")
+// simple-object-vector
+define test second-5 ()
   check-true("", vector(0, 1, 2, 3, 4).second = 1);
   check-true("", second(vector(), default: #"no") = #"no");
 end test second-5;
 
-define test second-6 (description: "string")
+// string
+define test second-6 ()
   check-true("", second("abcde") = 'b' & second("", default: #"no") = #"no");
 end test second-6;
 
-define test third-type (description: "")
+define test third-type ()
   check-true("", instance?(third, <generic-function>));
 end test third-type;
 
-define test third-0 (description: "simple cases")
+// simple cases
+define test third-0 ()
   check-true("", third(#(1, 2, 3, 4, 5)) = 3 & third(#(), default: #"no") = #"no");
 end test third-0;
 
-define test third-1 (description: "dotted pair")
+// dotted pair
+define test third-1 ()
   check-true("", pair(#"a", pair(#"b", pair(#"c", #"d"))).third = #"c");
 end test third-1;
 
-define test third-2 (description: "range")
+// range
+define test third-2 ()
   check-true("", range(from: 0, below: 9).third = 2);
   check-true("", third(range(from: 0, below: 0), default: #"no") = #"no");
 end test third-2;
 
-define test third-3 (description: "deque")
+// deque
+define test third-3 ()
   check-true("", deque-instance(0, 1, 2, 3, 4).third = 2);
   check-true("", third(deque-instance(), default: #"no") = #"no");
 end test third-3;
 
-define test third-4 (description: "stretchy-vector")
+// stretchy-vector
+define test third-4 ()
   check-true("", stretchy-vector-instance(0, 1, 2, 3, 4).third = 2);
   check-true("", third(stretchy-vector-instance(), default: #"no") = #"no");
 end test third-4;
 
-define test third-5 (description: "simple-object-vector")
+// simple-object-vector
+define test third-5 ()
   check-true("", vector(0, 1, 2, 3, 4).third = 2);
   check-true("", third(vector(), default: #"no") = #"no");
 end test third-5;
 
-define test third-6 (description: "string")
+// string
+define test third-6 ()
   check-true("", third("abcde") = 'b' & third("", default: #"no") = #"no");
 end test third-6;
 
 // first-setter
 
-define test first-setter-type (description: "")
+define test first-setter-type ()
   check-true("", instance?(first-setter, <generic-function>));
 end test first-setter-type;
 
-define test first-setter-0 (description: "simple cases")
+// simple cases
+define test first-setter-0 ()
   check-true("", begin
     let t = #(3, 4, 5);
     first-setter(#(1, 2), t);
@@ -134,11 +155,12 @@ end test first-setter-0;
 
 // second-setter
 
-define test second-setter-type (description: "")
+define test second-setter-type ()
   check-true("", instance?(second-setter, <generic-function>));
 end test second-setter-type;
 
-define test second-setter-0 (description: "simple cases")
+// simple cases
+define test second-setter-0 ()
   check-true("", begin
     let t = #(3, 4, 5);
     second-setter(#(1, 2), t);
@@ -154,11 +176,12 @@ end test second-setter-0;
 
 // third-setter
 
-define test third-setter-type (description: "")
+define test third-setter-type ()
   check-true("", instance?(third-setter, <generic-function>));
 end test third-setter-type;
 
-define test third-setter-0 (description: "simple cases")
+// simple cases
+define test third-setter-0 ()
   check-true("", begin
     let t = #(3, 4, 5);
     third-setter(#(1, 2), t);
@@ -172,50 +195,58 @@ define test third-setter-0 (description: "simple cases")
     = #(1, 2, 0, 4, 5, 6, 7, 8, 9));
 end test third-setter-0;
 
-define test last-type (description: "")
+define test last-type ()
   check-true("", instance?(last, <generic-function>));
 end test last-type;
 
-define test last-0 (description: "list")
+// list
+define test last-0 ()
   check-true("", last(#(1, 2, 3, 4, 5)) = 5 & last(#(), default: #"no") = #"no");
 end test last-0;
 
-define test last-1 (description: "dotted pair")
+// dotted pair
+define test last-1 ()
   check-true("", pair(#"a", pair(#"b", pair(#"c", #"d"))).last = #"c");
 end test last-1;
 
-define test last-2 (description: "range")
+// range
+define test last-2 ()
   check-true("", range(from: 0, below: 9).last = 8);
   check-true("", last(range(from: 0, below: 0), default: #"no") = #"no");
 end test last-2;
 
-define test last-3 (description: "deque")
+// deque
+define test last-3 ()
   check-true("", deque-instance(0, 1, 2, 3, 4).last = 4);
   check-true("", last(deque-instance(), default: #"no") = #"no");
 end test last-3;
 
-define test last-4 (description: "stretchy-vector")
+// stretchy-vector
+define test last-4 ()
   check-true("", stretchy-vector-instance(0, 1, 2, 3, 4).last = 4);
   check-true("", last(stretchy-vector-instance(), default: #"no") = #"no");
 end test last-4;
 
-define test last-5 (description: "simple-object-vector")
+// simple-object-vector
+define test last-5 ()
   check-true("", vector(0, 1, 2, 3, 4).last = 4);
   check-true("", last(vector(), default: #"no") = #"no");
 end test last-5;
 
-define test last-6 (description: "string")
+// string
+define test last-6 ()
   check-true("", last("abcde") = 'e' & last("", default: #"no") = #"no");
 end test last-6;
 
 // Design note #11: add last-setter
 //
 
-define test last-setter-type (description: "")
+define test last-setter-type ()
   check-true("", instance?(last-setter, <generic-function>));
 end test last-setter-type;
 
-define test last-setter-0 (description: "simple cases")
+// simple cases
+define test last-setter-0 ()
   check-true("", begin
     let t = #(3, 4, 5);
     last-setter(#(1, 2), t);
@@ -229,41 +260,42 @@ define test last-setter-0 (description: "simple cases")
     = #(1, 2, 3, 4, 5, 6, 7, 8, -1));
 end test last-setter-0;
 
-define test last-setter-string (description: "")
+define test last-setter-string ()
   let s = byte-string-instance('g', 'l', 'u', 'e');
   s.last := 'b';
   check-true("", s = "glub");
 end test last-setter-string;
 
-define test last-setter-vector (description: "")
+define test last-setter-vector ()
   let v = vector(7, 8, 9);
   v.last := -1;
   check-true("", v = #[7, 8, -1]);
 end test last-setter-vector;
 
-define test last-setter-stretchy-vector (description: "")
+define test last-setter-stretchy-vector ()
   let v = stretchy-vector-instance(7, 8, 9);
   v.last := -1;
   check-true("", v = stretchy-vector-instance(7, 8, -1));
 end test last-setter-stretchy-vector;
 
-define test last-setter-simple-object-vector (description: "")
+define test last-setter-simple-object-vector ()
   let v = vector(7, 8, 9);
   v.last := -1;
   check-true("", v = vector(7, 8, -1));
 end test last-setter-simple-object-vector;
 
-define test last-setter-deque (description: "")
+define test last-setter-deque ()
   let d = deque-instance(7, 8, 9);
   d.last := -1;
   check-true("", d = deque-instance(7, 8, -1));
 end test last-setter-deque;
 
-define test subsequence-position-type (description: "")
+define test subsequence-position-type ()
   check-true("", instance?(subsequence-position, <generic-function>));
 end test subsequence-position-type;
 
-define test subsequence-position-0 (description: "list")
+// list
+define test subsequence-position-0 ()
   check-true("", subsequence-position
     (#(#"a", #"b", #"c", #"x", #"y", #"z"), #(#"c", #"x", #"y"))
   = 2);
@@ -272,36 +304,43 @@ define test subsequence-position-0 (description: "list")
     = #f);
 end test subsequence-position-0;
 
-define test subsequence-position-1 (description: "empty list")
+// empty list
+define test subsequence-position-1 ()
   check-true("", subsequence-position(#(), #(1, 2, 3, 4)) = #f);
 end test subsequence-position-1;
 
-define test subsequence-position-2 (description: "range")
+// range
+define test subsequence-position-2 ()
   check-true("", subsequence-position(range(from: 0, below: 6), range(from: 2, below: 5)) = 2);
 end test subsequence-position-2;
 
-define test subsequence-position-3 (description: "deque")
+// deque
+define test subsequence-position-3 ()
   check-true("", subsequence-position(deque-instance(0, 1, 2, 3, 4, 5), deque-instance(3, 4))
   = 3);
 end test subsequence-position-3;
 
-define test subsequence-position-4 (description: "stretchy-vector")
+// stretchy-vector
+define test subsequence-position-4 ()
   check-true("", subsequence-position
     (stretchy-vector-instance(0, 1, 2, 3, 4, 5),
      stretchy-vector-instance(3, 4))
   = 3);
 end test subsequence-position-4;
 
-define test subsequence-position-5 (description: "simple-object-vector")
+// simple-object-vector
+define test subsequence-position-5 ()
   check-equal("", 3, subsequence-position(vector(0, 1, 2, 3, 4, 5),
                                           vector(3, 4)));
 end test subsequence-position-5;
 
-define test subsequence-position-6 (description: "string")
+// string
+define test subsequence-position-6 ()
   check-equal("", 3, subsequence-position("my cat", "cat"));
 end test subsequence-position-6;
 
-define test subsequence-position-7 (description: "test:")
+// test:
+define test subsequence-position-7 ()
   check-equal("", 1, subsequence-position(#(2, 4, 6, 8),
                                           #(2, 3),
                                           test: method (a, b)
@@ -313,11 +352,13 @@ define test subsequence-position-7 (description: "test:")
   check-equal("", 3, subsequence-position(#(5, 4, 3, 2, 1), #(3), test: \<));
 end test subsequence-position-7;
 
-define test subsequence-position-8 (description: "count:")
+// count:
+define test subsequence-position-8 ()
   check-equal("", 10, subsequence-position("my cat concatenates", "cat", count: 2));
 end test subsequence-position-8;
 
-define test subsequence-position-9 (description: "count: and test:")
+// count: and test:
+define test subsequence-position-9 ()
   check-equal("", 4, subsequence-position(#(5, 4, 3, 2, 1, 0), #(4, 2), test: \<, count: 2));
 end test subsequence-position-9;
 

--- a/sources/io/tests/streams.dylan
+++ b/sources/io/tests/streams.dylan
@@ -777,7 +777,8 @@ define test test-position-alt-string-streams ()
   */
 end test;
 
-define test test-stretchy-stream (description: "<string-stream> stretchy vector tests")
+// <string-stream> stretchy vector tests
+define test test-stretchy-stream ()
   begin
     let sv = make(<stretchy-vector>);
     let s = make(<string-stream>, contents: sv, direction: #"output");

--- a/sources/lib/c-ffi/test/tests.dylan
+++ b/sources/lib/c-ffi/test/tests.dylan
@@ -219,7 +219,7 @@ end;
 
 
 /// try some things with a variable defined via define c-variable
-define test variable-address-test (description: "Variable Address Tests")
+define test variable-address-test ()
   check-equal("set c-address",
                (pointer-value($foos-address) := 1), 1);
   check-equal("c-address value", pointer-value($foos-address), 1);
@@ -233,7 +233,7 @@ end;
 
 /// try some C-struct in different ways
 /// Could always use some more tests here.
-define test c-struct-test (description: "C-Struct Tests")
+define test c-struct-test ()
   format-out("minimal-size: %s", size-of(<minimal>));
   check-equal("<minimal> struct size",
               struct-minimal-size(), size-of(<minimal>));
@@ -267,7 +267,7 @@ end;
 
 /// Try some C functions in some different ways.
 /// this could always use more tests.
-define test c-function-test (description: "C Function Tests")
+define test c-function-test ()
   format-out("Running c-function tests\n");
   for (i from 0 below (ash(1, 8 * size-of(<C-unsigned-char>)) - 2) by 17)
     check-equal("c-function unsigned char increment",
@@ -413,8 +413,7 @@ end;
 
 
 
-
-define test c-types-test (description: "C Types Tests")
+define test c-types-test ()
   format-out("Running c-types tests\n");
   /// check that all of these things are classes
   /// All of the names below are wrapped in '<c-` and '>`


### PR DESCRIPTION
It hasn't been supported for a long time.

Also removed trailing whitespace, mostly from apple-dylan-test-suite, while I was here.

Fixes #1165