### PR TITLE
file-source-records: use strings library, add tests

### DIFF
--- a/sources/lib/source-records/file-source-records-library.dylan
+++ b/sources/lib/source-records/file-source-records-library.dylan
@@ -9,6 +9,7 @@ define library file-source-records
   use common-dylan;
   use collections;
   use io;
+  use strings;
   use system;
 
   use source-records;
@@ -38,6 +39,7 @@ define module file-source-records-implementation
   use byte-vector;
   use set;
   use streams;
+  use strings;
   use format;
   use print;
   use standard-io;

--- a/sources/lib/source-records/tests/file-source-records-test-library.dylan
+++ b/sources/lib/source-records/tests/file-source-records-test-library.dylan
@@ -1,0 +1,19 @@
+Module: dylan-user
+
+define library file-source-records-test-suite
+  use common-dylan;
+  use io;
+  use file-source-records;
+  use testworks;
+
+  export file-source-records-test-suite;
+end library;
+
+define module file-source-records-test-suite
+  use common-dylan;
+  use file-source-records;
+  use streams;
+  use testworks;
+
+  export file-source-records-test-suite;
+end module;

--- a/sources/lib/source-records/tests/file-source-records-test-suite.dylan
+++ b/sources/lib/source-records/tests/file-source-records-test-suite.dylan
@@ -1,0 +1,9 @@
+Module: file-source-records-test-suite
+
+define suite file-source-records-test-suite ()
+  // header-reader.dylan
+  test test-read-header-from-stream/empty-header;
+  test test-read-header-from-stream/no-trailing-newline;
+  test test-read-header-from-stream/no-continuation-lines;
+  test test-read-header-from-stream/continuation-lines;
+end suite;

--- a/sources/lib/source-records/tests/file-source-records-test-suite.lid
+++ b/sources/lib/source-records/tests/file-source-records-test-suite.lid
@@ -1,0 +1,4 @@
+Library: file-source-records-test-suite
+Files: file-source-records-test-library.dylan
+       header-reader.dylan
+       file-source-records-test-suite.dylan

--- a/sources/lib/source-records/tests/header-reader.dylan
+++ b/sources/lib/source-records/tests/header-reader.dylan
@@ -1,0 +1,48 @@
+Module: file-source-records-test-suite
+
+define test test-read-header-from-stream/empty-header ()
+  let header = "";
+  let stream = make(<string-stream>, contents: header, direction: #"input");
+  let (keys, nlines, nchars) = read-header-from-stream(stream);
+  assert-equal(0, keys.size);
+  assert-equal(0, nlines);
+  assert-equal(0, nchars);
+end test;
+
+define test test-read-header-from-stream/no-trailing-newline ()
+  for (header in #("Module: m\nSynopsis:   s",          // no newline at end
+                   "Module: m\nSynopsis:s   "))         // no space after colon
+    let stream = make(<string-stream>, contents: header, direction: #"input");
+    let (keys, nlines, nchars) = read-header-from-stream(stream);
+    assert-equal(2, keys.size);
+    assert-equal(1, nlines);
+    assert-equal(23, nchars);
+    assert-equal(#("m"), keys[#"module"]);
+    assert-equal(#("s"), keys[#"synopsis"]);
+  end;
+end test;
+
+define test test-read-header-from-stream/no-continuation-lines ()
+  for (header in #("Module: m\nSynopsis:   s\n\n123\n", // stops at empty line?
+                   "Module: m  \nSynopsis: s\n\n123\n")) // space after 'm' stripped?
+    let stream = make(<string-stream>, contents: header, direction: #"input");
+    let (keys, nlines, nchars) = read-header-from-stream(stream);
+    assert-equal(2, keys.size);
+    assert-equal(3, nlines);
+    assert-equal(25, nchars);
+    assert-equal(#("m"), keys[#"module"]);
+    assert-equal(#("s"), keys[#"synopsis"]);
+  end;
+end test;
+
+define test test-read-header-from-stream/continuation-lines ()
+  let header = "Module: m\nSynopsis: a \n b\n c\nXYZ: xyz\n\n123\n";
+  let stream = make(<string-stream>, contents: header, direction: #"input");
+  let (keys, nlines, nchars) = read-header-from-stream(stream);
+  assert-equal(3, keys.size);
+  assert-equal(6, nlines);
+  assert-equal(39, nchars);
+  assert-equal(#("m"), keys[#"module"]);
+  assert-equal(#("a", "b", "c"), keys[#"synopsis"]);
+  assert-equal(#("xyz"), keys[#"xyz"]);
+end test;

--- a/sources/registry/generic/file-source-records-test-suite
+++ b/sources/registry/generic/file-source-records-test-suite
@@ -1,0 +1,1 @@
+abstract://dylan/lib/source-records/tests/file-source-records-test-suite.lid

--- a/sources/testing/libraries-test-suite/libraries-test-suite-lib.dylan
+++ b/sources/testing/libraries-test-suite/libraries-test-suite-lib.dylan
@@ -9,11 +9,13 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 define library libraries-test-suite
   use common-dylan;
   use testworks;
-  use dylan-test-suite;
-  use common-dylan-test-suite;
+
   use collections-test-suite;
-  use system-test-suite;
+  use common-dylan-test-suite;
+  use dylan-test-suite;
+  use file-source-records-test-suite;
   use io-test-suite;
+  use system-test-suite;
   use testworks-test-suite;
 
   export libraries-test-suite
@@ -22,11 +24,13 @@ end library libraries-test-suite;
 define module libraries-test-suite
   use common-dylan;
   use testworks;
-  use dylan-test-suite;
-  use common-dylan-test-suite;
+
   use collections-test-suite;
-  use system-test-suite;
+  use common-dylan-test-suite;
+  use dylan-test-suite;
+  use file-source-records-test-suite;
   use io-test-suite;
+  use system-test-suite;
   use testworks-test-suite;
 
   export libraries-test-suite

--- a/sources/testing/libraries-test-suite/libraries-test-suite.dylan
+++ b/sources/testing/libraries-test-suite/libraries-test-suite.dylan
@@ -9,6 +9,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define suite libraries-test-suite ()
   suite dylan-test-suite;
+  suite file-source-records-test-suite;
   suite common-dylan-test-suite;
   suite collections-test-suite;
   suite system-test-suite;


### PR DESCRIPTION
Was reading through this before using it in the dylan-tool library and noticed it duplicates some code that's in the strings library. Removed the duplicated code, cleaned up a bit, added some tests to make sure I didn't break anything.

3-stage bootstrap works