### PR TITLE
DFMC Improved source-location tracking

### DIFF
--- a/documentation/release-notes/source/2021.1.rst
+++ b/documentation/release-notes/source/2021.1.rst
@@ -23,6 +23,9 @@ Compiler
 * Improved support for code generation of ``apply`` calls to known
   methods.
 
+* Improved source line tracking in the generated code, reducing the
+  occurence of code marked as being at line 0 by the debugger.
+
 Run-time
 ========
 

--- a/sources/dfmc/conversion/convert.dylan
+++ b/sources/dfmc/conversion/convert.dylan
@@ -3220,8 +3220,6 @@ define function convert-method-to-model-as
   let (sig-spec, body) = parse-method-signature(name, form);
   let signature
     = compute-signature(#f, sig-spec);
-  let body
-    = as-body(body);
   let model
     = compute-method-explicitly
         (class, #f, name, sig-spec, body);

--- a/sources/dfmc/conversion/define-method.dylan
+++ b/sources/dfmc/conversion/define-method.dylan
@@ -160,10 +160,15 @@ define method compute-method-explicitly
     (method-class :: <class>,
      form, name, signature-spec, body-spec,
      #rest options, #key, #all-keys)
-      => (model :: <&method>)
+ => (model :: <&method>);
+  let source-location
+    = (form & form.form-source-location)
+    | (body-spec & body-spec.fragment-source-location)
+    | parent-source-location();
   apply(^make,
         method-class,
         definition: form,
+        source-location: source-location,
         body-spec: body-spec,
         // debug-name:
         //   ~form & name & mapped-model(as-lowercase(as(<string>, name))),
@@ -367,7 +372,7 @@ end method;
 
 define method compute-and-install-method-dfm
     (method-object :: <&lambda>) => ()
-  with-parent-source-location (model-source-location(method-object))
+  with-parent-source-location (lambda-source-location(method-object))
     let body = compute-method-body(method-object);
     if (body)
       convert-lambda-into*($top-level-environment, method-object, body);

--- a/sources/dfmc/conversion/define-method.dylan
+++ b/sources/dfmc/conversion/define-method.dylan
@@ -273,7 +273,9 @@ define method maybe-compute-and-install-method-dfm (m :: <&lambda>) => ()
       ("Skip generating DFM for this method",
        "Retry generating DFM for this method")
       with-dependent-context($compilation of model-creator(m))
-        compute-and-install-method-dfm(m);
+        with-parent-source-location (lambda-source-location(m))
+          compute-and-install-method-dfm(m);
+        end;
       end;
     end;
   end unless;

--- a/sources/dfmc/conversion/top-level-init-form.dylan
+++ b/sources/dfmc/conversion/top-level-init-form.dylan
@@ -5,14 +5,16 @@ License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define compiler-sideways method compute-and-install-form-model-objects
-    (form :: <top-level-init-form>) => ()
-  let init-model
-    = if (*interactive-compilation-layer*)
-        convert-top-level-initializer-for-values(form-body(form));
-      else
-        convert-top-level-initializer(form-body(form));
-      end;
-  form-init-method(form) := init-model;
+    (form :: <top-level-init-form>) => ();
+  with-parent-source-location (form-source-location(form))
+    let init-model
+      = if (*interactive-compilation-layer*)
+          convert-top-level-initializer-for-values(form-body(form));
+        else
+          convert-top-level-initializer(form-body(form));
+        end;
+    form-init-method(form) := init-model;
+  end;
 end method;
 
 define method convert-top-level-initializer-for-values

--- a/sources/dfmc/harp-cg/harp-main.dylan
+++ b/sources/dfmc/harp-cg/harp-main.dylan
@@ -178,13 +178,12 @@ define sideways method dummy-harp-source-locator?(locator :: <compiler-range-sou
 end method;
 
 define function find-a-source-location(o :: <&iep>)
-
   if (o.function.model-has-definition?)
     o.function.model-source-location
   else
-    make-dummy-source-locator(model-compilation-record(o));
-  end if;
-
+    o.function.lambda-source-location
+      | make-dummy-source-locator(model-compilation-record(o))
+  end if
 end function;
 
 /// EMIT

--- a/sources/dfmc/llvm-back-end/llvm-emit-debug.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-emit-debug.dylan
@@ -39,7 +39,7 @@ define method llvm-lambda-dbg-function
         let sig-spec = signature-spec(fun);
 
         // Compute the source location
-        let loc = fun.model-source-location;
+        let loc = fun.lambda-source-location;
         let (dbg-file, dbg-line, dbg-column)
           = if (instance?(loc, <source-location>))
               source-location-dbg-loc(back-end, loc)
@@ -108,7 +108,7 @@ define method emit-lambda-dbg-function
   let dbg-function = llvm-lambda-dbg-function(back-end, fun);
 
   // Compute the source location
-  let loc = fun.model-source-location;
+  let loc = fun.lambda-source-location;
   let (dbg-file, dbg-line, dbg-column)
     = if (instance?(loc, <source-location>))
         source-location-dbg-loc(back-end, loc)

--- a/sources/dfmc/management/back-end-driver.dylan
+++ b/sources/dfmc/management/back-end-driver.dylan
@@ -237,18 +237,6 @@ define method maybe-collect-and-dump-call-sites-from
   maybe-dump-call-sites(ld, call-sites);
 end method;
 
-define function lambda-source-location (object :: <&lambda>) => (loc)
-  let body-spec = body-spec(object);
-  let body      = body(object);
-  if (body-spec)
-    body-spec.fragment-source-location
-  elseif (body)
-    computation-source-location(body)
-  else
-    #f
-  end if;
-end function;
-
 define function find-a-source-location(o :: <&lambda>) => (res)
   if (model-has-definition?(o))
     o.model-source-location

--- a/sources/dfmc/modeling/functions.dylan
+++ b/sources/dfmc/modeling/functions.dylan
@@ -289,6 +289,8 @@ define primary &class <lambda> (<method>)
     init-keyword: compiler-debug-name:;
   // Compile-time slots.
   slot function-properties :: <integer> = 0;
+  lazy slot lambda-source-location :: false-or(<source-location>) = #f,
+    init-keyword: source-location:;
   // definition slots
   lazy slot signature-spec :: <signature-spec>,
     required-init-keyword: signature-spec:;

--- a/sources/dfmc/modeling/modeling-library.dylan
+++ b/sources/dfmc/modeling/modeling-library.dylan
@@ -209,6 +209,7 @@ define module-with-models dfmc-modeling
       ^function-specializers,
     <&lambda-or-code>,
     <&lambda>,
+      slot lambda-source-location,
       slot lambda-body,
       slot body-spec,
 //      slot data,

--- a/sources/dfmc/optimization/assignment.dylan
+++ b/sources/dfmc/optimization/assignment.dylan
@@ -65,19 +65,32 @@ end method cell-assigned-temporaries;
 define method convert-make-cell
     (env :: <lambda-lexical-environment>, t :: <temporary>)
  => (first-c :: <computation>, last-c :: <computation>, t :: <cell>);
-   with-parent-computation (t.generator)
-     let type
+  local
+    method make-cell
+        (env :: <lambda-lexical-environment>, t :: <temporary>)
+     => (first-c :: <computation>, last-c :: <computation>, t :: <cell>);
+      let type
         = as(<&type>, type-estimate(t));
-     let (unboxer-c, unboxed-t)
-       = maybe-convert-unbox(env, t, type);
-     let (c, tmp)
-       = make-with-temporary
-           (env, <make-cell>, value: unboxed-t, temporary-class: <cell>);
-     let cell = c.temporary;
-     cell-type(cell) := type;
-     rename-temporary!(t, cell);
-     join-1x1-t!(unboxer-c, c, tmp);
-   end;
+      let (unboxer-c, unboxed-t)
+        = maybe-convert-unbox(env, t, type);
+      let (c, tmp)
+        = make-with-temporary
+            (env, <make-cell>, value: unboxed-t, temporary-class: <cell>);
+      let cell = c.temporary;
+      cell-type(cell) := type;
+      rename-temporary!(t, cell);
+      join-1x1-t!(unboxer-c, c, tmp)
+    end method;
+  if (t.generator)
+    with-parent-computation (t.generator)
+      make-cell(env, t)
+    end
+  else
+    // No geneator, probably an argument
+    with-parent-source-location (env.lambda.lambda-source-location)
+      make-cell(env, t)
+    end
+  end if;
 end method convert-make-cell;
 
 define method convert-get-cell-value

--- a/sources/dfmc/reader/fragments.dylan
+++ b/sources/dfmc/reader/fragments.dylan
@@ -1420,9 +1420,14 @@ end macro;
 
 define inline function do-with-parent-fragment
     (f :: <function>, fragment :: <fragment>)
-  dynamic-bind (*parent-source-location* = fragment-source-location(fragment))
+  let loc = fragment-source-location(fragment);
+  if (loc)
+    dynamic-bind (*parent-source-location* = loc)
+      f()
+    end
+  else
     f()
-  end;
+  end if
 end function;
 
 define macro with-parent-fragment


### PR DESCRIPTION
These commits greatly reduce the number of DFM computations without source location info (identified with @??? in the DFM dump files), and thereby improve the DWARF debug info output by the LLVM back-end (as well as the CV4 debug info output by the HARP back-end).