### PR TITLE
Update TLS support

### DIFF
--- a/sources/lib/ssl/c-wrapper.dylan
+++ b/sources/lib/ssl/c-wrapper.dylan
@@ -103,49 +103,19 @@ end;
 //hope that I can treat this as opaque
 define constant <SSL-METHOD> = <C-void*>;
 
-define C-function SSLv2-method
+define C-function TLS-method
   result ssl-method :: <SSL-METHOD>;
-  c-name: "SSLv2_method"
+  c-name: "TLS_method"
 end;
 
-define C-function SSLv2-server-method
+define C-function TLS-server-method
   result ssl-method :: <SSL-METHOD>;
-  c-name: "SSLv2_server_method"
+  c-name: "TLS_server_method"
 end;
 
-define C-function SSLv2-client-method
+define C-function TLS-client-method
   result ssl-method :: <SSL-METHOD>;
-  c-name: "SSLv2_client_method"
-end;
-
-define C-function SSLv3-method
-  result ssl-method :: <SSL-METHOD>;
-  c-name: "SSLv3_method"
-end;
-
-define C-function SSLv3-server-method
-  result ssl-method :: <SSL-METHOD>;
-  c-name: "SSLv3_server_method"
-end;
-
-define C-function SSLv3-client-method
-  result ssl-method :: <SSL-METHOD>;
-  c-name: "SSLv3_client_method"
-end;
-
-define C-function SSLv23-method
-  result ssl-method :: <SSL-METHOD>;
-  c-name: "SSLv23_method"
-end;
-
-define C-function SSLv23-server-method
-  result ssl-method :: <SSL-METHOD>;
-  c-name: "SSLv23_server_method"
-end;
-
-define C-function SSLv23-client-method
-  result ssl-method :: <SSL-METHOD>;
-  c-name: "SSLv23_client_method"
+  c-name: "TLS_client_method"
 end;
 
 define C-function TLSv1-method
@@ -161,6 +131,36 @@ end;
 define C-function TLSv1-client-method
   result ssl-method :: <SSL-METHOD>;
   c-name: "TLSv1_client_method"
+end;
+
+define C-function TLSv1-1-method
+  result ssl-method :: <SSL-METHOD>;
+  c-name: "TLSv1_1_method"
+end;
+
+define C-function TLSv1-1-server-method
+  result ssl-method :: <SSL-METHOD>;
+  c-name: "TLSv1_1_server_method"
+end;
+
+define C-function TLSv1-1-client-method
+  result ssl-method :: <SSL-METHOD>;
+  c-name: "TLSv1_1_client_method"
+end;
+
+define C-function TLSv1-2-method
+  result ssl-method :: <SSL-METHOD>;
+  c-name: "TLSv1_2_method"
+end;
+
+define C-function TLSv1-2-server-method
+  result ssl-method :: <SSL-METHOD>;
+  c-name: "TLSv1_2_server_method"
+end;
+
+define C-function TLSv1-2-client-method
+  result ssl-method :: <SSL-METHOD>;
+  c-name: "TLSv1_2_client_method"
 end;
 
 //opaque!?

--- a/sources/lib/ssl/c-wrapper.dylan
+++ b/sources/lib/ssl/c-wrapper.dylan
@@ -248,3 +248,10 @@ define C-function SSL-context-add-extra-chain-certificate
   result res :: <C-long>;
   c-name: "my_SSL_CTX_add_extra_chain_cert"
 end;
+
+define C-function SSL-set-tlsext-host-name
+  input parameter context :: <SSL-CTX>;
+  input parameter name :: <C-string>;
+  result res :: <C-int>;
+  c-name: "my_SSL_set_tlsext_host_name"
+end;

--- a/sources/lib/ssl/library.dylan
+++ b/sources/lib/ssl/library.dylan
@@ -46,7 +46,8 @@ define module openssl-wrapper
     $SSL-ERROR-WANT-WRITE, $SSL-ERROR-WANT-X509-LOOKUP, $SSL-ERROR-SYSCALL,
     $SSL-ERROR-ZERO-RETURN, $SSL-ERROR-WANT-CONNECT, $SSL-ERROR-WANT-ACCEPT;
 
-  export SSL-set-mode, PEM-read-X509, SSL-context-add-extra-chain-certificate;
+  export SSL-set-mode, PEM-read-X509,
+    SSL-context-add-extra-chain-certificate, SSL-set-tlsext-host-name;
 end;
 
 define module ssl-sockets

--- a/sources/lib/ssl/library.dylan
+++ b/sources/lib/ssl/library.dylan
@@ -30,10 +30,10 @@ define module openssl-wrapper
 
   export ERR-get-error, ERR-error-string;
 
-  export SSLv2-method, SSLv2-server-method, SSLv2-client-method,
-    SSLv3-method, SSLv3-server-method, SSLv3-client-method,
-    SSLv23-method, SSLv23-server-method, SSLv23-client-method,
-    TLSv1-method, TLSv1-server-method, TLSv1-client-method;
+  export TLS-method, TLS-server-method, TLS-client-method,
+    TLSv1-method, TLSv1-server-method, TLSv1-client-method,
+    TLSv1-1-method, TLSv1-1-server-method, TLSv1-1-client-method,
+    TLSv1-2-method, TLSv1-2-server-method, TLSv1-2-client-method;
 
   export <SSL-CTX>, SSL-context-new, SSL-context-free, SSL-free,
     SSL-context-use-certificate-file, SSL-context-use-private-key-file;

--- a/sources/lib/ssl/openssl-wrapper.dylan
+++ b/sources/lib/ssl/openssl-wrapper.dylan
@@ -157,6 +157,8 @@ define method initialize (sock :: <ssl-socket>, #rest rest, #key lower, requeste
     if (null-pointer?(ssl))
       ERR-error();
     end;
+    // always set SNI
+    SSL-set-tlsext-host-name(ssl, host-name(remote-host(sock)));
     sock.accessor.socket-descriptor := ssl;
     let r = SSL-set-fd(ssl, lower.accessor.socket-descriptor);
     if (r ~= 1)

--- a/sources/lib/ssl/openssl-wrapper.dylan
+++ b/sources/lib/ssl/openssl-wrapper.dylan
@@ -134,7 +134,7 @@ end;
 define class <err-error> (<ssl-failure>)
 end;
 
-define method initialize (sock :: <ssl-socket>, #rest rest, #key lower, requested-buffer-size, acc?, ssl-method = #"SSLv23", #all-keys)
+define method initialize (sock :: <ssl-socket>, #rest rest, #key lower, requested-buffer-size, acc?, ssl-method = #"TLS", #all-keys)
  => ()
   let keys = list(#"port", lower.remote-port,
                   #"host", lower.remote-host,
@@ -143,9 +143,10 @@ define method initialize (sock :: <ssl-socket>, #rest rest, #key lower, requeste
   unless (acc?) //not a server socket via accept
     //already setup a connection! do SSL handshake over this connection
     let con = select (ssl-method)
-                #"SSLv23" => SSLv23-client-method;
-                #"SSLv2" => SSLv2-client-method;
+                #"TLS" => TLS-client-method;
                 #"TLSv1" => TLSv1-client-method;
+                #"TLSv1.1" => TLSv1-1-client-method;
+                #"TLSv1.2" => TLSv1-2-client-method;
               end;
     let ctx = SSL-context-new(con());
     if (null-pointer?(ctx))
@@ -183,12 +184,13 @@ define class <unix-ssl-socket-accessor> (<unix-socket-accessor>)
 end;
 
 define method initialize (s :: <ssl-server-socket>, #rest rest,
-                          #key ssl-method = #"SSLv23", certificate, key, certificate-chain, #all-keys)
+                          #key ssl-method = #"TLS", certificate, key, certificate-chain, #all-keys)
  => ()
   let con = select (ssl-method)
-              #"SSLv23" => SSLv23-server-method;
-              #"SSLv2" => SSLv2-server-method;
+              #"TLS" => TLS-server-method;
               #"TLSv1" => TLSv1-server-method;
+              #"TLSv1.1" => TLSv1-1-server-method;
+              #"TLSv1.2" => TLSv1-2-server-method;
 	    end;
   let ctx = SSL-context-new(con());
   if (null-pointer?(ctx))

--- a/sources/lib/ssl/support.c
+++ b/sources/lib/ssl/support.c
@@ -26,3 +26,7 @@ X509* my_PEM_read_X509 (char* filename, X509** x, pem_password_cb* cb, void* u) 
 long my_SSL_CTX_add_extra_chain_cert (SSL_CTX* ctx, X509* x509) {
   return SSL_CTX_add_extra_chain_cert(ctx, x509);
 }
+
+int my_SSL_set_tlsext_host_name(SSL_CTX* ctx, char* name) {
+  return SSL_set_tlsext_host_name(ctx, name);
+}

--- a/sources/network/sockets/internet-address.dylan
+++ b/sources/network/sockets/internet-address.dylan
@@ -157,6 +157,9 @@ define method initialize
     // Ignore all of the other initializers, if any, use the
     // information from the network.  Nyah-nyah.
     accessor-get-host-by-name(new-address, initialization-name);
+    // Darwin's get-host-by-name could resolved h-name to CDN host name
+    // instead of just copied the initialization-name
+    new-address.%host-name := initialization-name;
   else
     error("make(<ipv4-address>: address: or name: keyword must be supplied.");
   end if;


### PR DESCRIPTION
Hi,

A few weeks ago I was trying to use Dylan for a 3rd party api validation program by hacking the `http` module for https support [here](https://github.com/phongphan/http/commit/ac2a98bc5994d6e8b16cb87cde239c6533faaa9b).

But since the target is behind some sort of the CDN, I have to update the  `network` and `ssl` packages as described below. 
* Update ssl module for openssl@1.1 or libressl
* Add SNI support to the client ssl
* Patch the network module to always return the `initialization-name` for `new-address.%hostname`.
  * The `gethostbyname` on macOS seems to resolve the h-name to CDN host name. Eg. `www.microsoft.com` was resolved to `e13678.dscb.akamaiedge.net` which is not usable for the SNI above.

At least I hope it would be useful for the future update. Or any suggestion that would convert them to a proper patch would be appreciated :)