### PR TITLE
deuce: Make buffer positions usable with stream-position-setter

### DIFF
--- a/sources/deuce/classes.dylan
+++ b/sources/deuce/classes.dylan
@@ -8,7 +8,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 /// Protocol classes
 
-define abstract class <bp> (<object>) end;                // _not_ open!
+define abstract class <bp> (<stream-position>) end; // _not_ open!
 
 define open abstract class <line> (<object>) end;
 


### PR DESCRIPTION
The stream-position and stream-position-setter methods on
`<wrapper-stream>` (and subclasses such as `<progress-stream>`) can
forward calls to the underlying stream provided the position is either
an `<integer>` or a subclass of `<stream-position>`. This change makes the
Deuce abstract `<bp>` class inherit from `<stream-position>` rather than
`<object>` so that the interactor streams in the environment will work
when wrapped.

* sources/deuce/classes.dylan
  (`<bp>`): Inherit from the abstract <stream-position> class.