### PR TITLE
Fix segfault with locator-name (Issue 1372)

### DIFF
--- a/sources/system/file-system/file-system.dylan
+++ b/sources/system/file-system/file-system.dylan
@@ -502,9 +502,7 @@ define sideways method list-locator
        let sublocator
          = select (type)
              #"file", #"link" =>
-               make(<file-system-file-locator>,
-                    directory: locator,
-                    name:      name);
+               merge-locators(as(<file-locator>, name), locator);
              #"directory" =>
                subdirectory-locator(locator, name);
            end;

--- a/sources/system/tests/locators.dylan
+++ b/sources/system/tests/locators.dylan
@@ -248,7 +248,25 @@ define test test-supports-list-locator? ()
 end test;
 
 define test test-list-locator ()
-  // Fill this in.
+  // Create some structure
+  let root = test-temp-directory();
+  let dir1 = create-directory(root, "dir1");
+  let file1 = merge-locators(as(<file-locator>, "file1"), root);
+  let file2 = merge-locators(as(<file-locator>, "file2"), dir1);
+  // Just need to touch the files, no need to write anything
+  close(open-locator(file1, direction: #"output"));
+  close(open-locator(file2, direction: #"output"));
+  // test it.
+  let entries = list-locator(root);
+  assert-equal(2, size(entries));
+  let found-file = any?(method(x)
+                            instance?(x, <file-locator>) & x
+                        end, entries);
+  let found-dir = any?(method(x)
+                           instance?(x, <directory-locator>) & x
+                       end, entries);
+  assert-equal(locator-name(file1), found-file & locator-name(found-file));
+  assert-equal(locator-name(dir1), found-dir & locator-name(found-dir));
 end test;
 
 define test test-locator-host ()


### PR DESCRIPTION
Fix behaviour of `list-locator`. For file entries it was returning a direct instance of `<file-system-file-locator>` which is difficult to work with, because it doesn't have specializations for methods such as `locator-name`. The new code returns classes based on the locator parameter, so, for example, calling it with a `<posix-directory-locator>` will return a sequence of `<posix-file-locator>`s and `<posix-directory-locator>`s.
Fixes #1372 