### PR TITLE
runtime-manager: Fix remote value cast to <character>

### DIFF
--- a/sources/runtime-manager/access-path/remote-value.dylan
+++ b/sources/runtime-manager/access-path/remote-value.dylan
@@ -125,7 +125,7 @@ end method;
 define method tagged-remote-value-as-character (x :: <remote-value>)
     => (c :: <character>)
   let int-bit = %shift-right(x, 2);
-  as(<character>, int-bit);
+  as(<character>, as(<integer>, int-bit));
 end method;
 
 


### PR DESCRIPTION
This change fixes a type error that caused an error dialog to be displayed whenever an expression in the interactor evaluated to a character.
