### PR TITLE
Reorganize the README file

### DIFF
--- a/BUILDING.rst
+++ b/BUILDING.rst
@@ -1,50 +1,15 @@
-**********************
-Welcome to Open Dylan!
-**********************
-
-Open Dylan is a compiler and a set of libraries for the `Dylan
-programming language <http://opendylan.org/books/drm>`_.
-
-If you're reading this inside of a binary release that you just downloaded and
-unpacked, then this is all you need to do to get started::
-
-  $ export PATH=/path/to/opendylan-2020.1/bin:$PATH    # for bash
-
-Verify that the downloaded version is working correctly by building a
-hello-world binary::
-
-  make-dylan-app hello-world
-  cd hello-world
-  dylan-compiler -build hello-world
-  _build/bin/hello-world
-
-Note: If there is no ``_build`` directory already, dylan-compiler will create
-it and build all used libraries.  Subsequent builds will be much faster.
-
-If this is your first time trying Open Dylan, take a look at the `Getting
-Started guide <http://opendylan.org/documentation/getting-started-cli/>`_.
-
-
-Contributing
-============
-
-The rest of this document is for those interested in working on the compiler
-and core libraries.
-
-Open Dylan is written in Dylan, thus a Dylan compiler is needed to bootstrap
-it. Download a release from http://opendylan.org/download/ and test it as
-described above.
-
-
+*******************
 Building Open Dylan
-===================
+*******************
+
+This document describes how to build the Open Dylan compiler and IDE.
 
 Clone the git repository::
 
-  git clone git://github.com/dylan-lang/opendylan.git --recursive
+  git clone --recursive git://github.com/dylan-lang/opendylan.git
 
-It does not work to download a ZIP file of the repository from github
-because it doesn't include git submodules.
+.. note:: It does not work to download a ZIP file of the repository from github
+   because it doesn't include git submodules.
 
 
 UNIX
@@ -148,10 +113,7 @@ complete::
   make check
 
 This runs the tests for the core language implementation as well as for many
-bundled libraries.  However, there are currently many test failures which
-need to be fixed. Most of the test failures are minor issues or are due to
-unimplemented tests rather than major bugs. Help is welcome in improving
-our test suites.
+bundled libraries.
 
 Windows
 =======
@@ -184,3 +146,4 @@ IDE in <target-dir>.
   * Go to packages\\win32-nsis, read Build.txt and follow the
     instructions. Make sure you are using the same command shell as
     used for building Open Dylan (to retain environment variables).
+

--- a/Makefile.in
+++ b/Makefile.in
@@ -263,7 +263,8 @@ install-stage:
 	@cp -R $(srcdir)/tools/bash_completion $(DESTDIR)$(prefix)/share/opendylan
 	@cp $(srcdir)/tools/scripts/dylan-lldb $(DESTDIR)$(prefix)/bin
 	@cp $(srcdir)/License.txt $(DESTDIR)$(prefix)
-	@cp $(srcdir)/README.rst $(DESTDIR)$(prefix)
+	@cp $(srcdir)/README.md $(DESTDIR)$(prefix)
+	@cp $(srcdir)/BUILDING.rst $(DESTDIR)$(prefix)
 	@echo Done!
 
 install: 3-stage-bootstrap install-stage
@@ -349,7 +350,8 @@ dist: 3-stage-bootstrap
 	cp -R $(srcdir)/tools/lldb release/opendylan-$(version)/share/opendylan
 	cp -R $(srcdir)/tools/bash_completion release/opendylan-$(version)/share/opendylan
 	cp $(srcdir)/License.txt release/opendylan-$(version)/
-	cp $(srcdir)/README.rst release/opendylan-$(version)/
+	cp $(srcdir)/README.md release/opendylan-$(version)/
+	cp $(srcdir)/BUILDING.rst release/opendylan-$(version)/
 	cd release && tar cjf opendylan-$(version)-$(TARGET_PLATFORM).tar.bz2 opendylan-$(version)
 
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+[![Gitter](https://badges.gitter.im/dylan-lang/general.svg)](https://gitter.im/dylan-lang/general?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) [![libraries-test-suite](https://github.com/dylan-lang/opendylan/actions/workflows/libraries-test-suite.yml/badge.svg)](https://github.com/dylan-lang/opendylan/actions/workflows/libraries-test-suite.yml)
+
+# Welcome to Open Dylan!
+
+Open Dylan is a compiler and a set of libraries for the [Dylan programming
+language](http://opendylan.org/books/drm).
+
+If you're reading this inside of a binary release that you just downloaded and
+unpacked, then this is all you need to do to get started:
+
+  ```
+  $ export PATH=/path/to/opendylan-2020.1/bin:$PATH    # for bash
+  ```
+
+Verify that the downloaded version is working correctly by building a
+hello-world binary:
+
+  ```
+  make-dylan-app hello-world
+  cd hello-world
+  dylan-compiler -build hello-world
+  _build/bin/hello-world
+  ```
+
+Note: if there is no `_build` directory already, dylan-compiler will create it
+and build all used libraries.  Subsequent builds will be much faster since they
+won't need to rebuild core libraries (as long as you always run the compiler in
+the same directory).
+
+## What Next?
+
+If this is your first time trying Open Dylan, take a look at the [Getting
+Started guide](http://opendylan.org/documentation/getting-started-cli/).
+
+See also:
+
+*  [BUILDING.rst](BUILDING.rst) - how to build the compiler and IDE
+*  [How to Contribute to Open
+   Dylan](https://opendylan.org/documentation/hacker-guide/contribute.html)
+*  [opendylan.org](https://opendylan.org) - our main website

--- a/documentation/hacker-guide/source/contribute.rst
+++ b/documentation/hacker-guide/source/contribute.rst
@@ -1,21 +1,11 @@
 *******************************
-How to contribute to Open Dylan
+How to Contribute to Open Dylan
 *******************************
 
-The first thing you'll need is a source checkout of the Git
-repository.  The `Open Dylan sources
-<https://github.com/dylan-lang/opendylan>`_ are hosted on GitHub,
-along with sources for the `opendylan.org web site
-<https://github.com/dylan-lang/website>`_ and many other repositories.
-If you don't yet have a GitHub account and ssh keys, now is a good
-time to get them.
-
-To checkout the main "opendylan" repository::
-
-    git clone --recursive git@github.com:dylan-lang/opendylan
-
-You'll want to fork this repository so you can push changes to your
-fork and then submit pull requests.
+This document only discusses how to make changes to the ``opendylan``
+repository. For external libraries (including ones that are pulled into
+``opendylan`` as submodules) just make your changes, run the test suite, and
+submit a pull request to the appropriate repository.
 
 Aside from `dylan-lang <https://github.com/dylan-lang>`_ there are two
 other GitHub organizations that may be of interest:
@@ -42,11 +32,28 @@ something in mind that isn't there, feel free to `talk with us
 Making Changes
 ==============
 
-* Fork the repository. You will need to have a GitHub account to do
-  this.
-* Create a topic branch with ``git checkout -t -b your-contribution``.
-* Commit your changes to your branch, putting each distinct fix in
-  a separate commit.
+The `Open Dylan sources <https://github.com/dylan-lang/opendylan>`_ are hosted
+on GitHub, along with sources for the `opendylan.org web site
+<https://github.com/dylan-lang/website>`_ and many other repositories.  If you
+don't yet have a GitHub account and ssh keys, now is a good time to get them.
+
+To checkout the main "opendylan" repository::
+
+    git clone --recursive https://github.com/dylan-lang/opendylan
+
+You'll want to fork this repository so you can push changes to your
+fork and then submit pull requests.
+
+In general, when making changes to the compiler and core libraries you'll use
+the ``Makefile`` to build and test your changes. See ``BUILDING.rst`` in the
+top-level directory of your checkout for details on how to install required
+software and build the compiler.
+
+* Fork the repository. You will need to have a GitHub account to do this.
+* Create a topic branch with ``git checkout -t -b my-branch``.
+* Build and test with ``make`` and ``make check``.
+* Commit changes to your branch, putting each distinct fix in a separate
+  commit.
 * Push your changes to your fork on GitHub.
 * Submit a pull request with your changes.
 
@@ -66,14 +73,6 @@ Guidelines
 * Use 2 spaces for indentation, **never** tabs.  If you use emacs,
   `dylan-mode <https://github.com/dylan-lang/dylan-mode>`_ does a
   decent job of indenting code.
-
-Testing
-=======
-
-In the near future, we will have our test suites working more
-reliably. We will also document the processes involved with updating
-and running tests. In the meantime, each library usually has a "tests"
-subdirectory with a test suite library named "\*-tests".
 
 Licensing
 =========

--- a/documentation/hacker-guide/source/topics/making-a-release.rst
+++ b/documentation/hacker-guide/source/topics/making-a-release.rst
@@ -28,9 +28,9 @@ now here is a manual check-list.
      FAIL``, fix the problem or discuss with others how to proceed.
 
    * As a smoke test, verify that the "hello world" instructions at the top of
-     `README.rst
-     <https://github.com/dylan-lang/opendylan/blob/master/README.rst>`_ work on
-     each platform.
+     `BUILDING.rst
+     <https://github.com/dylan-lang/opendylan/blob/master/BUILDING.rst>`_ work
+     on each platform.
 
 #. Update the version number in the sources
 
@@ -74,7 +74,7 @@ now here is a manual check-list.
      $ ./build/unix/release-with-batteries.sh
 
    Use the previous release as the bootstrap compiler so that we can be sure
-   that works.  If it doesn't work, then opendylan/README.rst must be updated
+   that works.  If it doesn't work, then opendylan/BUILDING.rst must be updated
    to indicate which version **can** be used to bootstrap the compiler.
 
    Ask Peter Housel to build the Windows release. :-)


### PR DESCRIPTION
In order to add badges to the repo front page it's easiest (possibly required)
to make the README file use Markdown instead of RST. At the same time I move
the instructions for bootstrapping the compiler to BUILDING.rst so that the
README.md can focus on only the most basic greeting message.
