### PR TITLE
Replace space with hyphen in LID keywords

### DIFF
--- a/sources/lib/ssl/examples/ssl-echo-client/ssl-echo-client.hdp
+++ b/sources/lib/ssl/examples/ssl-echo-client/ssl-echo-client.hdp
@@ -5,5 +5,5 @@ target-type:	executable
 Copyright:    Original Code is Copyright (c) 1998-2002 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
-Dual License: GNU Lesser General Public License
+Dual-License: GNU Lesser General Public License
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND

--- a/sources/lib/ssl/examples/ssl-echo-server/ssl-echo-server.hdp
+++ b/sources/lib/ssl/examples/ssl-echo-server/ssl-echo-server.hdp
@@ -5,5 +5,5 @@ target-type:	executable
 Copyright:    Original Code is Copyright (c) 1998-2002 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
-Dual License: GNU Lesser General Public License
+Dual-License: GNU Lesser General Public License
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND

--- a/sources/lib/ssl/examples/ssl-smtp-server/ssl-smtp-server.hdp
+++ b/sources/lib/ssl/examples/ssl-smtp-server/ssl-smtp-server.hdp
@@ -5,5 +5,5 @@ target-type:	executable
 Copyright:    Original Code is Copyright (c) 1998-2002 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
-Dual License: GNU Lesser General Public License
+Dual-License: GNU Lesser General Public License
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND

--- a/sources/network/examples/daytime-client/daytime-client.hdp
+++ b/sources/network/examples/daytime-client/daytime-client.hdp
@@ -12,5 +12,5 @@ comment:	additional keywords
 Copyright:    Original Code is Copyright (c) 1999-2002 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
-Dual License: GNU Lesser General Public License
+Dual-License: GNU Lesser General Public License
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND

--- a/sources/network/examples/daytime-server/daytime-server.hdp
+++ b/sources/network/examples/daytime-server/daytime-server.hdp
@@ -12,5 +12,5 @@ comment:	additional keywords
 Copyright:    Original Code is Copyright (c) 1998-2002 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
-Dual License: GNU Lesser General Public License
+Dual-License: GNU Lesser General Public License
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND

--- a/sources/network/examples/echo-client/echo-client.hdp
+++ b/sources/network/examples/echo-client/echo-client.hdp
@@ -12,5 +12,5 @@ comment:	additional keywords
 Copyright:    Original Code is Copyright (c) 1998-2002 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
-Dual License: GNU Lesser General Public License
+Dual-License: GNU Lesser General Public License
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND

--- a/sources/network/examples/echo-server/echo-server.hdp
+++ b/sources/network/examples/echo-server/echo-server.hdp
@@ -12,5 +12,5 @@ comment:	additional keywords
 Copyright:    Original Code is Copyright (c) 1998-2002 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
-Dual License: GNU Lesser General Public License
+Dual-License: GNU Lesser General Public License
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND

--- a/sources/network/examples/simple-daytime-client/simple-daytime-client.lid
+++ b/sources/network/examples/simple-daytime-client/simple-daytime-client.lid
@@ -5,5 +5,5 @@ target-type:	executable
 Copyright:    Original Code is Copyright (c) 1998-2002 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
-Dual License: GNU Lesser General Public License
+Dual-License: GNU Lesser General Public License
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND

--- a/sources/network/examples/simple-daytime-server/simple-daytime-server.lid
+++ b/sources/network/examples/simple-daytime-server/simple-daytime-server.lid
@@ -5,5 +5,5 @@ target-type:	executable
 Copyright:    Original Code is Copyright (c) 1998-2002 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
-Dual License: GNU Lesser General Public License
+Dual-License: GNU Lesser General Public License
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND


### PR DESCRIPTION
The `dylan` tool has informed me that space is not valid in LID keywords, and the `dylan` tool is correct.