### PR TITLE
Fix build/install of dylan-tool

### DIFF
--- a/sources/registry/generic/dylan-tool
+++ b/sources/registry/generic/dylan-tool
@@ -1,0 +1,1 @@
+abstract://dylan/app/dylan-tool/dylan-tool.lid

--- a/sources/registry/generic/dylan-tool-lib
+++ b/sources/registry/generic/dylan-tool-lib
@@ -1,0 +1,1 @@
+abstract://dylan/app/dylan-tool/dylan-tool-lib.lid

--- a/sources/registry/generic/dylan-tool-test-suite
+++ b/sources/registry/generic/dylan-tool-test-suite
@@ -1,0 +1,1 @@
+abstract://dylan/app/dylan-tool/tests/dylan-tool-test-suite.lid

--- a/sources/registry/generic/uncommon-dylan
+++ b/sources/registry/generic/uncommon-dylan
@@ -1,0 +1,1 @@
+abstract://dylan/app/dylan-tool/ext/uncommon-dylan/uncommon-dylan.lid


### PR DESCRIPTION
Attempting to use the dylan-tool Makefile is just more complicated than it
needs to be so I switched to building dylan-tool the same as, e.g.,
make-dylan-app and adding registry entries.