### PR TITLE
dfmc-debug-back-end: Gracefully handle type estimation errors

### DIFF
--- a/sources/dfmc/debug-back-end/print-method.dylan
+++ b/sources/dfmc/debug-back-end/print-method.dylan
@@ -107,13 +107,21 @@ define method output-computation
     do-used-value-references
       (method (t)
          unless (member?(t, seen))
-           indentd-format(stream, depth, "| %s :: %s\n", t, type-estimate(t));
+           block ()
+             indentd-format(stream, depth, "| %s :: %s\n", t, type-estimate(t));
+           exception (<error>)
+             // Ignore
+           end block;
            add!(seen, t)
          end unless;
        end, c);
     if (c.temporary & c.temporary.used?)
       let t = c.temporary;
-      indentd-format(stream, depth, "\\ %s :: %s\n", t, type-estimate(t));
+      block ()
+        indentd-format(stream, depth, "\\ %s :: %s\n", t, type-estimate(t));
+      exception (<error>)
+        // Ignore
+      end block;
       add!(seen, t)
     end if;
   end if;


### PR DESCRIPTION
Since type estimates are not critical in DFM dumps, gracefully omit
them in the (rare) instances where they fail.

* sources/dfmc/debug-back-end/print-method.dylan
  (output-computation): Don't try to print a type estimate line
   for values where the type estimate computation fails.