### PR TITLE
[locators] Return "." if locator-name is #"self"

### DIFF
--- a/sources/system/file-system/microsoft-locators.dylan
+++ b/sources/system/file-system/microsoft-locators.dylan
@@ -144,7 +144,12 @@ define sealed method locator-name
  => (name :: false-or(<string>))
   let path = locator.locator-path;
   unless (empty?(path))
-    path[size(path) - 1]
+    let name = path[size(path) - 1];
+    if (name == #"self")
+      "."
+    else
+      name
+    end
   end
 end method locator-name;
 

--- a/sources/system/file-system/posix-locators.dylan
+++ b/sources/system/file-system/posix-locators.dylan
@@ -69,7 +69,12 @@ define sealed method locator-name
  => (name :: false-or(<string>))
   let path = locator.locator-path;
   unless (empty?(path))
-    path[size(path) - 1]
+    let name = path[size(path) - 1];
+    if (name == #"self")
+      "."
+    else
+      name
+    end
   end
 end method locator-name;
 

--- a/sources/system/tests/locators.dylan
+++ b/sources/system/tests/locators.dylan
@@ -320,6 +320,8 @@ define test test-locator-name ()
   assert-equal("example.txt", locator-name(as(<file-locator>, "example.txt")));
   assert-equal("example", locator-name(as(<file-locator>, "example")));
   assert-equal("example.dylan", locator-name(as(<file-locator>, "/home/andrewa/example.dylan")));
+  assert-equal("d", locator-name(as(<directory-locator>, "/a/b/c/d")));
+  assert-equal(".", locator-name(as(<directory-locator>, ".")));
 end test;
 
 /// Coercion protocols


### PR DESCRIPTION
`#"self"` doesn't match the return type of the function.