### PR TITLE
mps: Use llvm code path for update_allocation_counter.

### DIFF
--- a/sources/lib/run-time/collector.c
+++ b/sources/lib/run-time/collector.c
@@ -524,7 +524,7 @@ BOOL WINAPI DylanBreakControlHandler(DWORD dwCtrlType)
 STATIC_INLINE
 void update_allocation_counter(gc_teb_t gc_teb, size_t count, void* wrapper)
 {
-#ifdef GC_USE_MPS
+#if defined(GC_USE_MPS) && defined(OPEN_DYLAN_BACKEND_HARP)
   gc_teb->gc_teb_allocation_counter += count;
 #elif defined(OPEN_DYLAN_BACKEND_LLVM)
   extern __thread DSINT Pallocation_count;
@@ -553,7 +553,7 @@ void update_allocation_counter(gc_teb_t gc_teb, size_t count, void* wrapper)
 
 static void zero_allocation_counter(gc_teb_t gc_teb)
 {
-#ifdef GC_USE_MPS
+#if defined(GC_USE_MPS) && defined(OPEN_DYLAN_BACKEND_HARP)
   gc_teb->gc_teb_allocation_counter = 0;
 #else
   unused(gc_teb);


### PR DESCRIPTION
When building with LLVM and using MPS, still need to use the LLVM code path for the allocation counter as the gc_teb doesn't exist within the LLVM backend.

This isn't sufficient to get allocation working as other things still use the gc_teb, but they can be fixed in subsequent commits.