### PR TITLE
doc: add intersphinx_mapping to Library Reference

### DIFF
--- a/documentation/building-with-duim/source/conf.py
+++ b/documentation/building-with-duim/source/conf.py
@@ -13,21 +13,19 @@
 
 import sys, os
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
+# Shared settings. They may be overridden later in this file.
 sys.path.insert(0, os.path.abspath('../../sphinx-extensions/sphinxcontrib'))
-
 import dylan.themes as dylan_themes
+
+# Shared settings. They may be overridden later in this file.
+sys.path.insert(0, os.path.abspath('../..'))
+from shared_sphinx_config import *
+
 
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
-
-# Add any Sphinx extension module names here, as strings. They can be extensions
-# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['dylan.domain']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/documentation/corba-guide/source/conf.py
+++ b/documentation/corba-guide/source/conf.py
@@ -13,21 +13,18 @@
 
 import sys, os
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('../../sphinx-extensions/sphinxcontrib'))
-
 import dylan.themes as dylan_themes
+
+# Shared settings. They may be overridden later in this file.
+sys.path.insert(0, os.path.abspath('../..'))
+from shared_sphinx_config import *
+
 
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
-
-# Add any Sphinx extension module names here, as strings. They can be extensions
-# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['dylan.domain']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/documentation/duim-reference/source/conf.py
+++ b/documentation/duim-reference/source/conf.py
@@ -13,21 +13,18 @@
 
 import sys, os
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('../../sphinx-extensions/sphinxcontrib'))
-
 import dylan.themes as dylan_themes
+
+# Shared settings. They may be overridden later in this file.
+sys.path.insert(0, os.path.abspath('../..'))
+from shared_sphinx_config import *
+
 
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
-
-# Add any Sphinx extension module names here, as strings. They can be extensions
-# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['dylan.domain']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/documentation/getting-started-cli/source/conf.py
+++ b/documentation/getting-started-cli/source/conf.py
@@ -13,21 +13,18 @@
 
 import sys, os
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('../../sphinx-extensions/sphinxcontrib'))
-
 import dylan.themes as dylan_themes
+
+# Shared settings. They may be overridden later in this file.
+sys.path.insert(0, os.path.abspath('../..'))
+from shared_sphinx_config import *
+
 
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
-
-# Add any Sphinx extension module names here, as strings. They can be extensions
-# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['dylan.domain']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/documentation/getting-started-cli/source/platform-specific.rst
+++ b/documentation/getting-started-cli/source/platform-specific.rst
@@ -13,9 +13,7 @@ https://github.com/dylan-lang/opendylan/tree/master/sources/system/.
 LID File
 --------
 
-For further details of the LID file format, see `LID file`_.
-
-.. _LID file: https://opendylan.org/documentation/library-reference/lid.html
+For further details of the LID file format, see :doc:`library-reference:lid`.
 
 1) Library
 

--- a/documentation/getting-started-ide/source/conf.py
+++ b/documentation/getting-started-ide/source/conf.py
@@ -13,21 +13,18 @@
 
 import sys, os
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('../../sphinx-extensions/sphinxcontrib'))
-
 import dylan.themes as dylan_themes
+
+# Shared settings. They may be overridden later in this file.
+sys.path.insert(0, os.path.abspath('../..'))
+from shared_sphinx_config import *
+
 
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
-
-# Add any Sphinx extension module names here, as strings. They can be extensions
-# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['dylan.domain']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/documentation/hacker-guide/source/conf.py
+++ b/documentation/hacker-guide/source/conf.py
@@ -13,21 +13,18 @@
 
 import sys, os
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('../../sphinx-extensions/sphinxcontrib'))
-
 import dylan.themes as dylan_themes
+
+# Shared settings. They may be overridden later in this file.
+sys.path.insert(0, os.path.abspath('../..'))
+from shared_sphinx_config import *
+
 
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
-
-# Add any Sphinx extension module names here, as strings. They can be extensions
-# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['dylan.domain']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/documentation/intro-dylan/source/conf.py
+++ b/documentation/intro-dylan/source/conf.py
@@ -13,21 +13,18 @@
 
 import sys, os
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('../../sphinx-extensions/sphinxcontrib'))
-
 import dylan.themes as dylan_themes
+
+# Shared settings. They may be overridden later in this file.
+sys.path.insert(0, os.path.abspath('../..'))
+from shared_sphinx_config import *
+
 
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
-
-# Add any Sphinx extension module names here, as strings. They can be extensions
-# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.todo', 'dylan.domain']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/documentation/library-reference/Makefile
+++ b/documentation/library-reference/Makefile
@@ -42,7 +42,7 @@ clean:
 	-rm -rf $(BUILDDIR)/*
 
 html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -b html -v $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/documentation/library-reference/source/conf.py
+++ b/documentation/library-reference/source/conf.py
@@ -13,21 +13,18 @@
 
 import sys, os
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('../../sphinx-extensions/sphinxcontrib'))
-
 import dylan.themes as dylan_themes
+
+# Shared settings. They may be overridden later in this file.
+sys.path.insert(0, os.path.abspath('../..'))
+from shared_sphinx_config import *
+
 
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
-
-# Add any Sphinx extension module names here, as strings. They can be extensions
-# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['dylan.domain']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -58,7 +55,8 @@ release = '1.0'
 # for a list of supported languages.
 #language = None
 
-# The primary domain.
+# The primary domain. Specifying this means (for example) that rather than
+# writing :dylan:func:`foo` we can just write :func:`foo`.
 primary_domain = 'dylan'
 
 # There are two options for replacing |today|: either, you set today to some
@@ -71,7 +69,10 @@ primary_domain = 'dylan'
 # directories to ignore when looking for source files.
 exclude_patterns = []
 
-# The reST default role (used for this markup: `text`) to use for all documents.
+# The reST default role (used for this markup: `text`) to use for all
+# documents.  (We could set this to 'func', for example, to make `foo`
+# equivalent to :func:`foo`. --cgay)
+
 #default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.

--- a/documentation/man-pages/source/conf.py
+++ b/documentation/man-pages/source/conf.py
@@ -13,12 +13,13 @@
 
 import sys, os
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('../../sphinx-extensions/sphinxcontrib'))
-
 import dylan.themes as dylan_themes
+
+# Shared settings. They may be overridden later in this file.
+sys.path.insert(0, os.path.abspath('../..'))
+from shared_sphinx_config import *
+
 
 # -- General configuration -----------------------------------------------------
 

--- a/documentation/release-notes/source/conf.py
+++ b/documentation/release-notes/source/conf.py
@@ -13,21 +13,18 @@
 
 import sys, os
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('../../sphinx-extensions/sphinxcontrib'))
-
 import dylan.themes as dylan_themes
+
+# Shared settings. They may be overridden later in this file.
+sys.path.insert(0, os.path.abspath('../..'))
+from shared_sphinx_config import *
+
 
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
-
-# Add any Sphinx extension module names here, as strings. They can be extensions
-# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['dylan.domain']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/documentation/shared_sphinx_config.py
+++ b/documentation/shared_sphinx_config.py
@@ -1,0 +1,56 @@
+# Sphinx configuration shared by all Dylan docs.
+
+# This file is imported by each Sphinx conf.py, usually with "from ... import *",
+# so remember to use leading underscore for _private variables.
+
+# Add any Sphinx extension module names here, as strings. They can be extensions
+# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
+extensions = [
+    'dylan.domain',
+    'sphinx.ext.intersphinx'    # eases linking to other document sets.
+]
+
+# For any key in this map you can link to objects in the corresponding document
+# using syntax like :func:`http:add-resource` or
+# :doc:`building-with-duim:intro` where "http" and "building-with-duim" are
+# keys in the map. HOWEVER, I (cgay) have not been able to get :class: links to
+# work. Maybe something to do with the < and > characters? Needs investigation,
+# but SOME working links are better than none. I have verified that :func: and
+# :var: refs work.
+#
+# Note: use `python -m sphinx.ext.intersphinx
+# https://opendylan.org/documentation/http/objects.inv` (for example) to print
+# a list of targets in one of these mappings. Useful for debugging.
+#
+intersphinx_mapping = {
+    'building-with-duim': (
+        'https://opendylan.org/documentation/building-with-duim/', None),
+    'corba': (
+        'https://opendylan.org/documentation/corba-guide/', None),
+    'duim': (
+        'https://opendylan.org/documentation/duim-reference/', None),
+    'getting-started-cli': (
+        'https://opendylan.org/documentation/getting-started-cli/', None),
+    'getting-started-ide': (
+        'https://opendylan.org/documentation/getting-started-ide/', None),
+    'hacker-guide': (
+        'https://opendylan.org/documentation/hacker-guide/', None),
+    'intro-dylan': (
+        'https://opendylan.org/documentation/intro-dylan/', None),
+    'library-reference': (
+        'https://opendylan.org/documentation/library-reference/', None),
+    'release-notes': (
+        'https://opendylan.org/documentation/release-notes/', None),
+    'style-guide': (
+        'https://opendylan.org/documentation/style-guide/', None),
+
+    # So-called "external libraries"
+    'binary-data': ('https://opendylan.org/documentation/binary-data/', None),
+    'concurrency': ('https://opendylan.org/documentation/concurrency/', None),
+    'http': ('https://opendylan.org/documentation/http/', None),
+    'melange': ('https://opendylan.org/documentation/melange/', None),
+    'objc-dylan': ('https://opendylan.org/documentation/objc-dylan/', None),
+    'statistics': ('https://opendylan.org/documentation/statistics/', None),
+    'testworks': ('https://opendylan.org/documentation/testworks/', None),
+    'tracing': ('https://opendylan.org/documentation/tracing/', None)
+}

--- a/documentation/style-guide/source/conf.py
+++ b/documentation/style-guide/source/conf.py
@@ -13,21 +13,18 @@
 
 import sys, os
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('../../sphinx-extensions/sphinxcontrib'))
-
 import dylan.themes as dylan_themes
+
+# Shared settings. They may be overridden later in this file.
+sys.path.insert(0, os.path.abspath('../..'))
+from shared_sphinx_config import *
+
 
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
-
-# Add any Sphinx extension module names here, as strings. They can be extensions
-# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['dylan.domain']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
Enables linking between independently built documents like the Hacker Guide and the Testworks docs with syntax like this:

```
:func:`library-reference:*standard-output*`
```

I added a couple of such references in this commit as proof of concept. There are some mysteries remaining to be solved, such as why this doesn't work:

```
:class:`library-reference:<bit-set>`
```

Rather than repeat the `intersphinx_mapping` configuration in each document I factored it out into `shared_sphinx_config.py` and load that with `... import *` in each document's `conf.py`, along with the `extensions` setting. (More configs could be moved into the shared config file over time.)