### PR TITLE
Intro Dylan doc: fix example and missing :term:s

### DIFF
--- a/documentation/intro-dylan/source/conditions.rst
+++ b/documentation/intro-dylan/source/conditions.rst
@@ -7,8 +7,8 @@ to recover smoothly from error conditions. Like C++, Dylan represents
 errors with objects. Dylan also supports advisory warnings and
 potentially correctable errors.
 
-When something unusual happens, a program can :term:`signal` a
-:term:`condition`. :term:`Handlers` specify how to react to various
+When something unusual happens, a program can :drm:`signal` a
+:drm:`condition`. :drm:`Handlers` specify how to react to various
 sorts of conditions.
 
 Signaling
@@ -42,7 +42,7 @@ conditions for you to examine.
 Handlers
 ========
 
-A function :term:`establishes a handler` with the :drm:`let handler`
+A function establishes a handler with the :drm:`let handler`
 statement. The handler remains in effect until the function exits. Other
 functions called by the first can establish new handlers. When the
 :drm:`signal` function looks for a handler, it looks for the most recently
@@ -61,7 +61,7 @@ The code to establish the handlers may have looked like this:
 .. code-block:: dylan
 
    let handler <key-not-found-error> = handle-no-pet-found;
-   
+
 A handler can be a normal function, but it can also be a local method or bare
 method, complete with access to local variables.
 
@@ -94,7 +94,7 @@ much encapsulation or allow for complicated recovery information, and the
 recovery information has to be processed locally.
 
 Another way to return recovery information is through the use of a
-:term:`restart`. A restart is a condition that includes recovery information.
+:drm:`restart`. A restart is a condition that includes recovery information.
 But unlike most conditions, this condition provides a solution instead of
 indicating a problem. A restart handler — which may be established anywhere
 useful — can use the information included in the restart to work around the
@@ -117,7 +117,7 @@ Dylan offers blocks.
 Blocks
 ======
 
-A :term:`block` is a group of statements. As with
+A :drm:`block` is a group of statements. As with
 other control structures, it may return a value. A simple block
 might appear as follows:
 
@@ -125,14 +125,15 @@ might appear as follows:
 
     block ()
       1 + 1
-    end; // returns 2
+    end
+    // => 2
 
-But in addition to returning a value normally, a :drm:`block` can use a :term:`nonlocal
+But in addition to returning a value normally, a :drm:`block` can use a :drm:`nonlocal
 exit`. This allows the :drm:`block` to exit at any time, optionally returning a value.
-In some ways, it is similar to the ``goto`` statement, the ``break`` statement,
+In some ways it is similar to the C++ ``goto`` statement, the ``break`` statement,
 or the POSIX ``longjmp`` function. To use a nonlocal exit,
 specify a name in the parentheses following a :drm:`block` statement. Dylan
-binds this name to an :term:`exit function` which can be
+binds this name to an :drm:`exit variable` which can be
 called from anywhere within the block or the functions it calls. The
 following block returns either ``"Weird!"`` or ``"All's well."``,
 depending on the color of the sky.
@@ -144,7 +145,7 @@ depending on the color of the sky.
         finished("Weird!");
       end;
       "All's well."
-    end block;
+    end block
 
 Many programs need to dispose of resources or perform other cleanup work when
 exiting a block. The block may contain optional :drm:`afterwards` and ``cleanup``
@@ -193,7 +194,7 @@ Java:
     exception (error :: <file-error>)
       report-problem(error);
     end;
-   
+
 You can use a block with a restart to abort some work entirely and fall back to
 the data supplied by the restart object, neatly circumventing the problem mentioned
 at the end of the `Restart handlers`_ section above:

--- a/documentation/intro-dylan/source/expressions-variables.rst
+++ b/documentation/intro-dylan/source/expressions-variables.rst
@@ -10,8 +10,6 @@ symbols ``- + ~ ? /``, although identifiers may begin
 with numbers, provided they contain at least two alphabetic characters
 in a row. Variable names are not case sensitive.
 
-.. todo:: Need DRM footnote here.
-
 This means that ``(a - b)`` subtracts one variable from another,
 whereas ``(a-b)`` simply returns the value of the hyphenated variable
 named ``a-b``.  Because of this, infix operators, such as addition,
@@ -65,8 +63,8 @@ desires.
 
 Furthermore, there's only one of any given numeric value in a
 Dylan program, at least from the programmer's point of view. All
-variables which refer to the integer 2 -- or, in Dylan-speak, are
-:term:`bound` to the integer 2 -- point to the
+variables which refer to the integer 2 -- or, in Dylan terminology, are
+:drm:`bound <bindings>` to the integer 2 -- point to the
 exact same thing.
 
 .. code-block:: dylan
@@ -88,9 +86,9 @@ structure, the results may surprise C and Pascal programmers.
 
 As long as one or more variables refer to an object, it
 continues to exist. However, as soon as the last reference either
-goes out of scope or gets rebound, the object becomes :term:`garbage`.
+goes out of scope or gets rebound, the object becomes garbage.
 Since there's no way that the program could ever refer to the object
-again, the :term:`garbage collector` feels free to reuse the memory
+again, the garbage collector is free to reuse the memory
 which once held it.
 
 Note that Dylan variables *must* be bound to a
@@ -110,11 +108,10 @@ language constructs such as :drm:`let`. (Two Dylan objects
 are equal, generally, if they belong to the same class and have equal
 substructure.)
 
-The C++ equality operator, :drm:`==`, acts as the
-:term:`identity` operator in Dylan. Two variables are
-:term:`identical` if and only if they are bound to the
-exact same object. For example, the following three expressions mean
-roughly the same thing::
+The :drm:`==` operator determines whether two objects are identical in
+Dylan. Two objects are identical if and only if they are the exact same
+object. For example, the following two expressions mean roughly the same
+thing::
 
     (a == b)   // in Dylan or Java
     (&a == &b) // in C or C++
@@ -190,19 +187,18 @@ compile time. To take advantage of this feature, use the ``::`` operator:
 As seen in the example, a variable may be bound to values of its
 declared type or to values of subclasses of its declared type. Type
 mismatch errors should be caught at compile time. In general, the
-compiler may infer the types of variables at when generating machine
-code. If a local variable never gets rebound to anything other than an
+compiler may infer the types of variables when generating machine
+code. If a local variable is never rebound to anything other than an
 integer, for example, the compiler can rely on this fact to optimize
 the resulting code.
 
 Module Variables and Constants
 ==============================
 
-Dylan supports :term:`module-level` variables,
-which serve roughly the same purpose as C's global variables. Although
-the :drm:`let` function may only be used within :term:`methods`
-(Dylan-speak for regular functions), the forms :drm:`define variable` and
-:drm:`define constant` may be used at module top level.
+Dylan supports module-level variables, which serve roughly the same purpose as
+C's global variables. The forms :drm:`define variable` and :drm:`define
+constant`
+may be used at module top level.
 
 .. code-block:: dylan
 
@@ -211,5 +207,5 @@ the :drm:`let` function may only be used within :term:`methods`
     define constant $hi = "Hi!";
 
 Note that there's not much point in declaring types for
-constants. Any remotely decent compiler will be able to figure that
+constants. Any decent compiler will be able to figure that
 information out on its own.

--- a/documentation/intro-dylan/source/methods-generic-functions.rst
+++ b/documentation/intro-dylan/source/methods-generic-functions.rst
@@ -2,7 +2,7 @@
 Methods & Generic Functions
 ***************************
 
-Dylan :term:`methods` correspond roughly to the
+Dylan :drm:`methods` correspond roughly to the
 functions found in C++. They take zero or more named parameters,
 but also return zero or more named return values. A minimal Dylan method
 might look like the following:
@@ -11,7 +11,7 @@ might look like the following:
 
     define method hello-world ()
       format-out("Hello, world!");
-    end;
+    end
 
 This method has no parameters and an unspecified return value. It
 could return any number of values of any type. In order to make the
@@ -33,8 +33,8 @@ follow an end statement.
 Parameters & Parameter Lists
 ============================
 
-Dylan methods declare parameters in fashion similar to that of
-conventional languages, except for the fact that parameters may
+Dylan methods declare parameters in a fashion similar to that of
+many languages, except for the fact that parameters may
 optionally be untyped. Both of the following methods are legal:
 
 .. code-block:: dylan
@@ -48,10 +48,9 @@ return value (or actually does anything). As in C, each typed parameter
 must have its own type declaration; there's no syntax for saying
 "the last three parameters are all integers".
 
-Functions with variable numbers of parameters include the
-``#rest`` keyword in their parameter lists.
-Thus, the declaration for C's ``printf`` function
-would appear something like the following in Dylan:
+Functions with the ``#rest`` keyword in their parameter list accept a variable
+number of arguments.  Thus, the declaration for C's ``printf`` function would
+appear something like the following in Dylan:
 
 .. code-block:: dylan
 
@@ -60,7 +59,7 @@ would appear something like the following in Dylan:
       // Note that Dylan actually allows us to verify the types of variables,
       // preventing those nasty printf errors, such as using %d instead of %ld.
       // ...
-    end method printf;
+    end method printf
 
 Note that Dylan makes no provision for passing variables by
 reference in the Pascal sense, or for passing pointers to variables.
@@ -68,7 +67,7 @@ parameter names are simply bound to whatever values are passed, and may
 be rebound like regular variables. This means that there's no way to
 write a ``swap`` function in Dylan.  (It may be done using
 macros). However, the following function works just fine, because it
-modifies the :term:`internal state` of another
+modifies the internal state of another
 object:
 
 .. code-block:: dylan
@@ -114,13 +113,13 @@ the value of the last expression in its body.
     end;
 
     define method baz () => ()
-      let (x,y) = moby();  // assign both
+      let (x, y) = moby();  // assign both
     end;
 
 Bare Methods
 ============
 
-Nameless methods may be declared inline. Such :term:`bare methods` are
+Nameless methods may be declared inline. Such :drm:`bare methods` are
 typically used as parameters to other methods.  For example, the
 following code fragment squares each element of a list using the built
 in :drm:`map` function and a bare method:
@@ -128,8 +127,8 @@ in :drm:`map` function and a bare method:
 .. code-block:: dylan
 
     define method square-list (numbers :: <list>) => (out :: <list>)
-      map(method(x) x * x end, numbers);
-    end;
+      map(method(x) x * x end, numbers)
+    end
 
 The :drm:`map` function takes each element of
 the list ``numbers`` and applies the anonymous method. It
@@ -137,12 +136,10 @@ then builds a new list using the resulting values and returns it.
 The method ``square-list`` might be invoked as
 follows:
 
-.. todo:: Must distinguish return values from code.
-
 .. code-block:: dylan
 
-    square-list(#(1, 2, 3, 4));
-    => #(1, 4, 9, 16)
+    square-list(#(1, 2, 3, 4))
+    // => #(1, 4, 9, 16)
 
 Local Methods
 =============
@@ -182,7 +179,7 @@ bound in a local method, allowing some interesting techniques:
 
 Local functions which contain references to local variables that are
 outside of the local function's own scope are known as
-:term:`closures`.  In the above example, ``string-putter`` "closes
+:drm:`closures`.  In the above example, ``string-putter`` "closes
 over" (or captures the binding of) the variable named ``string``.
 
 .. _generic-functions:
@@ -190,31 +187,31 @@ over" (or captures the binding of) the variable named ``string``.
 Generic Functions
 =================
 
-A :term:`generic function` represents zero or more
+A :drm:`generic function` represents zero or more
 similar methods. Every method created by means of
-:drm:`define method` is automatically :term:`contained`
-within the generic function of the same name. For example, a 
+:drm:`define method` is automatically contained
+within the generic function of the same name. For example, a
 programmer could define three methods named ``display``,
 each of which acted on a different data type:
 
 .. code-block:: dylan
 
     define method display (i :: <integer>)
-      do-display-integer(i);
+      write(*standard-output*, integer-to-string(i));
     end;
 
     define method display (s :: <string>)
-      do-display-string(s);
+      write(*standard-output*, s);
     end;
 
     define method display (f :: <float>)
-      do-display-float(f);
+      write(*standard-output*, float-to-string(f));
     end;
 
 When a program calls ``display``, Dylan examines
 all three methods. Depending on the type of the argument to
 ``display``, Dylan invokes one of the above methods.
-If no methods match the actual parameters, an error occurs.
+If no method matches the actual parameters, an error occurs.
 
 In C++, this process occurs only at compile time. (It's called
 operator overloading.) In Dylan, calls to ``display``
@@ -238,9 +235,9 @@ runtime. If no applicable method can be found, the Dylan runtime
 environment throws an exception.
 
 Generic functions may also be declared explicitly, allowing the
-programmer to exercise control over what sort of methods get added.
+programmer to exercise control over what sort of methods are added.
 For example, the following declaration limits all ``display``
-methods to single parameter and no return values:
+methods to a single parameter and no return values:
 
 .. code-block:: dylan
 
@@ -252,10 +249,10 @@ Generic functions are explained in greater detail in the chapter on
 Keyword Arguments
 =================
 
-Functions may accept :term:`keyword arguments`,
+Functions may accept keyword arguments,
 extra parameters which are identified by a label rather than by their
 position in the argument list. Keyword arguments are often used in a
-fashion similar to :term:`default parameter values`
+fashion similar to default parameter values
 in C++, and they are always optional.
 
 The following hypothetical method might print records to an output device:
@@ -267,7 +264,7 @@ The following hypothetical method might print records to an output device:
      => ()
       send-init-codes(init-codes)
       // ...print the records
-    end method;
+    end method
 
 The arguments following ``#key`` are keyword arguments. You could call this
 method in several ways:
@@ -285,7 +282,7 @@ that the order of the keyword arguments does not matter.
 With all three calls, the ``init-codes`` and ``lines-per-page`` variables are
 available in the body of the method, even though keyword arguments are omitted
 in two of the calls. When a keyword argument is omitted, it is given the default
-value specified in the method definition. Therefore, in the first call, the 
+value specified in the method definition. Therefore, in the first call, the
 ``lines-per-page`` variable has the value ``66``, and in the first and second
 calls, the ``init-codes`` variable has the value ``""``.
 
@@ -340,7 +337,7 @@ were called like so:
 .. code-block:: dylan
 
    format("Today will be %s with a high of %d.", "cloudy", 52);
-   
+
 The ``format-parameters`` variable in the body of the method would have the
 value ``#["cloudy", 52]``.
 
@@ -382,7 +379,7 @@ methods that it contains.
    +-----------------------------------+-----------+---------------+---------------+-----------+
    | ``(x, #rest r)``                  | Forbidden | Forbidden     | Forbidden     | Required  |
    +-----------------------------------+-----------+---------------+---------------+-----------+
-   
+
    Required:
       Each method must have this element in its parameter list.
    Allowed:
@@ -402,16 +399,16 @@ does not permit.
    ======================================  =================  =========================  ======================
    Method's parameter list                 Contents of ``r``  Permits ``a:`` and ``b:``  Permits other keywords
    ======================================  =================  =========================  ======================
-   ``(x)``                                 —                  No                         No            
+   ``(x)``                                 —                  No                         No
    ``(x, #key)``                           —                  If next method permits     If next method permits
    ``(x, #key a, b)``                      —                  Yes                        If next method permits
-   ``(x, #key, #all-keys)``                —                  Yes                        Yes           
-   ``(x, #key a, b, #all-keys)``           —                  Yes                        Yes           
-   ``(x, #rest r)``                        Extra arguments    No                         No            
+   ``(x, #key, #all-keys)``                —                  Yes                        Yes
+   ``(x, #key a, b, #all-keys)``           —                  Yes                        Yes
+   ``(x, #rest r)``                        Extra arguments    No                         No
    ``(x, #rest r, #key)``                  Keywords/values    If next method permits     If next method permits
    ``(x, #rest r, #key a, b)``             Keywords/values    Yes                        If next method permits
-   ``(x, #rest r, #key, #all-keys)``       Keywords/values    Yes                        Yes           
-   ``(x, #rest r, #key a, b, #all-keys)``  Keywords/values    Yes                        Yes           
+   ``(x, #rest r, #key, #all-keys)``       Keywords/values    Yes                        Yes
+   ``(x, #rest r, #key a, b, #all-keys)``  Keywords/values    Yes                        Yes
    ======================================  =================  =========================  ======================
 
    Extra arguments:
@@ -433,10 +430,10 @@ does not permit.
 To illustrate the "next method" rule, say we have the following definitions:
 
 .. code-block:: dylan
-   
+
    define class <shape> (<object>) ... end;
    define generic draw (s :: <shape>, #key);
-   
+
    define class <polygon> (<shape>) ... end;
    define class <triangle> (<polygon>) ... end;
 
@@ -445,7 +442,7 @@ To illustrate the "next method" rule, say we have the following definitions:
 
    define method draw (s :: <polygon>, #key sides) ... end;
    define method draw (s :: <triangle>, #key) ... end;
-   
+
    define method draw (s :: <ellipse>, #key) ... end;
    define method draw (s :: <circle>, #key radius) ... end;
 

--- a/documentation/intro-dylan/source/modules-libraries.rst
+++ b/documentation/intro-dylan/source/modules-libraries.rst
@@ -133,11 +133,10 @@ example, could belong to the ``vehicle-application`` library.
 Sealing
 =======
 
-Classes and generic functions may be :term:`sealed`
-using a number of Dylan forms. This prevents code in other libraries
-from subclassing objects or adding methods to generic functions, and
-lets the compiler optimize more effectively. Both classes and generic
-functions are sealed by default.
+Classes and generic functions may be :drm:`sealed <sealing>`, preventing code
+in other libraries from subclassing objects or adding methods to generic
+functions. This allows the compiler optimize more effectively. Both classes and
+generic functions are sealed by default.
 
 To allow code in other libraries to subclass a given class,
 declare it as ``open``:
@@ -157,5 +156,4 @@ A third form, :drm:`define sealed domain`, partially
 seals a generic function, disallowing only some additions from outside
 a library.
 
-For more information on sealing, see the chapter
-"Controlling Dynamism" in the DRM.
+For more information on sealing, see :drm:`"Sealing" in the DRM <sealing>`.

--- a/documentation/intro-dylan/source/multiple-dispatch.rst
+++ b/documentation/intro-dylan/source/multiple-dispatch.rst
@@ -2,11 +2,11 @@
 Multiple Dispatch
 *****************
 
-:term:`Multiple dispatch` is one of the most powerful
+"Multiple dispatch" is one of the most powerful
 and elegant features of Dylan. As explained in the section on
 :ref:`generic functions and objects <generic-functions-objects>`,
 Dylan methods are declared separately from the classes upon which they
-act.  :term:`Polymorphism`, the specialization of methods
+act.  Polymorphism, the specialization of methods
 for use with particular classes, can be implemented by declaring several
 methods with different parameters and attaching them to one generic
 function:
@@ -53,7 +53,7 @@ with these arguments performs three separate tasks:
 ``<car>`` and ``<state-inspector>`` -- is invoked first
 and calls :drm:`next-method` to invoke the less-specific methods in turn.
 
-For an exact definition of "specific", see the DRM.
+For an exact definition of "specific", see :drm:`method dispatch` in the DRM.
 
 Dispatching on Specific Objects
 ===============================
@@ -61,7 +61,7 @@ Dispatching on Specific Objects
 Dylan also allows functions to dispatch on specific objects. For
 example, state inspectors might pass the governor's car without
 actually looking at it. Dylan expresses this situation using
-:term:`singletons`, objects which are treated as
+:drm:`singletons`, objects which are treated as
 though they were in a class of their own. For example:
 
 .. code-block:: dylan
@@ -73,5 +73,7 @@ though they were in a class of their own. For example:
       wave-through(car);
     end;
 
-(In this example, none of the usual inspection methods will be
-invoked since the above code doesn't call :drm:`next-method`.)
+The ``car`` parameter is specialized via ``== $governors-car``, meaning "the
+object identical to $governors-car".  (In this example, none of the usual
+inspection methods are invoked since the above code doesn't call
+:drm:`next-method`.)

--- a/documentation/intro-dylan/source/objects.rst
+++ b/documentation/intro-dylan/source/objects.rst
@@ -4,7 +4,7 @@ Objects
 
 The features of Dylan's object system don't map directly onto the
 features found in C++. Dylan handles access control using
-:term:`modules`, not ``private`` declarations within
+:drm:`modules`, not ``private`` declarations within
 individual classes. Standard Dylan has no destructors, but instead relies
 upon the garbage collector to recover memory and on :drm:`block`/cleanup
 to recover lexically scoped resources. Dylan objects don't even have real
@@ -12,7 +12,7 @@ member functions.
 
 Dylan's object system is at least as powerful as that of C++. Multiple
 inheritance works smoothly, constructors are rarely needed and there's
-no such thing as object slicing. Alternate constructs replace the
+no such thing as object slicing. Alternative constructs replace the
 missing C++ features. Quick and dirty classes can be turned into clean
 classes with little editing of existing code.
 
@@ -59,13 +59,12 @@ also standardizes strings and byte-strings.
 Not all the built-in classes may be subclassed. This allows the
 compiler to heavily optimize code dealing with basic numeric types and
 certain common collections. The programmer may also mark classes as
-:term:`sealed`, restricting how and where they may be subclassed. See
-`Sealing <https://opendylan.org/books/drm/Sealing>`_ for details.
+:drm:`sealed <sealing>`, restricting how and where they may be subclassed.
 
 Slots
 =====
 
-Objects have :term:`slots`, which resemble the data
+Objects have :drm:`slots`, which resemble data
 members in C++ or fields in Java. Like
 variables, slots are bound to values; they don't actually contain
 their data. A simple Dylan class shows how slots are declared:
@@ -112,14 +111,14 @@ with the specified serial number and the default owner. In the second
 example, :drm:`make` sets both slots using the keyword
 arguments.
 
-Only one of ``required-init-keyword``, ``init-value`` and
+Only one of ``required-init-keyword``, ``init-value``, or
 ``init-function`` may be specified. However, ``init-keyword``
 may be paired with either of the latter two if desired. More
 than one slot may be initialized by a given keyword.
 
 Dylan also provides for the equivalent of C++ ``static``
 members, plus several other useful allocation schemes. See
-the DRM for the full details.
+the `DRM <https://opendylan.org/books/drm/>`_ for the full details.
 
 Getters and Setters
 ===================
@@ -141,10 +140,11 @@ for these two functions. They may also be written as:
 
     sample-vehicle.owner;  // returns owner
     sample-vehicle.owner := "Faisal";
+    owner(sample-vehicle) := "Faisal";
 
 .. _generic-functions-objects:
 
-Generic functions and Objects
+Generic Functions and Objects
 =============================
 
 Generic functions, introduced in :doc:`Methods and Generic functions
@@ -241,14 +241,16 @@ example, if vehicle serial numbers must be at least seven digits:
       end if;
     end method;
 
-:drm:`initialize` methods get called after regular
+:drm:`initialize` methods are called after regular
 slot initialization. They typically perform error checking or calculate
-derived slot values. Initialize methods must specify ``#key`` in their
+derived slot values. :drm:`initialize` methods must specify ``#key`` in their
 parameter lists.
 
-It's possible to access the values of slot keywords from
-:drm:`initialize` methods, and even to specify additional
-keywords in the class declaration. See the DRM for further details.
+It's possible to access the values of slot keywords from :drm:`initialize`
+methods, and even to specify additional keywords in the class declaration. See
+the `Instance Creation and Initialization
+<https://opendylan.org/books/drm/Instance_Creation_and_Initialization>`_ in the
+DRM for further details.
 
 Abstract Classes and Overriding Make
 ====================================
@@ -266,12 +268,12 @@ be defined as follows:
       // ...as before
     end;
 
-The above modification prevents the creation of direct instances
+The addition of :drm:`abstract` above prevents the creation of direct instances
 of ``<vehicle>``. At the moment, calling
 :drm:`make` on this class would result in an error.
-However, a programmer could add a method to make which allowed the
+However, a programmer may add a method to :drm:`make` which allows the
 intelligent creation of vehicles based on some criteria, thus making
-``<vehicle>`` an :term:`instantiable abstract class`:
+``<vehicle>`` an :drm:`instantiable` :drm:`abstract` class":
 
 .. code-block:: dylan
 
@@ -279,14 +281,14 @@ intelligent creation of vehicles based on some criteria, thus making
         (class == <vehicle>, #rest keys, #key big?)
      => (vehicle :: <vehicle>)
       if (big?)
-        make(<truck>, keys, tons: 2)
+        apply(make, <truck>, tons: 2, keys)
       else
-        make(<car>, keys)
+        apply(make, <car>, keys)
       end
     end method make;
 
 A number of new features appear in the parameter list. The expression
-"``class == <vehicle>``" specifies a :term:`singleton` dispatch,
+``class == <vehicle>`` specifies a :drm:`singleton <singletons>` dispatch,
 meaning this method will be called only if ``class`` is exactly
 ``<vehicle>``, not a subclass such as ``<car>``.  Singleton dispatch
 is discussed in the chapter on :doc:`Multiple Dispatch

--- a/documentation/intro-dylan/source/why-dylan.rst
+++ b/documentation/intro-dylan/source/why-dylan.rst
@@ -17,12 +17,12 @@ inheritance and exceptions, implements :doc:`multiple dispatch
 Dynamic vs. Static Languages
 ============================
 
-:term:`Static` languages need to know the type of every variable at
+Static languages need to know the type of every variable at
 compile time. Examples of static languages include C++, Java, and Go.
 Code written in static languages typically compiles efficiently, and
 strong type-checking at compile-time reduces the risk of errors.
 
-:term:`Dynamic` languages allow the programmer to create variables
+Dynamic languages allow the programmer to create variables
 without explicitly specifying the type of information they
 contain. This simplifies prototyping and cleans up certain kinds of
 object oriented code. Typical dynamic languages include Common Lisp,
@@ -40,7 +40,7 @@ the flexibility of a dynamic language.
 Functional Languages
 ====================
 
-:term:`Functional` languages, such as Common Lisp,
+Functional languages, such as Common Lisp,
 Scheme and to a large extent TCL, view an entire program as one large
 function to be evaluated. Expressions, statements and even control
 structures all return values, which may in turn be used as arguments
@@ -67,7 +67,7 @@ returns 11. Since no other statements follow the ``if``, its return
 value is used as the return value of the entire function.
 
 The same function could also have been written as follows, in a
-more :term:`imperative` idiom:
+more imperative idiom:
 
 .. code-block:: dylan
 
@@ -83,7 +83,7 @@ Algebraic Infix Syntax
 ======================
 
 Languages based on LISP typically use a notation called
-:term:`fully-parenthesized prefix syntax` (also known as
+fully-parenthesized prefix syntax (also known as
 s-expressions). This consists of nested parentheses, as seen in the
 following Scheme version of the ``shoe-size`` function:
 
@@ -108,19 +108,19 @@ functions and classes themselves.
 Dylan's design makes this reasonably efficient. Compile-time analysis
 and explicit :ref:`type declarations <type-declarations>` allow the
 compiler to optimize away most of the overhead. Other language features
-permit the programmer to mark certain classes as :term:`sealed`, that is,
+permit the programmer to mark certain classes as :drm:`sealed <sealing>`, that is,
 ineligible for further subclassing.  This allows for further compile-time
 optimizations.
 
 Dylan's object model, detailed in the following sections of this
 tutorial, differs from that of C++ in several important respects.
 Multiple inheritance may be used freely, without concern for
-:term:`object slicing`, erroneous down-casting or a
+"object slicing", erroneous down-casting or a
 whole host of other gotchas familiar to C++ programmers. Methods are
 separate from class declarations, allowing a programmer to write new
 polymorphic functions without editing the relevant base class.  Methods
 may also dispatch polymorphically on more than one parameter, a
-powerful technique known as :term:`multiple dispatch`.
+powerful technique known as :doc:`multiple dispatch <multiple-dispatch>`.
 All of these features will be explained in greater detail later on.
 
 .. _garbage-collection:
@@ -128,7 +128,7 @@ All of these features will be explained in greater detail later on.
 Garbage Collection
 ==================
 
-Languages with :term:`garbage collection` have no need of a ``free`` or
+Languages with garbage collection have no need of a ``free`` or
 ``delete`` operator, because unused heap memory gets reclaimed automatically
 by the language runtime. This reduces the complexity of source code,
 eliminates the need of keeping reference counts for shared objects,


### PR DESCRIPTION
This fixes the bug reported by "nsxfh"

```diff
-        make(<truck>, keys, tons: 2)
+        apply(make, <truck>, tons: 2, keys)
```

as well as many missing `:term:` targets. The latter were mostly references to the DRM, which have been created in
https://github.com/dylan-lang/sphinx-extensions/pull/26. For a few I just removed the `:term:` markup.