### PR TITLE
ssl: Update openssl-1.1 compatibility

### DIFF
--- a/sources/lib/ssl/c-wrapper.dylan
+++ b/sources/lib/ssl/c-wrapper.dylan
@@ -8,12 +8,12 @@ Warranty:  Distributed WITHOUT WARRANTY OF ANY KIND
 
 define C-function SSL-library-init
   result success :: <C-int>;
-  c-name: "SSL_library_init"
+  c-name: "my_SSL_library_init"
 end;
 
 define C-function SSL-load-error-strings
   result res :: <C-void*>;
-  c-name: "SSL_load_error_strings"
+  c-name: "my_SSL_load_error_strings"
 end;
 
 define C-function ERR-load-BIO-strings

--- a/sources/lib/ssl/support.c
+++ b/sources/lib/ssl/support.c
@@ -30,3 +30,11 @@ long my_SSL_CTX_add_extra_chain_cert (SSL_CTX* ctx, X509* x509) {
 int my_SSL_set_tlsext_host_name(SSL_CTX* ctx, char* name) {
   return SSL_set_tlsext_host_name(ctx, name);
 }
+
+int my_SSL_library_init() {
+  return SSL_library_init();
+}
+
+void my_SSL_load_error_strings() {
+  SSL_load_error_strings();
+}


### PR DESCRIPTION
Hi,

OpenSSL-1.1 deprecates `SSL_library_init` and `SSL_load_error_strings` and doesn't build anymore for their 1.1.1l.

Seems like the last time I was mistakenly build against the libressl instead of the openssl-1.1.