### PR TITLE
Fix compiler command-line parsing: -internal-debug

### DIFF
--- a/sources/environment/commands/command-line.dylan
+++ b/sources/environment/commands/command-line.dylan
@@ -1095,15 +1095,14 @@ define method parameter-type-name
 end method parameter-type-name;
 
 define method parse-next-argument
-    (context :: <server-context>, type == $keyword-list-type,
-     text :: <string>,
+    (context :: <server-context>, type == $keyword-list-type, text :: <string>,
      #key start :: <integer> = 0, end: stop = #f)
  => (value :: <sequence>, next-index :: <integer>)
-  let (keyword, next-index)
+  let (word, next-index)
     = parse-next-word(text, start: start, end: stop);
-  if (keyword)
+  if (word)
     let options
-      = tokenize-string(text, $option-separator, start: start, end: stop);
+      = tokenize-string(text, $option-separator, start: start, end: next-index);
     values(map(curry(as, <symbol>), options), next-index)
   else
     parse-error("Missing keyword argument")


### PR DESCRIPTION
"dylan-compiler -internal-debug xx -build -debugger yy" previously parsed the
value of the -internal-debug flag as #(#"xx -build -debugger yy") when it
should have parsed it as #(#"xx"). It worked if you put "-internal-debug xx" at
the end of the command-line.

The call to tokenize-string is also broken, for the edge case where the string is
quoted, but that's another yak.