### PR TITLE
Back-end dependency fixes

### DIFF
--- a/sources/dfmc/browser-support/debug-info-api.dylan
+++ b/sources/dfmc/browser-support/debug-info-api.dylan
@@ -63,8 +63,10 @@ define macro back-ended-function-definer
 
       define function ?name
           (?context :: ?type, ?args) => (?vals)
-        let back-end = ?context . context-back-end;
-        apply-to-arg-spec "back-end-" ## ?name, back-end, ?context, ?args end;
+        with-context (?context)
+          let back-end = ?context . context-back-end;
+          apply-to-arg-spec "back-end-" ## ?name, back-end, ?context, ?args end;
+        end
       end }
 end macro;
 

--- a/sources/dfmc/llvm-back-end/llvm-back-end.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-back-end.dylan
@@ -92,31 +92,33 @@ define sealed method initialize
     (back-end :: <llvm-back-end>, #key, #all-keys) => ()
   next-method();
 
-  // Initialize MV return value structure
-  back-end.%mv-struct-type
-    := make(<&raw-struct-type>,
-            debug-name: "dylan-mv",
-            options: #[],
-            members:
-              vector(make(<raw-aggregate-ordinary-member>,
-                          raw-type: dylan-value(#"<raw-pointer>")),
-                     make(<raw-aggregate-ordinary-member>,
-                          raw-type: dylan-value(#"<raw-byte>"))));
+  without-dependency-tracking
+    // Initialize MV return value structure
+    back-end.%mv-struct-type
+      := make(<&raw-struct-type>,
+              debug-name: "dylan-mv",
+              options: #[],
+              members:
+                vector(make(<raw-aggregate-ordinary-member>,
+                            raw-type: dylan-value(#"<raw-pointer>")),
+                       make(<raw-aggregate-ordinary-member>,
+                            raw-type: dylan-value(#"<raw-byte>"))));
 
-  // Initialize TEB structure
-  initialize-teb-struct-type(back-end);
+    // Initialize TEB structure
+    initialize-teb-struct-type(back-end);
 
-  // Initialize NLX bind exit frame structure
-  initialize-bef-struct-type(back-end);
+    // Initialize NLX bind exit frame structure
+    initialize-bef-struct-type(back-end);
 
-  // Initialize predefined/raw LLVM types
-  initialize-type-table(back-end);
+    // Initialize predefined/raw LLVM types
+    initialize-type-table(back-end);
 
-  // Create canonical instances of the 256 i8 constants
-  for (i from 0 below 256)
-    back-end.%byte-character-constants[i]
-      := make(<llvm-integer-constant>, type: $llvm-i8-type, integer: i);
-  end for;
+    // Create canonical instances of the 256 i8 constants
+    for (i from 0 below 256)
+      back-end.%byte-character-constants[i]
+        := make(<llvm-integer-constant>, type: $llvm-i8-type, integer: i);
+    end for;
+  end;
 end method;
 
 define thread variable *loose-mode?* = #f;


### PR DESCRIPTION
These changes fix dependency errors sometimes signaled when the back-end is initialized other than at the start of a compilation, such as within the debugger.
