### PR TITLE
Minor patches

### DIFF
--- a/sources/dylan/dfmc-boot.dylan
+++ b/sources/dylan/dfmc-boot.dylan
@@ -6,4 +6,7 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
+// If you got here via the IDE's "jump to definition" feature it means that the
+// definition is implemented in the compiler.
+
 boot-dylan-definitions();

--- a/sources/environment/dfmc/projects/projects.dylan
+++ b/sources/environment/dfmc/projects/projects.dylan
@@ -560,7 +560,7 @@ define sealed method link-project
                      mode:        if (unify?) #"combine" end,
                      target-type: target,
                      build-script: build-script | default-build-script(),
-                     jobs:        jobs,
+                     jobs:        jobs | 1,
                      release?:    release?)
       end
     cleanup


### PR DESCRIPTION
Using `M-.` on things like `<integer>` lands you in dfmc-boot.dylan and hopefully the comment will clarify what's going on for unsuspecting lsp-dylan users.

