### PR TITLE
dfmc-reader: fix bug in make-hash-literal

### DIFF
--- a/documentation/library-reference/source/language-extensions/parser-expansions.rst
+++ b/documentation/library-reference/source/language-extensions/parser-expansions.rst
@@ -18,7 +18,7 @@ gets transformed, setter-like, into::
 
 The ``<text>`` part can be either *delimited* or *undelimited*. Undelimited
 text can contain anything but commas, semicolons, brackets of any kind, and
-whitespace. There is no ``\`` escape processing. All the following are valid::
+whitespace. All the following are valid::
 
     #:http://opendylan.org/
     #:time:12:30am
@@ -51,3 +51,9 @@ An example parser:
 
 If an appropriate function isn't defined, you get a standard unbound variable
 reference message indicating the # literal.
+
+Note that there is no escape processing except that the end delimiter may be
+escaped with a backslash and *the escape character itself is not removed*. For
+example, ``#:file:"C:\foo\"`` is an error because the end delimiter is escaped
+and therefore the hash literal is unterminated. ``#:file:"C:\foo\""`` results
+in the literal string ``C:\foo\"`` being passed to the parser.

--- a/sources/dfmc/reader/interface.dylan
+++ b/sources/dfmc/reader/interface.dylan
@@ -109,6 +109,11 @@ define serious-program-warning <ratios-not-supported> (<invalid-token>)
   format-arguments token-string;
 end serious-program-warning;
 
+define serious-program-warning <unterminated-parser-expansion>
+  format-string "Unterminated parser expansion %s";
+  format-arguments token-string;
+end serious-program-warning;
+
 define serious-program-warning <invalid-end-of-input> (<reader-error>)
   format-string
     "Unexpected end of input encountered while reading form.";

--- a/sources/dfmc/reader/tests/expressions-test-suite.dylan
+++ b/sources/dfmc/reader/tests/expressions-test-suite.dylan
@@ -112,7 +112,7 @@ define function verify-hash-literal-function-call
   assert-equal(arg1.fragment-value, arg);
 end function;
 
-define test hash-literal-test ()
+define test hash-literal-ast-test ()
   verify-hash-literal-function-call("#:foo:bar", #"foo-parser", "bar");
   verify-hash-literal-function-call("#:foo:{\nbar\n}", #"foo-parser", "\nbar\n");
 end test;
@@ -136,5 +136,5 @@ define suite expressions-test-suite ()
   test binary->=-test;
   // This doesn't test &, | and := yet.
   test escaped-name-test;
-  test hash-literal-test;
+  test hash-literal-ast-test;
 end suite expressions-test-suite;

--- a/sources/dfmc/reader/tests/literal-test-suite.dylan
+++ b/sources/dfmc/reader/tests/literal-test-suite.dylan
@@ -229,6 +229,14 @@ define test vector-literal-test ()
   verify-presentation(f, "#[\"a\", b:]");
 end test vector-literal-test;
 
+define test hash-literal-test ()
+  // End delimiter is escaped so the hash literal is not terminated. This used
+  // to crash the compiler, unless '}' appeared somewhere later in the source
+  // record.
+  let source = "#:foo:{\\}";
+  assert-false(read-fragment(source));
+end test;
+
 define suite literal-test-suite ()
   test binary-integer-literal-test;
   test boolean-literal-test;
@@ -243,4 +251,5 @@ define suite literal-test-suite ()
   test string-literal-test;
   test symbol-literal-test;
   test vector-literal-test;
+  test hash-literal-test;
 end suite literal-test-suite;


### PR DESCRIPTION
`#:foo:{\}` would crash the compiler with "element outside of range" unless the `}` delimiter occurred later in the same source record.