### PR TITLE
Doc linkification and :macrocall: improvements

### DIFF
--- a/documentation/library-reference/source/c-ffi/index.rst
+++ b/documentation/library-reference/source/c-ffi/index.rst
@@ -1240,7 +1240,7 @@ these classes.
 
    :description:
 
-     Returns ``#t`` if a pointer is null and ``#f`` otherwise.
+     Returns :drm:`#t` if a pointer is null and :drm:`#f` otherwise.
 
 .. index::
    single: <C-void*> class
@@ -1543,7 +1543,7 @@ these classes.
 .. method:: =
    :specializer: <C-pointer>
 
-   Returns ``#t`` if two pointers are equal.
+   Returns :drm:`#t` if two pointers are equal.
 
    :signature: = *C-pointer-1* *C-pointer-2* => *boolean*
 
@@ -1556,7 +1556,7 @@ these classes.
 
    :description:
 
-     Returns ``#t`` if two pointers are equal. This is equivalent to:
+     Returns :drm:`#t` if two pointers are equal. This is equivalent to:
 
      .. code-block:: dylan
 
@@ -1578,7 +1578,7 @@ these classes.
 .. method:: <
    :specializer: <C-pointer>
 
-   Returns ``#t`` if the second argument is less than the first.
+   Returns :drm:`#t` if the second argument is less than the first.
 
    :signature: < *C-pointer-1* *C-pointer-2* => *boolean*
 
@@ -1588,7 +1588,7 @@ these classes.
 
    :description:
 
-     Returns ``#t`` if the second argument is less than the first. This
+     Returns :drm:`#t` if the second argument is less than the first. This
      allows pointer comparison operations to be performed on instances
      of :class:`<C-pointer>`.
 
@@ -2722,7 +2722,7 @@ Describing structure types
      The optional setter keyword specifies the generic function to which
      the setter method for the structure slot will be added. It defaults
      to getter-name*-setter*. No setter method is defined if the
-     *setter* option is ``#f``. If the *constant* keyword is supplied, no
+     *setter* option is :drm:`#f`. If the *constant* keyword is supplied, no
      *setter* option should be supplied.
 
      .. index::
@@ -3007,7 +3007,7 @@ Describing C functions to Dylan
      *generic-function-method:* option.
 
      Either the *c-name:* function option must be supplied, or the
-     *indirect:* option must be supplied with a value other than ``#f``,
+     *indirect:* option must be supplied with a value other than :drm:`#f`,
      but not both.
 
      A parameter-spec has the following syntax::
@@ -3066,12 +3066,12 @@ Describing C functions to Dylan
      Dylan function corresponding to each *input* *output* parameter of
      the C function that is specialized as the union of the export type
      of the referenced type of the type given for the parameter in
-     ``define c-function``, and ``#f``. When the C function returns, the
+     ``define c-function``, and :drm:`#f`. When the C function returns, the
      value in the location is accessed and returned as an extra result
      from the Dylan function. If an *input* *output* parameter is passed
-     as ``#f`` from Dylan then a ``NULL`` pointer is passed to the C
+     as :drm:`#f` from Dylan then a ``NULL`` pointer is passed to the C
      function, and the extra value returned by the Dylan function will
-     be ``#f``.
+     be :drm:`#f`.
 
      Example of *input* *output* parameter definition:
 
@@ -3110,10 +3110,10 @@ Describing C functions to Dylan
 	single: define C-function definition macro
 
      Each *function-option* is a keyword–value pair. The
-     *generic-function-method:* option may be either ``#t`` or ``#f``,
+     *generic-function-method:* option may be either :drm:`#t` or :drm:`#f`,
      indicating whether to add a method to the generic function name or
      to bind a bare constant method directly to name. The default value
-     for *generic-function-method:* is ``#f``. The option *C-modifiers:*
+     for *generic-function-method:* is :drm:`#f`. The option *C-modifiers:*
      can be used to specify platform dependent modifiers for the C
      function being called. For example, on Windows, use *C-modifiers:*
      ``"__stdcall"`` if the C function to be called is defined to be a
@@ -3127,13 +3127,13 @@ Describing C functions to Dylan
 	single: <C-function-pointer> class
 	single: classes; <C-function-pointer>
 
-     The *indirect:* ``#t`` option defines a function that accepts a C
+     The *indirect:* :drm:`#t` option defines a function that accepts a C
      function pointer as its first argument and calls the function given
      with the signature described by the parameters and result given. In
      this case the Dylan function defined accepts one more argument than
      if *c-name* was given. The type specified for the first parameter
      of the Dylan function is :class:`<c-function-pointer>`. One of
-     *c-name* or *indirect:* ``#t`` must be supplied, but not both.
+     *c-name* or *indirect:* :drm:`#t` must be supplied, but not both.
 
      Example C declarations:
 
@@ -3282,10 +3282,10 @@ Describing Dylan functions for use by C
      name is made visible to C as the name of the generated *C-callable
      wrapper* function. Given a compatible ``extern`` declaration, this
      allows C code to call Dylan code simply by invoking a named
-     function. The *export:* option takes the values ``#t`` or ``#f``
+     function. The *export:* option takes the values :drm:`#t` or :drm:`#f`
      and indicates whether the c-name for the generated
      *C-callable-wrapper* function is to be exported from the library's
-     *.dll*. ``#t`` means it is exported, ``#f`` means it is not. The
+     *.dll*. :drm:`#t` means it is exported, :drm:`#f` means it is not. The
      default is #f. The *c-modifiers:* option is the same as in the
      *c-function* macro, except that the modifiers apply to the C
      function wrapper which is generated. See :macro:`define C-function`.
@@ -3323,7 +3323,7 @@ Describing Dylan functions for use by C
      an extra value which is placed into the location specified by the
      pointer passed to the C function. If the pointer passed to the C
      function is ``NULL``, then the value passed to the Dylan function
-     will be ``#f``, and the extra value returned will be ignored.
+     will be :drm:`#f`, and the extra value returned will be ignored.
 
      There is currently no way to define a C-callable function that
      accepts a variable number of arguments.
@@ -3532,9 +3532,9 @@ This section covers describing and accessing C variables.
 
    :parameter getter-name: A Dylan variable name.
    :parameter c-type: A Dylan name.
-   :parameter setter: ``#f`` or a Dylan variable name.
+   :parameter setter: :drm:`#f` or a Dylan variable name.
    :parameter c-name: A string constant.
-   :parameter import: ``#f`` or ``#t``.
+   :parameter import: :drm:`#f` or :drm:`#t`.
 
    :description:
      .. index::
@@ -3547,19 +3547,19 @@ This section covers describing and accessing C variables.
      argument is required and gives the C name of the variable to be
      accessed. The *setter* keyword allows you to specify the name of
      the setter function, or if a setter function is to be defined at
-     all. If *setter* is ``#f``, no setter function will be defined.
+     all. If *setter* is :drm:`#f`, no setter function will be defined.
 
      The *import:* option indicates if the C variable must be imported
-     from another *.dll* or not. ``#t`` indicates it is in another
-     *.dll* and must be imported, ``#f`` means that it is not to be
+     from another *.dll* or not. :drm:`#t` indicates it is in another
+     *.dll* and must be imported, :drm:`#f` means that it is not to be
      imported. Whether the variable has to be imported from another
      *.dll* or not is determined by which Dylan project the C source
      files are part of. If they are in the same project as the
      *C-variable* definition then the value of "import:" should be
-     ``#f`` as the definition and variable will be linked into the same
+     :drm:`#f` as the definition and variable will be linked into the same
      *.dll*. If the definition is in a different project from the C
      source files then they will be in separate *.dll* s and *import:*
-     needs to be ``#t``. The default value is ``#f``.
+     needs to be :drm:`#t`. The default value is :drm:`#f`.
 
      .. index::
 	single: <C-pointer> class
@@ -3621,7 +3621,7 @@ This section covers describing and accessing C variables.
    :parameter name: A Dylan variable name.
    :parameter pointer-designator-type:
    :parameter c-name: A string constant.
-   :parameter import: ``#f`` or ``#t``.
+   :parameter import: :drm:`#f` or :drm:`#t`.
 
    :description:
 
@@ -3633,16 +3633,16 @@ This section covers describing and accessing C variables.
      defined, and a subtype of ``<C-pointer>``.
 
      The *import:* option indicates if the C address must be imported
-     from another *.dll* or not. ``#t`` indicates it is in another
-     *.dll* and must be imported, ``#f`` means that it is not to be
+     from another *.dll* or not. :drm:`#t` indicates it is in another
+     *.dll* and must be imported, :drm:`#f` means that it is not to be
      imported. Whether the variable has to be imported from another
      *.dll* or not is determined by which Dylan project the C source
      files are part of. If they are in the same project as the
-     *C-address* definition then the value of "import:" should be ``#f``
+     *C-address* definition then the value of "import:" should be :drm:`#f`
      as the definition and variable will be linked into the same *.dll*.
      If the definition is in a different project from the C source files
      then they will be in separate *.dll* s and *import:* needs to be
-     ``#t``. The default value is ``#f``.
+     :drm:`#t`. The default value is :drm:`#f`.
 
 .. index::
    single: allocation; C storage
@@ -3857,8 +3857,8 @@ using :macro:`define c-mapped-subtype`.
      A mapped subclass of ``<C-int>`` that provides an analogue to
      Dylan's :drm:`<boolean>` class. The Dylan type for both import and
      export is :drm:`<boolean>`, and the C type is ``int``. The C integer
-     ``0`` is mapped to ``#f`` in Dylan, and all other values are mapped
-     to ``#t``.
+     ``0`` is mapped to :drm:`#f` in Dylan, and all other values are mapped
+     to :drm:`#t`.
 
 .. index::
    single: <C-character> class
@@ -3987,7 +3987,7 @@ using :macro:`define c-mapped-subtype`.
 
 .. function:: equal-memory?
 
-   Returns ``#t`` if the size of the two designated memory spaces have
+   Returns :drm:`#t` if the size of the two designated memory spaces have
    the same contents.
 
    :signature: equal-memory? *ptr1*, *ptr2*, *size* => <boolean>
@@ -3998,9 +3998,9 @@ using :macro:`define c-mapped-subtype`.
 
    :description:
 
-     Returns ``#t`` if the *size* bytes of memory starting at pointer
+     Returns :drm:`#t` if the *size* bytes of memory starting at pointer
      *ptr1* have the same contents as the memory starting at *ptr2*,
-     else ``#f``. The space is assumed to be a whole number of words and
+     else :drm:`#f`. The space is assumed to be a whole number of words and
      word-aligned.
 
 .. index::

--- a/documentation/library-reference/source/c-ffi/index.rst
+++ b/documentation/library-reference/source/c-ffi/index.rst
@@ -1285,9 +1285,9 @@ these classes.
    designator class name.
 
    :macrocall:
-     .. code-block:: dylan
+     .. parsed-literal:: 
 
-       define C-pointer-type *pointer-class-name* => *designator-class-name*
+        define C-pointer-type `pointer-class-name` => `designator-class-name`
 
    :parameter pointer-class-name: A Dylan variable name.
    :value designator-class: A Dylan name.
@@ -2263,17 +2263,17 @@ Defining specialized versions of designator classes
    existing designator class for that type.
 
    :macrocall:
-     .. code-block:: dylan
+     .. parsed-literal:: 
 
-       define [*modifiers* *] C-subtype name (superclasses)
-         [*slot-spec* ; ...] [;]
-         [*type-options* ] [;]
-       end [C-subtype] [*name* ]
+        define [`modifiers`] C-subtype `name` (`superclasses`)
+          [`slot-spec` ; ...] [;]
+          [`type-options`] [;]
+        end [C-subtype] [`name`]
 
-   :parameter modifiers: The same as the modifiers allowed in :drm:`define class <class>`.
+   :parameter modifiers: The same as the modifiers allowed in :drm:`define class`.
    :parameter name: A Dylan variable name.
    :parameter superclasses: A list of Dylan names.
-   :parameter slot-spec: Same syntax as a slot definition in ``define class``.
+   :parameter slot-spec: Same syntax as a slot definition in :drm:`define class`.
    :parameter type-options: A property list.
 
    :description:
@@ -2281,9 +2281,9 @@ Defining specialized versions of designator classes
      Defines a specialized designator class for a C type based on an
      existing designator class for that type. It does this by defining a
      subclass of the original designator class, and is a simple wrapper
-     around :drm:`define class <class>` from which it takes its syntax. The
-     superclasses, slot-specs, and *modifiers* are passed on to ``define
-     class`` unchanged. In effect, it expands to:
+     around :drm:`define class` from which it takes its syntax. The
+     superclasses, slot-specs, and *modifiers* are passed on to :drm:`define
+     class` unchanged. In effect, it expands to:
 
      .. code-block:: dylan
 
@@ -2295,7 +2295,7 @@ Defining specialized versions of designator classes
 	single: define C-subtype definition macro
 	single: define C-subtype; define C-subtype
 
-     In terms of C, ``define C-subtype`` can be thought of as
+     In terms of C, :macro:`define C-subtype` can be thought of as
      implementing a strongly typed version of ``typedef`` because a new
      designator class is generated that Dylan's type system can
      distinguish from the designator class on which it was based. As
@@ -2427,20 +2427,20 @@ Defining specialized designator classes
    Allows you to define a name to which to bind a pointer designator.
 
    :macrocall:
-     .. code-block:: dylan
+     .. parsed-literal:: 
 
-       define *modifiers* C-mapped-subtype *type-name* (*superclasses*)
-         [map *high-level-type*
-           [, import-function: *import-fun* ]
-           [, export-function: *export-fun* ];]
-         [import-map *high-level-type*,
-           import-function: *import-fun* ;]
-         [export-map *high-level-type*,
-           export-function: *export-fun* ;]
-         [type-options]
-       end
+        define [`modifier` ...] C-mapped-subtype `type-name` (`superclass` )
+          [map `high-level-type`
+            [, import-function: `import-fun` ]
+            [, export-function: `export-fun` ];]
+          [import-map `high-level-type`,
+            import-function: `import-fun` ;]
+          [export-map `high-level-type`,
+            export-function: `export-fun` ;]
+          [`type-options`]
+        end
 
-   :parameter modifiers: The same as the modifiers allowed in :drm:`define-class <class>`.
+   :parameter modifiers: The same as the modifiers allowed in :drm:`define-class`.
    :parameter type-name: A Dylan variable name.
    :parameter superclasses: A list of Dylan names.
    :parameter high-level-type: An instance of a Dylan :drm:`<type>`.
@@ -2653,12 +2653,12 @@ Describing structure types
    Describes C's aggregate structures.
 
    :macrocall:
-     .. code-block:: dylan
+     .. parsed-literal:: 
 
-       define C-struct *name*
-         [*slot-spec* ; ...] [;]
-         [*type-options* ] [;]
-       end [C-struct] [*name* ]
+        define C-struct `name`
+          [`slot-spec` ; ...] [;]
+          [`type-options`] [;]
+        end [C-struct] [`name`]
 
    :parameter name: A Dylan variable name.
    :parameter slot-spec:
@@ -2831,12 +2831,12 @@ Describing union types
    Describes C union types to the *c-ffi*.
 
    :macrocall:
-     .. code-block:: dylan
+     .. parsed-literal:: 
 
-       define C-union *name*
-         [*slot-spec* ; ...] [;]
-         [*type-options* ] [;]
-       end [C-union] [*name* ]
+        define C-union `name`
+          [`slot-spec` ; ...] [;]
+          [`type-options`] [;]
+        end [C-union] [`name`]
 
    :parameter name: A Dylan variable name.
    :parameter slot-spec:
@@ -2969,13 +2969,13 @@ Describing C functions to Dylan
    Describes a C function to the *c-ffi*.
 
    :macrocall:
-     .. code-block:: dylan
+     .. parsed-literal:: 
 
-       define C-function *name*
-         [*parameter-spec*; ...]
-         [*result-spec*;]
-         [*function-option*, ...;]
-       end [C-function] [*name*]
+        define C-function `name`
+          [`parameter-spec`; ...]
+          [`result-spec`;]
+          [`function-option`, ...;]
+        end [C-function] [`name`]
 
    :parameter name: A Dylan variable name.
    :parameter parameter-spec:
@@ -2994,7 +2994,7 @@ Describing C functions to Dylan
      .. index::
 	single: definition macros; define C-function
 
-     The result of processing a ``define C-function`` definition is a
+     The result of processing a :macro:`define C-function` definition is a
      Dylan function which is bound to name. This function takes Dylan
      objects as arguments, converting them to their C representations
      according to the types declared for the parameters of the C
@@ -3066,7 +3066,7 @@ Describing C functions to Dylan
      Dylan function corresponding to each *input* *output* parameter of
      the C function that is specialized as the union of the export type
      of the referenced type of the type given for the parameter in
-     ``define c-function``, and :drm:`#f`. When the C function returns, the
+     :macro:`define c-function`, and :drm:`#f`. When the C function returns, the
      value in the location is accessed and returned as an extra result
      from the Dylan function. If an *input* *output* parameter is passed
      as :drm:`#f` from Dylan then a ``NULL`` pointer is passed to the C
@@ -3188,7 +3188,7 @@ Describing C functions to Dylan
      .. index::
 	single: define C-callable-wrapper definition macro
 
-     In effect, a ``define C-function`` such as:
+     In effect, a :macro:`define C-function` such as:
 
      .. code-block:: dylan
 
@@ -3235,14 +3235,13 @@ Describing Dylan functions for use by C
    the function.
 
    :macrocall:
-     .. code-block:: dylan
+     .. parsed-literal:: 
 
-       define C-callable-wrapper [*dylan-rep-name* ]
-        of *dylan-function*
-         [*parameter-spec* ; ...] [;]
-         [*result-spec* ] [;]
-         [*function-options* ][;]
-       end [C-callable-wrapper]
+        define C-callable-wrapper [`dylan-rep-name`] of `dylan-function`
+          [`parameter-spec` ; ...] [;]
+          [`result-spec` ] [;]
+          [`function-options` ][;]
+        end [C-callable-wrapper]
 
    :parameter dylan-rep-name: A Dylan variable name.
    :parameter dylan-function: An instance of :drm:`<function>`.
@@ -3264,7 +3263,7 @@ Describing Dylan functions for use by C
 	single: define C-function definition macro
 	single: definition macros; define C-callable wrapper
 
-     The result of processing a ``define C-callable-wrapper`` definition
+     The result of processing a :macro:`define C-callable-wrapper` definition
      is a function with a C entry point with the contract described.
      This function takes C values as arguments, converting them to Dylan
      representations according to the types declared for the parameters
@@ -3405,7 +3404,7 @@ Describing Dylan functions for use by C
      .. index::
 	single: definition macros; define C-callable wrapper
 
-     In effect, a ``define C-callable-wrapper`` such as:
+     In effect, a :macro:`define C-callable-wrapper` such as:
 
      .. code-block:: dylan
 
@@ -3469,13 +3468,13 @@ of that bridge are implemented within this library.
    Describe Objective C selectors to the *c-ffi*.
 
    :macrocall:
-     .. code-block:: dylan
+     .. parsed-literal:: 
 
-       define objc-selector *name*
-         [*parameter-spec*; ...]
-         [*result-spec*;]
-         [*function-option*, ...;]
-       end [C-function] [*name*]
+        define objc-selector `name`
+          [`parameter-spec`; ...]
+          [`result-spec`;]
+          [`function-option`, ...;]
+        end [C-function] [`name`]
 
    :parameter name: A Dylan variable name.
    :parameter parameter-spec:
@@ -3524,11 +3523,11 @@ This section covers describing and accessing C variables.
    Describes C variables to the *c-ffi*.
 
    :macrocall:
-     .. code-block:: dylan
+     .. parsed-literal:: 
 
-       define C-variable *getter-name* :: *c-type*
-         #key *setter* *c-name* import: *boolean*
-       end [C-variable]
+        define C-variable `getter-name` :: `c-type`
+          #key `setter` `c-name` import: `boolean`
+        end [C-variable]
 
    :parameter getter-name: A Dylan variable name.
    :parameter c-type: A Dylan name.
@@ -3569,7 +3568,7 @@ This section covers describing and accessing C variables.
      translation is not so simple. A C union or struct has no direct
      representation in Dylan. You may only have a reference to the C
      object in Dylan through a :class:`<c-pointer>` object. For this
-     reason, ``define c-variable`` is not permitted for variables with C
+     reason, :macro:`define c-variable` is not permitted for variables with C
      aggregate types. Use :macro:`define C-address` for those variables.
 
    :example:
@@ -3612,11 +3611,11 @@ This section covers describing and accessing C variables.
    the location of a C global variable.
 
    :macrocall:
-     .. code-block:: dylan
+     .. parsed-literal:: 
 
-       define C-address *name* :: *pointer-designator-type*
-         #key *c-name* import: *boolean*
-       end [C-address] [*name* ]
+        define C-address `name` :: `pointer-designator-type`
+          #key `c-name` import: `boolean`
+        end [C-address] [`name`]
 
    :parameter name: A Dylan variable name.
    :parameter pointer-designator-type:
@@ -3786,11 +3785,11 @@ function :func:`destroy`.
    Allocates an object within the scope of the body of the code.
 
    :macrocall:
-     .. code-block:: dylan
+     .. parsed-literal:: 
 
-        with-stack-structure (*name* :: *wrapper-type*
-            #key *element-count* *extra-bytes*)
-          *body*
+        with-stack-structure (`name` :: `wrapper-type`
+            #key `element-count`, `extra-bytes`)
+          `body`
         end [with-stack-structure]
 
    :parameter name: A Dylan variable name.
@@ -3904,10 +3903,10 @@ using :macro:`define c-mapped-subtype`.
    Passes a C pointer to the contents of a :drm:`<byte-string>`.
 
    :macrocall:
-     .. code-block:: dylan
+     .. parsed-literal:: 
 
-        with-c-string (*variable* = *string-valued-expression*)
-          *body*
+        with-c-string (`variable` = `string-valued-expression`)
+          `body`
         end
 
    :parameter variable: A Dylan variable name.

--- a/documentation/library-reference/source/c-ffi/index.rst
+++ b/documentation/library-reference/source/c-ffi/index.rst
@@ -357,8 +357,8 @@ simple example. Suppose we have a C ``extern`` function declaration
 
 This function is intended to return the sum of two ``double`` values.
 Instead of implementing the function in C, we can implement it in Dylan
-using Dylan's generic function ``+``. All we need to do is define a
-C-callable wrapper for ``+``, as follows:
+using Dylan's generic function :drm:`+`. All we need to do is define a
+C-callable wrapper for :drm:`+`, as follows:
 
 .. code-block:: dylan
 

--- a/documentation/library-reference/source/collections/bit-set.rst
+++ b/documentation/library-reference/source/collections/bit-set.rst
@@ -13,7 +13,7 @@ The bit-set Module
    :keyword all-members-from: If this is a non-negative integer then the set
       created will be infinite. All integers greater than
       or equal to the one supplied will be members of the
-      set. The default is ``#f``.
+      set. The default is :drm:`#f`.
    :keyword member-vector:
    :keyword members: If supplied, this gives the initial elements of the
       set as a sequence of integers.
@@ -67,7 +67,7 @@ The bit-set Module
 
    :description:
 
-      Returns ``#t`` if the set is infinite, otherwise ``#f``.
+      Returns :drm:`#t` if the set is infinite, otherwise :drm:`#f`.
 
 .. generic-function:: member?
    :sealed:
@@ -80,7 +80,7 @@ The bit-set Module
 
    :description:
 
-     Returns ``#t`` if ``element`` is a member of the set, otherwise ``#f``.
+     Returns :drm:`#t` if ``element`` is a member of the set, otherwise :drm:`#f`.
      ``element`` must be a non-negative integer.
 
 .. generic-function:: set-add
@@ -260,11 +260,11 @@ The bit-set Module
    :signature: size *set* => *false-or-integer*
 
    :parameter set: An instance of :class:`<bit-set>`.
-   :value size: Either ``#f`` or an instance of :drm:`<integer>`.
+   :value size: Either :drm:`#f` or an instance of :drm:`<integer>`.
 
    :description:
 
-     Returns the cardinality of the set or ``#f`` if the set is
+     Returns the cardinality of the set or :drm:`#f` if the set is
      infinite. This operation may be relatively slow.
 
 .. function:: universal-bit-set!

--- a/documentation/library-reference/source/collections/plists.rst
+++ b/documentation/library-reference/source/collections/plists.rst
@@ -79,9 +79,8 @@ Reference
    Modify the *plist*, adding *indicator* with the given *value*.
 
    :macrocall:
-     .. code-block:: dylan
-
-       put-property!(*plist*, *indicator*, *value*)
+      .. parsed-literal:: 
+         put-property!(`plist`, `indicator`, `value`)
 
    :parameter plist: An instance of :drm:`<sequence>`.
    :parameter indicator: An instance of :drm:`<object>`.
@@ -120,9 +119,8 @@ Reference
    if any.
 
    :macrocall:
-     .. code-block:: dylan
-
-       remove-property!(*plist*, *indicator*)
+      .. parsed-literal:: 
+         remove-property!(`plist`, `indicator`)
 
    :parameter plist: An instance of :drm:`<sequence>`.
    :parameter indicator: An instance of :drm:`<object>`.
@@ -157,16 +155,13 @@ Reference
    :statement:
 
    :macrocall:
-     .. code-block:: dylan
+      .. parsed-literal:: 
+         with-keywords-removed(`var` = `plist`, `keywords`) `body` end
 
-       with-keywords-removed(*var* = *plist*, *keywords*)
-         *body*
-       end
-
-   :parameter var: A Dylan name *bnf*.
+   :parameter var: A Dylan name *BNF*.
    :parameter plist: An instance of :drm:`<sequence>`.
    :parameter keywords: An instance of :drm:`<sequence>`.
-   :parameter body: A Dylan body *bnf*.
+   :parameter body: A Dylan body *BNF*.
 
    :description:
 

--- a/documentation/library-reference/source/collections/table-extensions.rst
+++ b/documentation/library-reference/source/collections/table-extensions.rst
@@ -73,7 +73,7 @@ init-keyword. The legal values for this keyword are:
 - ``#"value"`` Creates a table with weak values. When there are no longer
   any strong references to a value, the table entry of which it is a
   part becomes eligible for garbage collection.
-- ``#f`` Creates a table with strong keys and values. This is the default
+- :drm:`#f` Creates a table with strong keys and values. This is the default
   value.
 
 The table-extensions Module
@@ -147,7 +147,7 @@ from the module *table-extensions*.
    :parameter elt-hash-function: An instance of :drm:`<function>`.
    :parameter collection: An instance of :drm:`<collection>`.
    :parameter initial-state: An instance of ``<hash-state>``.
-   :parameter #key ordered: An instance of :drm:`<boolean>`. Default value: ``#f``.
+   :parameter #key ordered: An instance of :drm:`<boolean>`. Default value: :drm:`#f`.
    :value hash-id: An instance of :drm:`<integer>`.
    :value result-state: An instance of ``<hash-state>``.
 
@@ -172,7 +172,7 @@ from the module *table-extensions*.
    :parameter elt-hash-function: An instance of :drm:`<function>`.
    :parameter sequence: An instance of :drm:`<sequence>`.
    :parameter initial-state: An instance of ``<hash-state>``.
-   :parameter #key ordered: An instance of :drm:`<boolean>`. Default value: ``#f``.
+   :parameter #key ordered: An instance of :drm:`<boolean>`. Default value: :drm:`#f`.
    :value hash-id: An instance of :drm:`<integer>`.
    :value result-state: An instance of ``<hash-state>``.
 

--- a/documentation/library-reference/source/collections/table-extensions.rst
+++ b/documentation/library-reference/source/collections/table-extensions.rst
@@ -104,13 +104,13 @@ from the module *table-extensions*.
 
 .. class:: <case-insensitive-string-table>
    :sealed:
-   
+
    A table class that uses case-insensitive strings for keys.
-   
+
    :superclasses: :drm:`<table>`
-   
+
    :description:
-   
+
      The ``<string-table>`` class is the class of tables that use
      instances of :drm:`<string>` for their keys. It is an error to use a
      key that is not an instance of :drm:`<string>`.
@@ -346,26 +346,26 @@ from the module *table-extensions*.
 
 .. macro:: tabling
    :macro-type: Function
-   
+
    Creates a table and populates it with keys and values.
-   
+
    :macrocall:
-     .. parsed-literal::
-        tabling( { `class`, } `key` => `value`, ...)
-           
+     .. parsed-literal:: 
+        tabling( [ `class`, ] `key` => `value`, ...)
+
    :parameter class:  An instance of :drm:`<class>`. Optional.
    :parameter key:    An expression.
    :parameter value:  An expression.
    :value table:      A new instance of *class*.
-   
+
    :description:
-   
+
      Creates a table of type *class* and populates it with *key*/*value*
      pairs. If *class* is omitted, creates a table of type :drm:`<table>`.
 
    :example:
-   
+
      .. code-block:: dylan
 
-       let my-table = tabling("red"=>"stop", "green"=>"go");
-       let my-table = tabling(<string-table>, "red"=>"stop", "green"=>"go");
+       let my-table = tabling(#"red" => "stop", #"green" => "go");
+       let my-table = tabling(<string-table>, "red" => "stop", "green" => "go");

--- a/documentation/library-reference/source/coloring-stream/index.rst
+++ b/documentation/library-reference/source/coloring-stream/index.rst
@@ -98,7 +98,7 @@ The coloring-stream Module
      to determine whether or not the underlying stream supports
      color output.
 
-     When *force-ansi?* is ``#t``, then the usual checks are skipped
+     When *force-ansi?* is :drm:`#t`, then the usual checks are skipped
      and a coloring stream that generates ANSI output is created.
      This is useful when outputting to a string prior to writing the
      text to :var:`*standard-output*` or when writing a network server
@@ -163,7 +163,7 @@ The coloring-stream Module
      ANSI color output, assuming that the underlying stream
      supports color output at all.
 
-     On Unix, this will always return ``#t``.
+     On Unix, this will always return :drm:`#t`.
 
      On Windows, this attempts to detect situations where ANSI
      output would be permissible, such as running within an

--- a/documentation/library-reference/source/command-line-parser/index.rst
+++ b/documentation/library-reference/source/command-line-parser/index.rst
@@ -349,7 +349,7 @@ The command-line-parser Module
 
    :signature: print-synopsis (parser subcommand #key stream) => ()
    :parameter parser: An instance of :class:`<command-line-parser>`.
-   :parameter subcommand: An instance of :class:`<subcommand>` or ``#f``.
+   :parameter subcommand: An instance of :class:`<subcommand>` or :drm:`#f`.
    :parameter #key stream: An instance of :class:`<stream>`.
 
    :description:
@@ -359,15 +359,15 @@ The command-line-parser Module
 
 .. function:: option-present?
 
-   Returns ``#t`` if this option was supplied on the command line.
+   Returns :drm:`#t` if this option was supplied on the command line.
 
    :signature: option-present? (option) => (present?)
    :parameter option: An instance of :class:`<option>`.
    :value present?: An instance of :drm:`<boolean>`.
    :description:
 
-     Returns ``#t`` if this option was supplied on the command line. Returns
-     ``#f`` if called before :func:`parse-command-line` has been called on the
+     Returns :drm:`#t` if this option was supplied on the command line. Returns
+     :drm:`#f` if called before :func:`parse-command-line` has been called on the
      associated parser, or if the option wasn't supplied on the command line.
 
 .. function:: option-value
@@ -382,7 +382,7 @@ The command-line-parser Module
      Returns the parsed value of the option supplied on the command line.  If
      no value was supplied on the command line it returns the value specified
      with ``default:`` when the option was created, which in turn defaults to
-     ``#f``.
+     :drm:`#f`.
 
      Note that the type of the return value is specified by the ``type:``
      keyword argument when the option was created and the string supplied on
@@ -517,7 +517,7 @@ Option Classes
 
      A default value for the option that will be used if the option isn't
      specified by the user. The default value should be a member of the type
-     specified with the ``type:`` keyword. ``#f`` is the default default value.
+     specified with the ``type:`` keyword. :drm:`#f` is the default default value.
 
 .. class:: <flag-option>
    :sealed:
@@ -532,7 +532,7 @@ Option Classes
 
    :description:
 
-     They default to ``#f`` and may exist in both positive and negative forms:
+     They default to :drm:`#f` and may exist in both positive and negative forms:
      ``--foo`` and ``--no-foo``.  In the case of conflicting options, the
      rightmost takes precedence to allow for abuse of the shell's "alias"
      command.
@@ -554,7 +554,7 @@ Option Classes
 
      If the option appears more than once, the rightmost value takes
      precedence. If the option never appears, these will default to
-     ``#f``.
+     :drm:`#f`.
 
      Examples::
 
@@ -572,8 +572,8 @@ Option Classes
    :description:
 
      The parameter must directly follow the option with no intervening
-     whitespace, or follow an "=" token. The value is ``#f`` if the option
-     never appears, ``#t`` if the option appears but the parameter does
+     whitespace, or follow an "=" token. The value is :drm:`#f` if the option
+     never appears, :drm:`#t` if the option appears but the parameter does
      not, and the value of the parameter otherwise.
 
      Examples::
@@ -651,7 +651,7 @@ Option Classes
      The final value is a :class:`<string-table>` containing each specified
      key, with one of the following values:
 
-     * ``#t``: The user specified "-Dkey"
+     * :drm:`#t`: The user specified "-Dkey"
      * a string: The user specified "-Dkey=value"
 
      You can read this with ``element(table, key, default: #f)`` to get a

--- a/documentation/library-reference/source/command-line-parser/index.rst
+++ b/documentation/library-reference/source/command-line-parser/index.rst
@@ -617,12 +617,12 @@ Option Classes
      :class:`<usage-error>` is signaled.  If you supply a sequence of
      non-string choices you will also need to supply the ``test:``
      init keyword since all command-line arguments are strings and
-     won't compare equal with the default test, ``=``.
+     won't compare equal with the default test, :drm:`=`.
 
    :keyword test:
 
      A function to test whether the value supplied on the command line
-     is the same as one of the choices.  The default is ``=``.  Another
+     is the same as one of the choices.  The default is :drm:`=`.  Another
      commonly used value is ``string-equal-ic?``, to ignore case in the
      comparison.
 

--- a/documentation/library-reference/source/common-dylan/common-extensions.rst
+++ b/documentation/library-reference/source/common-dylan/common-extensions.rst
@@ -51,14 +51,11 @@ The extensions are:
    Signals an error if the expression passed to it evaluates to false.
 
    :macrocall:
+     .. parsed-literal:: 
+        assert `expression` `format-string` [`format-arg`] => `false`
 
-     .. code-block:: dylan
-
-       assert *expression* *format-string* [*format-arg* ]* => *false*
-
-     .. code-block:: dylan
-
-       assert *expression* => *false*
+     .. parsed-literal:: 
+        assert `expression` => `false`
 
    :parameter expression: A Dylan expression *bnf*.
    :parameter format-string: A Dylan expression *bnf*.
@@ -77,7 +74,7 @@ The extensions are:
      the DRM. If *format-string* is supplied, the error is formatted
      accordingly, along with any instances of *format-arg*.
 
-     If *expression* is not :drm:`#f`, ``assert`` does not evaluate
+     If *expression* is not :drm:`#f`, :macro:`assert` does not evaluate
      *format-string* or any instances of *format-arg*.
 
    :seealso:
@@ -158,13 +155,11 @@ The extensions are:
    but only when the code is compiled in interactive development mode.
 
    :macrocall:
-     .. code-block:: dylan
+     .. parsed-literal:: 
+        debug-assert `expression` `format-string` [`format-arg`] => `false`
 
-       debug-assert *expression* *format-string* [ *format-arg* ]* => *false*
-
-     .. code-block:: dylan
-
-       debug-assert *expression* => *false*
+     .. parsed-literal:: 
+        debug-assert `expression` => `false`
 
    :parameter expression: A Dylan expression *bnf*.
    :parameter format-string: A Dylan expression *bnf*.
@@ -317,14 +312,12 @@ The extensions are:
    before calling :drm:`default-handler`.
 
    :macrocall:
-     .. code-block:: dylan
+     .. parsed-literal:: 
+        define last-handler (`condition`, #key `test`, `init-args`) = `handler` ;
 
-       define last-handler (*condition*, #key *test*, *init-args*)
-         = *handler* ;
+        define last-handler `condition` = `handler`;
 
-       define last-handler condition = handler;
-
-       define last-handler;
+        define last-handler;
 
    :parameter condition: A Dylan expression *bnf*. The class of
      condition for which the handler should be invoked.
@@ -385,9 +378,8 @@ The extensions are:
    to a new table object.
 
    :macrocall:
-     .. code-block:: dylan
-
-       define table *name* [ :: *type* ] = { [ *key* => *element* ]* }
+     .. parsed-literal:: 
+        define table `name` [ :: `type` ] = { [ `key` => `element` ]* }
 
    :parameter name: A Dylan name *bnf*.
    :parameter type: A Dylan operand *bnf*. Default value: :drm:`<table>`.
@@ -680,11 +672,11 @@ The extensions are:
    Iterates over a body.
 
    :macrocall:
-     .. code-block:: dylan
+     .. parsed-literal:: 
 
-       iterate *name* ({*argument* = *init-value*}*)
-         [ *body* ]
-       end [ iterate ]
+        iterate `name` ({`argument` = `init-value`}*)
+          [ `body` ]
+        end [ iterate ]
 
    :parameter name: A Dylan variable-name *bnf*.
    :parameter argument: A Dylan variable-name *bnf*.
@@ -1261,9 +1253,8 @@ The extensions are:
    nothing if the test is false.
 
    :macrocall:
-     .. code-block:: dylan
-
-       when (*test*) [ *consequent* ] end [ when ]
+     .. parsed-literal:: 
+        when (`test`) [ `consequent` ] end [ when ]
 
    :parameter test: A Dylan expression *bnf*.
    :parameter consequent: A Dylan body *bnf*.

--- a/documentation/library-reference/source/common-dylan/common-extensions.rst
+++ b/documentation/library-reference/source/common-dylan/common-extensions.rst
@@ -64,11 +64,11 @@ The extensions are:
    :parameter format-string: A Dylan expression *bnf*.
    :parameter format-arg: A Dylan expression *bnf*.
 
-   :value false: ``#f``.
+   :value false: :drm:`#f`.
 
    :description:
 
-     Signals an error if *expression* evaluates to ``#f``.
+     Signals an error if *expression* evaluates to :drm:`#f`.
 
      An assertion or "assert" is a simple tool for testing that
      conditions hold in program code.
@@ -77,7 +77,7 @@ The extensions are:
      the DRM. If *format-string* is supplied, the error is formatted
      accordingly, along with any instances of *format-arg*.
 
-     If *expression* is not ``#f``, ``assert`` does not evaluate
+     If *expression* is not :drm:`#f`, ``assert`` does not evaluate
      *format-string* or any instances of *format-arg*.
 
    :seealso:
@@ -169,7 +169,7 @@ The extensions are:
    :parameter expression: A Dylan expression *bnf*.
    :parameter format-string: A Dylan expression *bnf*.
    :parameter format-arg: A Dylan expression *bnf*.
-   :value false: ``#f``.
+   :value false: :drm:`#f`.
 
    :description:
 
@@ -217,7 +217,7 @@ The extensions are:
    :signature: default-handler *warning* => *false*
 
    :parameter warning: An instance of :drm:`<warning>`.
-   :value false: ``#f``.
+   :value false: :drm:`#f`.
 
    :description:
 
@@ -507,7 +507,7 @@ The extensions are:
    :parameter collection: An instance of :drm:`<collection>`.
    :parameter predicate: An instance of :drm:`<function>`.
    :parameter #key skip: An instance of :drm:`<integer>`. Default value: 0.
-   :parameter #key failure: An instance of :drm:`<object>`. Default value: ``#f``.
+   :parameter #key failure: An instance of :drm:`<object>`. Default value: :drm:`#f`.
    :value element: An instance of :drm:`<object>`.
 
    :description:
@@ -663,7 +663,7 @@ The extensions are:
    :parameter base: An instance of :drm:`<integer>` (default 10).
    :parameter size: An instance of :drm:`<integer>` (default 0).
    :parameter fill: An instance of :drm:`<character>` (default 0).
-   :parameter lowercase?: An instance of :drm:`<boolean>` (default ``#f``).
+   :parameter lowercase?: An instance of :drm:`<boolean>` (default :drm:`#f`).
    :value string: An instance of :drm:`<byte-string>`.
 
    :description:
@@ -747,9 +747,9 @@ The extensions are:
    :parameter target: An instance of :drm:`<object>`.
    :parameter #key test: An instance of :drm:`<function>`. Default value: :drm:`==`.
    :parameter #key start: An instance of :drm:`<integer>`. Default value: 0.
-   :parameter #key end: An instance of :drm:`<object>`. Default value: ``#f``.
+   :parameter #key end: An instance of :drm:`<object>`. Default value: :drm:`#f`.
    :parameter #key skip: An instance of :drm:`<integer>`. Default value: 0.
-   :parameter #key count: An instance of :drm:`<object>`. Default value: ``#f``.
+   :parameter #key count: An instance of :drm:`<object>`. Default value: :drm:`#f`.
    :value position: An instance of ``false-or(<integer>)``.
 
    :description:
@@ -764,7 +764,7 @@ The extensions are:
      The *skip* argument is interpreted as it is by Dylan's :drm:`find-key`
      function: *position* ignores the first *skip* elements that match
      *target*, and if *skip* or fewer elements satisfy *test*, it
-     returns ``#f``.
+     returns :drm:`#f`.
 
      The *start* and *end* arguments indicate, if supplied, which subrange
      of the *sequence* is used for the search.
@@ -1341,7 +1341,7 @@ The extensions are:
    2. the start index in that sequence at which to begin searching, and
    3. the index at which to stop searching (exclusive).
 
-   The *separator* function must return ``#f`` to indicate that no separator was
+   The *separator* function must return :drm:`#f` to indicate that no separator was
    found, or two values:
 
    1. The start index of the separator in the sequence and
@@ -1516,7 +1516,7 @@ The extensions are:
    :description:
 
      Returns the full filename (that is, the absolute pathname) of the
-     running application, or ``#f`` if the filename cannot be
+     running application, or :drm:`#f` if the filename cannot be
      determined.
 
    :example:

--- a/documentation/library-reference/source/common-dylan/machine-words.rst
+++ b/documentation/library-reference/source/common-dylan/machine-words.rst
@@ -156,7 +156,7 @@ integer value.
    :signature: limited t == <machine-word> #key signed? min max => r
 
    :parameter #key signed?: An instance of :drm:`<boolean>`. Defaults to
-                            ``#t``
+                            :drm:`#t`.
    :parameter #key min: An instance of :class:`<machine-word>`
    :parameter #key max: An instance of :class:`<machine-word>`
    :value r: An instance of :class:`<type>`

--- a/documentation/library-reference/source/common-dylan/simple-profiling.rst
+++ b/documentation/library-reference/source/common-dylan/simple-profiling.rst
@@ -18,9 +18,9 @@ Simple Profiling
    of code it is wrapped around.
 
    :macrocall:
-     .. code-block:: dylan
+     .. parsed-literal:: 
 
-       timing () [ *body* ] end [ timing ]
+        timing () [ `body` ] end [ timing ]
 
    :parameter body: A Dylan body *bnf*
    :value seconds: An instance of :drm:`<integer>`.
@@ -53,12 +53,12 @@ Simple Profiling
    it is wrapped around.
 
    :macrocall:
-     .. code-block:: dylan
+     .. parsed-literal:: 
 
-        profiling ([*profiling-type*, ...])
-          *body*
+        profiling ([`profiling-type`, ...])
+          `body`
         results
-          *results*
+          `results`
         end
 
    :parameter profiling-type: Any of ``cpu-time-seconds``,

--- a/documentation/library-reference/source/dood/index.rst
+++ b/documentation/library-reference/source/dood/index.rst
@@ -153,7 +153,7 @@ The DOOD module
    :value value: An instance of :class:`<object>`.
 
    Returns the one distinguished root of the specified dood. It is
-   defaulted to be ``#f`` when a new dood is created.
+   defaulted to be :drm:`#f` when a new dood is created.
 
 .. generic-function:: dood-root-setter
 

--- a/documentation/library-reference/source/dylan/finalization.rst
+++ b/documentation/library-reference/source/dylan/finalization.rst
@@ -323,7 +323,7 @@ finalization interface. These items are exported from the
 
    :signature: automatic-finalization-enabled? () => *enabled?*
 
-   :value enabled?: An instance of :drm:`<boolean>`. Default value: ``#f``.
+   :value enabled?: An instance of :drm:`<boolean>`. Default value: :drm:`#f`.
 
    :description:
 
@@ -348,11 +348,11 @@ finalization interface. These items are exported from the
 
      Sets the automatic finalization system state to *newval*.
 
-     The initial state is ``#f``. If the state changes from ``#f`` to
-     ``#t``, a new thread is created which regularly calls
+     The initial state is :drm:`#f`. If the state changes from :drm:`#f` to
+     :drm:`#t`, a new thread is created which regularly calls
      :func:`drain-finalization-queue` inside an empty dynamic
      environment (that is, no dynamic condition handlers). If the state
-     changes from ``#t`` to ``#f``, the thread exits.
+     changes from :drm:`#t` to :drm:`#f`, the thread exits.
 
    :seealso:
 

--- a/documentation/library-reference/source/dylan/primitives.rst
+++ b/documentation/library-reference/source/dylan/primitives.rst
@@ -153,7 +153,7 @@ Simple Locks
    :signature: (lock :: <portable-container>, name :: false-or(<byte-string>)) => ()
 
    :parameter lock: An instance of :class:`<simple-lock>`.
-   :parameter name: The name of the lock (as a :drm:`<byte-string>`) or ``#f``.
+   :parameter name: The name of the lock (as a :drm:`<byte-string>`) or :drm:`#f`.
 
    :description:
 
@@ -229,7 +229,7 @@ Recursive Locks
    :signature: (lock :: <portable-container>, name :: false-or(<byte-string>)) => ()
 
    :parameter lock: An instance of :class:`<recursive-lock>`.
-   :parameter name: The name of the lock (as a :drm:`<byte-string>`) or ``#f``.
+   :parameter name: The name of the lock (as a :drm:`<byte-string>`) or :drm:`#f`.
 
    :description:
 
@@ -310,7 +310,7 @@ Semaphores
    :signature: (lock :: <portable-container>, name :: false-or(<byte-string>), initial :: <integer>, max :: <integer>) => ()
 
    :parameter lock: An instance of :class:`<semaphore>`.
-   :parameter name: The name of the lock (as a :drm:`<byte-string>`) or ``#f``.
+   :parameter name: The name of the lock (as a :drm:`<byte-string>`) or :drm:`#f`.
    :parameter initial: The initial value for the semaphore count.
 
    :description:
@@ -378,7 +378,7 @@ Notifications
    :signature: (notification :: <portable-container>, name :: false-or(<byte-string>)) => ()
 
    :parameter notification: An instance of :class:`<notification>`.
-   :parameter name: The name of the notification (as a :drm:`<byte-string>`) or ``#f``.
+   :parameter name: The name of the notification (as a :drm:`<byte-string>`) or :drm:`#f`.
 
    :description:
 
@@ -670,7 +670,7 @@ Entry Point Functions
     wrong. It then sets the calling convention for calling the internal
     entry point. This basically means that the function register is
     appropriately set, and the implementation 'mlist' parameter is set to
-    ``#f``.
+    :drm:`#f`.
 
 .. c:function:: D optional_xep (FN* function, int argument_count, ...)
 
@@ -818,8 +818,8 @@ This primitive returns Dylan true if *value* is non-zero, and false if
 
    :description:
 
-This is the complement of *primitive-true?*, returning ``#t`` if the
-value is 0, ``#f`` otherwise.
+This is the complement of *primitive-true?*, returning :drm:`#t` if the
+value is 0, :drm:`#f` otherwise.
 
 .. primitive:: primitive-equals?
 

--- a/documentation/library-reference/source/dylan/threads.rst
+++ b/documentation/library-reference/source/dylan/threads.rst
@@ -731,12 +731,11 @@ Locks
    Holds a lock while executing a body of code.
 
    :macrocall:
-     .. code-block:: dylan
-
-       with-lock (*lock*, #key *keys*)
-         *body*
-       [failure *failure-expr* ]
-       end
+     .. parsed-literal:: 
+        with-lock (`lock`, #key `keys`)
+          `body`
+        [ failure `failure-expr` ]
+        end
 
    :param lock: An instance of :class:`<lock>`.
    :param keys: Zero or more of the keywords provided by :gf:`wait-for`.
@@ -1461,9 +1460,7 @@ Thread variables
    An adjective to *define variable* for defining thread variables.
 
    :macrocall:
-     .. code-block:: dylan
-
-       define thread variable *bindings* = *init* ;
+     .. parsed-literal:: define thread variable `bindings` = `init` ;
 
    :description:
 
@@ -1492,11 +1489,10 @@ Dynamic binding
    rebound.
 
    :macrocall:
-     .. code-block:: dylan
-
-       dynamic-bind (*place1* = *init1*, *place2* = *init2*, ...)
-         *body*
-       end;
+     .. parsed-literal:: 
+        dynamic-bind (`place1` = `init1`, `place2` = `init2`, ...)
+          `body`
+        end
 
    :description:
 
@@ -1557,11 +1553,10 @@ The extended form is described below.
    are dynamically rebound.
 
    :macrocall:
-     .. code-block:: dylan
-
-        dynamic-bind (*place1* = *init1*, *place2* = *init2*, ...)
-          *body*
-        end;
+     .. parsed-literal:: 
+        dynamic-bind (`place1` = `init1`, `place2` = `init2`, ...)
+          `body`
+        end
 
      (This is the same as the simple form.)
 
@@ -1612,9 +1607,7 @@ Locked variables
    Defines a locked variable.
 
    :macrocall:
-     .. code-block:: dylan
-
-       define locked variable *bindings* = *init* ;
+     .. parsed-literal:: define locked variable `bindings` = `init` ;
 
    :description:
 
@@ -1649,17 +1642,15 @@ Conditional update
    Performs an atomic test-and-set operation.
 
    :macrocall:
+     .. parsed-literal:: 
+        conditional-update!(`local-name` = `place`)
+          `body`
+          [success `success-expr` ]
+          [failure `failure-expr` ]
+        end
 
-     .. code-block:: dylan
-
-       conditional-update!(*local-name* = *place*)
-         *body*
-         [success *success-expr* ]
-         [failure *failure-expr* ]
-       end
-
-   :parameter local-name: A Dylan variable-name*bnf*.
-   :parameter place: A Dylan variable-namebnf,
+   :parameter local-name: A Dylan variable-name *bnf*.
+   :parameter place: A Dylan variable-name *bnf*,
      If the implementation provides the extended form of
      :macro:`conditional-update!`, *place* can also be a
      function call.
@@ -1727,13 +1718,11 @@ Conditional update
    Atomically increments a place containing a numeric value.
 
    :macrocall:
-     .. code-block:: dylan
+     .. parsed-literal:: atomic-increment!(`place`)
 
-       atomic-increment!(*place*);
+     .. parsed-literal:: atomic-increment!(`place`, `by`)
 
-       atomic-increment!(*place*, *by*);
-
-   :parameter place: A Dylan variable-namebnf.
+   :parameter place: A Dylan variable-name *bnf*.
      If the implementation provides the extended form of
      :macro:`conditional-update!`, *place* can also be a
      function call.
@@ -1776,13 +1765,11 @@ Conditional update
    Atomically decrements a place containing a numeric value.
 
    :macrocall:
-     .. code-block:: dylan
+     .. parsed-literal:: atomic-decrement!(`place`)
 
-       atomic-decrement!(*place*)
+     .. parsed-literal:: atomic-decrement!(`place`, `by`)
 
-       atomic-decrement!(*place*, *by*)
-
-   :parameter place: A Dylan variable-namebnf.
+   :parameter place: A Dylan variable-name *bnf*.
      If the implementation provides the extended form of
      :macro:`conditional-update!`, *place* can also be a
      function call.
@@ -1815,13 +1802,12 @@ feature.
    Performs an atomic test-and-set operation.
 
    :macrocall:
-     .. code-block:: dylan
-
-       conditional-update!(*local-name* = *place*)
-         *body*
-         [success *success-expr* ]
-         [failure *failure-expr* ]
-       end
+     .. parsed-literal:: 
+        conditional-update!(`local-name` = `place`)
+          `body`
+          [success `success-expr` ]
+          [failure `failure-expr` ]
+        end
 
    :parameter local-name: A Dylan variable-name *bnf*.
    :parameter place: A Dylan variable-name *bnf* or a function call.

--- a/documentation/library-reference/source/dylan/threads.rst
+++ b/documentation/library-reference/source/dylan/threads.rst
@@ -715,7 +715,7 @@ Locks
      a thread uses a lock for *mutual-exclusion* in this way, the thread
      is said to *own the lock*.
 
-     :class:`<lock>` has no direct instances; calling *make* on :class:`<lock>`
+     :class:`<lock>` has no direct instances; calling :drm:`make` on :class:`<lock>`
      returns an instance of :class:`<simple-lock>`.
 
    :operations:
@@ -744,21 +744,21 @@ Locks
 
    :conditions:
 
-     *with-lock* may signal a condition of the following class (a
+     :macro:`with-lock` may signal a condition of the following class (a
      subclass of :drm:`<serious-condition>`):
 
      :class:`<timeout-expired>`
-       This is signalled when *with-lock* did not succeed in claiming
+       This is signalled when :macro:`with-lock` did not succeed in claiming
        the lock within the timeout period.
 
    :description:
 
      Execute the *body* with *lock* held. If a *failure* clause is
      supplied, then it will be evaluated and its values returned from
-     *with-lock* if the lock cannot be claimed (because a timeout
+     :macro:`with-lock` if the lock cannot be claimed (because a timeout
      occurred). The default, if no *failure* clause is supplied, is
      to signal an exception of class :class:`<timeout-expired>`. If there
-     is no failure, *with-lock* returns the results of evaluating the
+     is no failure, :macro:`with-lock` returns the results of evaluating the
      body.
 
    :example:
@@ -855,7 +855,7 @@ Semaphores
 
    :conditions:
 
-     An implementation of this *release* method is permitted to signal a
+     An implementation of this :gf:`release` method is permitted to signal a
      condition of the following class, which is a subclass of
      :drm:`<error>`:
 
@@ -893,13 +893,13 @@ Exclusive locks
      The notion of ownership is directly supported by the class, and a
      thread can test whether an :class:`<exclusive-lock>` is currently owned.
      An instance of :class:`<exclusive-lock>` can only be owned by one thread
-     at a time, by calling *wait-for* on the lock.
+     at a time, by calling :gf:`wait-for` on the lock.
 
      Once owned, any attempt by any other thread to wait for the lock
      will cause that thread to block. It is an error for a thread to
      release an :class:`<exclusive-lock>` if another thread owns it.
 
-     :class:`<exclusive-lock>` has no direct instances; calling *make* on
+     :class:`<exclusive-lock>` has no direct instances; calling :drm:`make` on
      :class:`<exclusive-lock>` returns an instance of :class:`<simple-lock>`.
 
    :operations:
@@ -921,7 +921,7 @@ Exclusive locks
 
    :conditions:
 
-     Implementations of *release* methods for subclasses of
+     Implementations of :gf:`release` methods for subclasses of
      :class:`<exclusive-lock>` are permitted to signal a condition
      of the following class, which is a subclass of :drm:`<error>`:
 
@@ -935,7 +935,7 @@ Exclusive locks
      Releases a lock that is owned by the calling thread. It is an error
      if the lock is not owned.
 
-     The Threads module does not provide a method on *release* for
+     The Threads module does not provide a method on :gf:`release` for
      :class:`<exclusive-lock>`, which is an open abstract class. Each
      concrete subclass will have an applicable method which may signal
      errors according to the protocol described above.
@@ -1359,19 +1359,19 @@ Notifications
      for another thread to release the notification. The current thread
      reclaims the lock once it has received the notification.
 
-     Note that the state should be tested again once *wait-for* has
+     Note that the state should be tested again once :gf:`wait-for` has
      returned, because there may have been a delay between the
      :meth:`release <release(<notification>)>` of the notification and
      the claiming of the lock, and the state may have been changed
      during that time. If a timeout is supplied, then this is used for
-     waiting for the release of the notification only. The *wait-for*
+     waiting for the release of the notification only. The :gf:`wait-for`
      function always waits for the lock with no timeout, and it is
-     guaranteed that the lock will be owned on return. The *wait-for*
+     guaranteed that the lock will be owned on return. The :gf:`wait-for`
      function returns :drm:`#f` if the notification wait times out.
 
    :conditions:
 
-     Implementations of this *wait-for* method are permitted to signal a
+     Implementations of this :gf:`wait-for` method are permitted to signal a
      condition of the following class, which is a subclass of :drm:`<error>`:
 
      :class:`<not-owned-error>`
@@ -1392,7 +1392,7 @@ Notifications
 
    :conditions:
 
-     Implementations of this *release* method are permitted to signal a
+     Implementations of this :gf:`release` method are permitted to signal a
      condition of the following class, which is a subclass of
      :drm:`<error>`:
 
@@ -1420,7 +1420,7 @@ Notifications
 
    :conditions:
 
-     Implementations of the *release-all* function are permitted to signal a
+     Implementations of the :gf:`release-all` function are permitted to signal a
      condition of the following class, which is a subclass of :drm:`<error>`:
 
      :class:`<not-owned-error>`
@@ -1457,7 +1457,7 @@ Thread variables
 .. macro:: thread
    :macro-type: variable definition adjective
 
-   An adjective to *define variable* for defining thread variables.
+   An adjective to :drm:`define variable` for defining thread variables.
 
    :macrocall:
      .. parsed-literal:: define thread variable `bindings` = `init` ;

--- a/documentation/library-reference/source/io/print.rst
+++ b/documentation/library-reference/source/io/print.rst
@@ -152,7 +152,7 @@ IO library's *print* module.
      circular printing was on shares the same tagging space; that is, if
      ``#1#`` is printed twice, once from each of two distinct recursive
      calls to print, then each ``#1#`` is guaranteed to signify the same
-     ``==`` object.
+     :drm:`==` object.
 
      The *pretty?* keyword indicates whether printing should attempt to
      insert line breaks and indentation to format objects according to

--- a/documentation/library-reference/source/io/print.rst
+++ b/documentation/library-reference/source/io/print.rst
@@ -331,12 +331,10 @@ IO library's *print* module.
    Wrapper around :macro:`printing-logical-block`.
 
    :macrocall:
-
-      .. code-block:: dylan
-
-         printing-object(*object*, *stream*, #key type? = #t)
-           *body*
-         end;
+      .. parsed-literal:: 
+         printing-object(`object`, `stream`, #key type? = #t)
+           `body`
+         end
 
    *printing-object* may be used within :gf:`print-object` to print Dylan
    objects in a standardized way while adding identifying information for your

--- a/documentation/library-reference/source/io/print.rst
+++ b/documentation/library-reference/source/io/print.rst
@@ -90,9 +90,9 @@ IO library's *print* module.
      :var:`*print-circle?*`.
    :parameter #key escape?: An instance of :drm:`<boolean>`. Default value:
      :var:`*print-escape?*`.
-   :parameter #key level: ``#f`` or an instance of :drm:`<integer>`.
+   :parameter #key level: :drm:`#f` or an instance of :drm:`<integer>`.
      Default value: :var:`*print-level*`.
-   :parameter #key length: ``#f`` or an instance of :drm:`<integer>`.
+   :parameter #key length: :drm:`#f` or an instance of :drm:`<integer>`.
      Default value: :var:`*print-length*`.
    :parameter #key pretty?: An instance of :drm:`<boolean>`. Default value:
      :var:`*print-pretty?*`.
@@ -113,7 +113,7 @@ IO library's *print* module.
      which is described in `Pretty printing`_.
 
      The *level* keyword controls how deep into a nested data structure
-     to print. The value ``#f`` indicates that there is no limit. The
+     to print. The value :drm:`#f` indicates that there is no limit. The
      default, :var:`*print-level*`, has no effect on recursive calls to
      :func:`print`. Recursive calls to :func:`print` may change the value of
      *print-level* explicitly, but :func:`print` always uses a value to
@@ -124,7 +124,7 @@ IO library's *print* module.
      not 4.
 
      The *length* keyword controls how many elements of a sequence to
-     print before printing ellipsis notation (*...*). The value ``#f``
+     print before printing ellipsis notation (*...*). The value :drm:`#f`
      indicates that there is no limit. The *print-length* control can be
      interpreted loosely by some :gf:`print-object` methods to control
      how many *elements* of any kind of object to print; for example,
@@ -141,13 +141,13 @@ IO library's *print* module.
      tags objects that occur more than once when they are first printed,
      and later occurrences are printed as a reference to the previously
      emitted tag. The default, :var:`*print-circle?*`, has no effect on
-     recursive calls to :func:`print`. If *print-circle?* is already ``#t``,
-     then it remains ``#t`` throughout all recursive calls. If
-     *print-circle?* is ``#f``, then recursive calls to :func:`print` can
-     change the value to ``#t`` ; however, when printing exits the
-     dynamic scope of the call that changed the value to ``#t``, the
-     value reverts back to ``#f``. If the original call to :func:`print`
-     specifies *circle?* as ``#f``, and dynamically distinct recursive
+     recursive calls to :func:`print`. If *print-circle?* is already :drm:`#t`,
+     then it remains :drm:`#t` throughout all recursive calls. If
+     *print-circle?* is :drm:`#f`, then recursive calls to :func:`print` can
+     change the value to :drm:`#t` ; however, when printing exits the
+     dynamic scope of the call that changed the value to :drm:`#t`, the
+     value reverts back to :drm:`#f`. If the original call to :func:`print`
+     specifies *circle?* as :drm:`#f`, and dynamically distinct recursive
      calls turn circular printing on and off, all output generated while
      circular printing was on shares the same tagging space; that is, if
      ``#1#`` is printed twice, once from each of two distinct recursive
@@ -158,11 +158,11 @@ IO library's *print* module.
      insert line breaks and indentation to format objects according to
      how programmers tend to find it easier to read data. The default,
      :var:`*print-pretty?*`, has no effect on recursive calls to
-     :func:`print`. If *print-pretty?* is already ``#t``, then it remains
-     ``#t`` throughout all recursive calls. If *print-pretty?* is
-     ``#f``, then recursive calls to :func:`print` can change the value to
-     ``#t`` ; however, when printing exits the dynamic scope of the call
-     that changed the value to ``#t``, the value reverts back to ``#f``.
+     :func:`print`. If *print-pretty?* is already :drm:`#t`, then it remains
+     :drm:`#t` throughout all recursive calls. If *print-pretty?* is
+     :drm:`#f`, then recursive calls to :func:`print` can change the value to
+     :drm:`#t` ; however, when printing exits the dynamic scope of the call
+     that changed the value to :drm:`#t`, the value reverts back to :drm:`#f`.
 
      The *escape?* keyword indicates whether printing should show escape
      codes in strings and, by extension, whether other objects should be
@@ -175,20 +175,20 @@ IO library's *print* module.
 
    :type: <boolean>
 
-   :value: ``#f``
+   :value: :drm:`#f`
 
    :description:
 
      :var:`*print-circle?*` holds the default value for whether or not to
-     detect circular structures when printing. When ``#t``, circularity
-     detection is enabled. The default is ``#f``.
+     detect circular structures when printing. When :drm:`#t`, circularity
+     detection is enabled. The default is :drm:`#f`.
 
      When calling :func:`print` directly, :var:`*print-circle?*` may be
      overridden by specifying a value for the ``circle?`` argument. It is
      dynamically bound by :func:`print` so that its value is inherited by
      recursive calls.
 
-     Note that when :var:`*print-circle?*` is ``#t`` attempts to print circular
+     Note that when :var:`*print-circle?*` is :drm:`#t` attempts to print circular
      structures may result in failure to terminate.
 
    :seealso:
@@ -202,7 +202,7 @@ IO library's *print* module.
 
    :type: <boolean>
 
-   :value: ``#t``
+   :value: :drm:`#t`
 
    :description:
 
@@ -228,12 +228,12 @@ IO library's *print* module.
 
    :type: false-or(<integer>)
 
-   :value: ``#f``
+   :value: :drm:`#f`
 
    :description:
 
      Controls how many elements to print at a given level of a nested
-     expression. The default is unlimited (``#f``).
+     expression. The default is unlimited (:drm:`#f`).
 
    :seealso:
 
@@ -246,7 +246,7 @@ IO library's *print* module.
 
    :type: false-or(<integer>)
 
-   :value: ``#f``
+   :value: :drm:`#f`
 
    :description:
 
@@ -263,7 +263,7 @@ IO library's *print* module.
 
    :type: <boolean>
 
-   :value: ``#f``
+   :value: :drm:`#f`
 
    :description:
 
@@ -308,9 +308,9 @@ IO library's *print* module.
    :signature: print-to-string *object* #key *circle? escape? level length pretty?* => *result*
 
    :parameter object: An instance of :drm:`<object>`.
-   :parameter #key level: ``#f`` or an instance of :drm:`<integer>`.
+   :parameter #key level: :drm:`#f` or an instance of :drm:`<integer>`.
      Default value: :var:`*print-level*`.
-   :parameter #key length: ``#f`` or an instance of :drm:`<integer>`.
+   :parameter #key length: :drm:`#f` or an instance of :drm:`<integer>`.
      Default value: :var:`*print-length*`.
    :parameter #key circle?: An instance of :drm:`<boolean>`. Default value:
      :var:`*print-circle?*`.
@@ -401,10 +401,10 @@ IO library's *pprint* module.
    :signature: pprint-logical-block *stream* #key *prefix per-line-prefix body suffix column* => ()
 
    :parameter stream: An instance of :class:`<stream>`.
-   :parameter #key prefix: ``#f`` or an instance of :drm:`<byte-string>`.
-   :parameter #key per-line-prefix: ``#f`` or an instance of :drm:`<byte-string>`.
+   :parameter #key prefix: :drm:`#f` or an instance of :drm:`<byte-string>`.
+   :parameter #key per-line-prefix: :drm:`#f` or an instance of :drm:`<byte-string>`.
    :parameter #key body: An instance of :drm:`<function>`.
-   :parameter #key suffix: ``#f`` or an instance of :drm:`<byte-string>`.
+   :parameter #key suffix: :drm:`#f` or an instance of :drm:`<byte-string>`.
    :parameter #key column: A *limited* instance of :drm:`<integer>`, minimum 0.
 
    :description:
@@ -417,7 +417,7 @@ IO library's *pprint* module.
      *prefix* ends. Alternatively, *per-line-prefix* is a string to
      print on every line of the logical block. This function signals an
      error if it is called with both *prefix* and *per-line-prefix*
-     supplied as non-``#f``. *Suffix* is a string to print at the end of
+     supplied as non-:drm:`#f`. *Suffix* is a string to print at the end of
      the logical block. *Column* advises the pretty printer as to the
      current column of the output stream (the default is zero). The
      *column* argument may be ignored entirely by some methods, and it
@@ -513,7 +513,7 @@ IO library's *pprint* module.
    Controls miser mode.
 
    :type: false-or(<integer>)
-   :value: ``#f``
+   :value: :drm:`#f`
 
    :description:
 
@@ -525,5 +525,5 @@ IO library's *pprint* module.
 
           *default-line-length* - *print-miser-width*
 
-     The value must be an integer or ``#f`` (the default); ``#f``
+     The value must be an integer or :drm:`#f` (the default); :drm:`#f`
      indicates that the pretty printer should never enter miser mode.

--- a/documentation/library-reference/source/io/streams.rst
+++ b/documentation/library-reference/source/io/streams.rst
@@ -2941,18 +2941,16 @@ are exported from the *streams* module.
    :statement:
 
    :macrocall:
+     .. parsed-literal:: 
+        with-indentation (`stream`)
+          `body`
+        end
 
-     .. code-block:: dylan
+     .. parsed-literal:: 
 
-        with-indentation (*stream*)
-          *body*
-        end;
-
-     .. code-block:: dylan
-
-        with-indentation (*stream*, 4)
-          *body*
-        end;
+        with-indentation (`stream`, 4)
+          `body`
+        end
 
    :parameter stream: A Dylan expression *bnf*. An instance of
      :class:`<indenting-stream>`.
@@ -2985,10 +2983,10 @@ are exported from the *streams* module.
    Runs a body of code within the context of a file stream.
 
    :macrocall:
-     .. code-block:: dylan
-
-       with-open-file (*stream-var* = *filename*, #rest *keys*)
-         *body* end => *values*
+     .. parsed-literal:: 
+        with-open-file (`stream-var` = `filename`, #rest `keys`)
+          `body`
+        end => `values`
 
    :parameter stream-var: An Dylan variable-name *bnf*.
    :parameter filename: An instance of :drm:`<string>`.
@@ -3047,11 +3045,10 @@ are exported from the *streams* module.
    Run a body of code while the stream is locked.
 
    :macrocall:
-     .. code-block:: dylan
-
-       with-stream-locked (*stream-var*)
-         *body*
-       end => *values*
+     .. parsed-literal:: 
+        with-stream-locked (`stream-var`)
+          `body`
+        end => `values`
 
    :parameter stream-var: An Dylan variable-name *bnf*.
    :parameter body: A Dylan body *bnf*.

--- a/documentation/library-reference/source/io/streams.rst
+++ b/documentation/library-reference/source/io/streams.rst
@@ -263,7 +263,7 @@ to *make* in addition to those described in `File streams`_:
 The ``if-exists:`` init-keyword allows you to specify an action to take if
 the file named by *filename* already exists. The options are:
 
-- ``#f`` The file is opened with the stream position at the beginning.
+- :drm:`#f` The file is opened with the stream position at the beginning.
   This is the default when the stream's direction is ``#"input"`` or
   ``#"input-output"``.
 - ``#"new-version"`` If the underlying file system supports file versioning,
@@ -286,7 +286,7 @@ the file named by *filename* already exists. The options are:
 The ``if-does-not-exist:`` init-keyword allows you to specify an action to
 take if the file named by *filename* does not exist. The options are:
 
-- ``#f`` No action.
+- :drm:`#f` No action.
 - ``#"signal"`` Signal a :class:`<file-does-not-exist-error>` condition. This is
   the default when the stream's direction is ``#"input"``.
 - ``#"create"`` Create a new zero-length file. This is the default when
@@ -316,16 +316,16 @@ are:
   The file is accessed as a sequence of unsigned 8-bit integers.
 
 The ``asynchronous?:`` init-keyword allows asynchronous writing of stream
-data to disk. If ``#f``, whenever the stream has to write a buffer to
+data to disk. If :drm:`#f`, whenever the stream has to write a buffer to
 disk, the thread which triggered the write must wait for the write to
-complete. If ``asynchronous?`` is ``#t``, the write proceeds in parallel
+complete. If ``asynchronous?`` is :drm:`#t`, the write proceeds in parallel
 with the subsequent actions of the thread.
 
 Note that asynchronous writes complicate error handling a bit. Any write
 error which occurs most likely occurs after the call which triggered the
 write. If this happens, the error is stored in a queue, and the next
 operation on that stream signals the error. If you *close* the stream
-with the *wait?* flag ``#f``, the close happens asynchronously (after all
+with the *wait?* flag :drm:`#f`, the close happens asynchronously (after all
 queued writes complete) and errors may occur after *close* has returned.
 A method :gf:`wait-for-io-completion` is provided to catch any errors that
 may occur after *close* is called.
@@ -422,7 +422,7 @@ If a stretchy vector is not supplied, the result is different:
     values(v, stream-contents(stream));
 
 This example returns as its first value the original vector, which was
-initially filled with all ``#f`` and then with the values from the first call
+initially filled with all :drm:`#f` and then with the values from the first call
 to :gf:`write`, but the second value is a new vector that had to be allocated
 on the second call to :gf:`write`:
 
@@ -1127,7 +1127,7 @@ are exported from the *streams* module.
    :signature: close *file-stream* #key *abort?* *wait?* => ()
 
    :parameter file-stream: An instance of :class:`<file-stream>`.
-   :parameter #key abort?: An instance of :drm:`<boolean>`. Default value: ``#f``.
+   :parameter #key abort?: An instance of :drm:`<boolean>`. Default value: :drm:`#f`.
    :parameter #key wait?: An instance of :drm:`<boolean>`.
 
    :description:
@@ -1308,13 +1308,13 @@ are exported from the *streams* module.
    :keyword direction: Specifies the direction of the stream. It must be one of
      ``#"input"``, ``#"output"``, or ``#"input-output"``. Default value:
      ``#"input"``.
-   :keyword if-exists: One of ``#f``, ``#"new-version"``,
+   :keyword if-exists: One of :drm:`#f`, ``#"new-version"``,
      ``#"overwrite"``, ``#"replace"``, ``#"append"``, ``#"truncate"``,
-     ``#"signal"``. Default value: ``#f``.
-   :keyword if-does-not-exist: One of ``#f``, ``#"signal"``, or
+     ``#"signal"``. Default value: :drm:`#f`.
+   :keyword if-does-not-exist: One of :drm:`#f`, ``#"signal"``, or
      ``#"create"``. Default value: depends on the value of ``direction:``.
-   :keyword asynchronous?: If ``#t``, all writes on this stream are
-     performed asynchronously. Default value:``#f``.
+   :keyword asynchronous?: If :drm:`#t`, all writes on this stream are
+     performed asynchronously. Default value::drm:`#f`.
 
    :description:
 
@@ -1346,7 +1346,7 @@ are exported from the *streams* module.
    :signature: force-output *output-stream* #key *synchronize?* => ()
 
    :parameter output-stream: An instance of :class:`<stream>`.
-   :parameter #key synchronize?: An instance of :drm:`<boolean>`. Default value: ``#f``.
+   :parameter #key synchronize?: An instance of :drm:`<boolean>`. Default value: :drm:`#f`.
 
    :description:
 
@@ -1407,8 +1407,8 @@ are exported from the *streams* module.
      Default value is ``0``.
    :keyword input-tab-width: An instance of :drm:`<integer>`.
      Default value is ``8``.
-   :keyword output-tab-width: An instance of ``#f`` or :drm:`<integer>`.
-     Default value is ``#f``.
+   :keyword output-tab-width: An instance of :drm:`#f` or :drm:`<integer>`.
+     Default value is :drm:`#f`.
 
    :description:
 
@@ -1589,14 +1589,14 @@ are exported from the *streams* module.
    :parameter #key filename: An instance of :drm:`<object>`.
    :parameter #key direction: One of ``#"input"``, ``#"output"``, or
      ``#"input-output"``. The default is ``#"input"``.
-   :parameter #key if-exists: One of ``#f``, ``#"new-version"``,
+   :parameter #key if-exists: One of :drm:`#f`, ``#"new-version"``,
      ``#"overwrite"``, ``#"replace"``, ``#"append"``, ``#"truncate"``,
-     ``#"signal"``. Default value: ``#f``.
-   :parameter #key if-does-not-exist: One of ``#f``, ``#"signal"``, or
+     ``#"signal"``. Default value: :drm:`#f`.
+   :parameter #key if-does-not-exist: One of :drm:`#f`, ``#"signal"``, or
      ``#"create"``. Default value: depends on the value of *direction*.
    :parameter #key buffer-size: An instance of :drm:`<integer>`.
    :parameter #key element-type: One of :type:`<byte-character>`,
-     :type:`<unicode-character>`, or :type:`<byte>`, or ``#f``.
+     :type:`<unicode-character>`, or :type:`<byte>`, or :drm:`#f`.
    :value file-stream-instance: An instance of :class:`<file-stream>`.
 
    :description:
@@ -1828,7 +1828,7 @@ are exported from the *streams* module.
 
    :parameter input-stream: An instance of :class:`<stream>`.
    :parameter #key on-end-of-stream: An instance of :drm:`<object>`.
-   :value element-or-eof: An instance of :drm:`<object>`, or ``#f``.
+   :value element-or-eof: An instance of :drm:`<object>`, or :drm:`#f`.
 
    :description:
 
@@ -2029,8 +2029,8 @@ are exported from the *streams* module.
      to the next newline sequence.
 
      The resulting string does not contain the newline sequence. The
-     second value returned is ``#t`` if the read terminated with a
-     newline or ``#f`` if the read terminated because it came to the end
+     second value returned is :drm:`#t` if the read terminated with a
+     newline or :drm:`#f` if the read terminated because it came to the end
      of the stream.
 
      The type of the result string is chosen so that the string can
@@ -2058,7 +2058,7 @@ are exported from the *streams* module.
    :parameter string: An instance of :drm:`<string>`.
    :parameter #key start: An instance of :drm:`<integer>`. Default value: 0.
    :parameter #key on-end-of-stream: An instance of :drm:`<object>`.
-   :parameter #key grow?: An instance of :drm:`<boolean>`. Default value: ``#f``.
+   :parameter #key grow?: An instance of :drm:`<boolean>`. Default value: :drm:`#f`.
    :value string-or-eof: An instance of :drm:`<string>`, or an instance of
      :drm:`<object>` if the end of the stream is reached.
    :value newline?: An instance of :drm:`<boolean>`.
@@ -2072,22 +2072,22 @@ are exported from the *streams* module.
      The input is written into *string* starting at the position
      *start*. By default, *start* is the start of the stream.
 
-     The second return value is ``#t`` if the read terminated with a
-     newline, or ``#f`` if the read completed by getting to the end of
+     The second return value is :drm:`#t` if the read terminated with a
+     newline, or :drm:`#f` if the read completed by getting to the end of
      the input stream.
 
-     If *grow?* is ``#t``, and *string* is not large enough to hold all
+     If *grow?* is :drm:`#t`, and *string* is not large enough to hold all
      of the input, ``read-line-into!`` creates a new string which it
      writes to and returns instead. The resulting string holds all the
      original elements of *string*, except where ``read-line-into!``
      overwrites them with input from *input-stream*.
 
      In a manner consistent with the intended semantics of *grow?*, when
-     *grow?* is ``#t`` and *start* is greater than or equal to
+     *grow?* is :drm:`#t` and *start* is greater than or equal to
      *string.size*, ``read-line-into!`` grows *string* to accommodate
      the *start* index and the new input.
 
-     If *grow?* is ``#f`` and *string* is not large enough to hold the
+     If *grow?* is :drm:`#f` and *string* is not large enough to hold the
      input, the function signals an error.
 
      The end-of-stream behavior and the interpretation of
@@ -2145,8 +2145,8 @@ are exported from the *streams* module.
      from the stream's current position to the first occurrence of
      *element*. The result does not contain *element*.
 
-     The second return value is ``#t`` if the read terminated with
-     *element*, or ``#f`` if the read terminated by reaching the end of
+     The second return value is :drm:`#t` if the read terminated with
+     *element*, or :drm:`#f` if the read terminated by reaching the end of
      the stream's source. The "boundary" element is consumed, that is,
      the stream is left positioned after *element*.
 
@@ -2260,8 +2260,8 @@ are exported from the *streams* module.
    :description:
 
      Positions *input-stream* after the first occurrence of *element*,
-     starting from the stream's current position. Returns ``#t`` if the
-     element was found, or ``#f`` if the end of the stream was
+     starting from the stream's current position. Returns :drm:`#t` if the
+     element was found, or :drm:`#f` if the end of the stream was
      encountered. When ``skip-through`` does not find *element*, it
      leaves *input-stream* positioned at the end.
 
@@ -2335,15 +2335,15 @@ are exported from the *streams* module.
 
    :description:
 
-     Returns ``#t`` if the stream is at its end and ``#f`` if it is not.
-     For input streams, it returns ``#t`` if a call to
+     Returns :drm:`#t` if the stream is at its end and :drm:`#f` if it is not.
+     For input streams, it returns :drm:`#t` if a call to
      :gf:`read-element` with no supplied keyword arguments would signal
      an :class:`<end-of-stream-error>`.
 
      This function differs from :gf:`stream-input-available?`, which
      tests whether the stream can be read.
 
-     For output-only streams, this function always returns ``#f``.
+     For output-only streams, this function always returns :drm:`#f`.
 
      For output streams, note that you can determine if a stream is one
      place past the last written element by comparing
@@ -2375,7 +2375,7 @@ are exported from the *streams* module.
    :signature: stream-contents *positionable-stream* #key *clear-contents?*  => *sequence*
 
    :parameter positionable-stream: An instance of :class:`<positionable-stream>`.
-   :parameter #key clear-contents?: An instance of :drm:`<boolean>`. Default value: ``#t``.
+   :parameter #key clear-contents?: An instance of :drm:`<boolean>`. Default value: :drm:`#t`.
    :value sequence: An instance of :drm:`<sequence>`.
 
    :description:
@@ -2387,7 +2387,7 @@ are exported from the *streams* module.
      The *clear-contents?* argument is only applicable to writeable
      sequence streams, and is not defined for file-streams or any other
      external stream. It returns an error if applied to an input only
-     stream. If clear-contents? is ``#t`` (the default for cases where
+     stream. If clear-contents? is :drm:`#t` (the default for cases where
      the argument is defined), this function sets the size of the stream
      to zero, and the position to the stream's start. Thus the next call
      to ``stream-contents`` will return only the elements written after
@@ -2445,11 +2445,11 @@ are exported from the *streams* module.
 
    :description:
 
-     Returns ``#t`` if *input-stream* would not block on
-     :gf:`read-element`, otherwise it returns ``#f``.
+     Returns :drm:`#t` if *input-stream* would not block on
+     :gf:`read-element`, otherwise it returns :drm:`#f`.
 
      This function differs from :gf:`stream-at-end?`. When
-     :gf:`stream-input-available?` returns ``#t``, :gf:`read-element`
+     :gf:`stream-input-available?` returns :drm:`#t`, :gf:`read-element`
      will not block, but it may detect that it is at the end of the
      stream's source, and consequently inspect the *on-end-of-stream*
      argument to determine how to handle the end of stream.
@@ -2471,7 +2471,7 @@ are exported from the *streams* module.
 
    :description:
 
-     Returns ``#t`` if the stream is directed to the console and ``#f`` if it is not.
+     Returns :drm:`#t` if the stream is directed to the console and :drm:`#f` if it is not.
 
    :example:
 
@@ -2494,7 +2494,7 @@ are exported from the *streams* module.
    :signature: stream-lock *stream* => *lock*
 
    :parameter stream: An instance of :class:`<stream>`.
-   :value lock: An instance of :class:`<lock>`, or ``#f``.
+   :value lock: An instance of :class:`<lock>`, or :drm:`#f`.
 
    :description:
 
@@ -2514,12 +2514,12 @@ are exported from the *streams* module.
    :signature: stream-lock-setter *stream lock* => *lock*
 
    :parameter stream: An instance of :class:`<stream>`.
-   :parameter lock: An instance of :class:`<lock>`, or ``#f``.
-   :value lock: An instance of :class:`<lock>`, or ``#f``.
+   :parameter lock: An instance of :class:`<lock>`, or :drm:`#f`.
+   :value lock: An instance of :class:`<lock>`, or :drm:`#f`.
 
    :description:
 
-     Sets *lock* for the specified *stream*. If *lock* is ``#f``, then
+     Sets *lock* for the specified *stream*. If *lock* is :drm:`#f`, then
      the lock on *stream* is freed. You can use this function in
      conjunction with :gf:`stream-lock` to implement a basic stream
      locking facility.
@@ -2540,7 +2540,7 @@ are exported from the *streams* module.
 
    :description:
 
-     Returns ``#t`` if *stream* is open and ``#f`` if it is not.
+     Returns :drm:`#t` if *stream* is open and :drm:`#f` if it is not.
 
    :seealso:
 
@@ -2659,7 +2659,7 @@ are exported from the *streams* module.
    :signature: stream-size *positionable-stream* => *size*
 
    :parameter positionable-stream: An instance of :class:`<positionable-stream>`.
-   :value size: An instance of :drm:`<integer>`, or ``#f``.
+   :value size: An instance of :drm:`<integer>`, or :drm:`#f`.
 
    :description:
 
@@ -2763,7 +2763,7 @@ are exported from the *streams* module.
 
    :parameter filename: An instance of :drm:`<object>`.
    :parameter element-type: One of :type:`<byte-character>`,
-     :type:`<unicode-character>`, or :type:`<byte>`, or ``#f``.
+     :type:`<unicode-character>`, or :type:`<byte>`, or :drm:`#f`.
    :value file-stream-type: An instance of :drm:`<type>`.
 
    :description:

--- a/documentation/library-reference/source/io/streams.rst
+++ b/documentation/library-reference/source/io/streams.rst
@@ -401,7 +401,7 @@ For example:
     write(stream, "ABC");
     values(v, stream-contents(stream));
 
-The example returns two values. Each value is the same (``==``) stretchy
+The example returns two values. Each value is the same (:drm:`==`) stretchy
 vector:
 
 .. code-block:: dylan
@@ -2107,7 +2107,7 @@ are exported from the *streams* module.
    :parameter input-stream: An instance of :class:`<stream>`.
    :parameter element: An instance of :drm:`<object>`.
    :parameter #key on-end-of-stream: An instance of :drm:`<object>`.
-   :parameter #key test: An instance of :drm:`<function>`. Default value: ``==``.
+   :parameter #key test: An instance of :drm:`<function>`. Default value: :drm:`==`.
    :value sequence-or-eof: An instance of :drm:`<sequence>`, or an instance of
      :drm:`<object>` if the end of the stream is reached.
    :value found?: An instance of :drm:`<boolean>`.
@@ -2134,7 +2134,7 @@ are exported from the *streams* module.
    :parameter input-stream: An instance of :class:`<stream>`.
    :parameter element: An instance of :drm:`<object>`.
    :parameter #key on-end-of-stream: An instance of :drm:`<object>`.
-   :parameter #key test: An instance of :drm:`<function>`. Default value: ``==``.
+   :parameter #key test: An instance of :drm:`<function>`. Default value: :drm:`==`.
    :value sequence-or-eof: An instance of :drm:`<sequence>`, or an instance of
      :drm:`<object>` if the end of the stream is reached.
    :value found?: An instance of :drm:`<boolean>`.
@@ -2254,7 +2254,7 @@ are exported from the *streams* module.
 
    :parameter input-stream: An instance of :class:`<stream>`.
    :parameter element: An instance of :drm:`<object>`.
-   :parameter #key test: An instance of :drm:`<function>`. Default value: ``==``.
+   :parameter #key test: An instance of :drm:`<function>`. Default value: :drm:`==`.
    :value found?: An instance of :drm:`<boolean>`.
 
    :description:

--- a/documentation/library-reference/source/language-extensions/define-function.rst
+++ b/documentation/library-reference/source/language-extensions/define-function.rst
@@ -31,12 +31,10 @@ implementation.
    new function.
 
    :macrocall:
-
-     .. code-block:: dylan
-
-       define {*adjective* }* function *name* *parameter-list*
-         [ *body* ]
-       end [ function ] [ *name* ]
+     .. parsed-literal:: 
+        define { `adjective` }* function `name` `parameter-list`
+          [ `body` ]
+        end [ function ] [ `name` ]
 
    :parameter adjective: A Dylan unreserved-name *bnf*.
    :parameter name: A Dylan variable-name *bnf*.

--- a/documentation/library-reference/source/language-extensions/language-differences.rst
+++ b/documentation/library-reference/source/language-extensions/language-differences.rst
@@ -110,7 +110,7 @@ a Table-extensions module, which you can read about in
    :description:
 
      Returns a hash code for *object* that corresponds to the
-     equivalence predicate ``==``.
+     equivalence predicate :drm:`==`.
 
      This function is a useful tool for writing hash functions in which
      the object identity of some component of a key is to be used in

--- a/documentation/library-reference/source/language-extensions/language-differences.rst
+++ b/documentation/library-reference/source/language-extensions/language-differences.rst
@@ -71,7 +71,7 @@ a Table-extensions module, which you can read about in
 
    :parameter id1: An instance of :drm:`<integer>`.
    :parameter id2: An instance of :drm:`<integer>`.
-   :parameter ordered: An instance of :drm:`<boolean>`. Default value: ``#f``.
+   :parameter ordered: An instance of :drm:`<boolean>`. Default value: :drm:`#f`.
    :value merged-id: An instance of :drm:`<integer>`.
 
    :description:

--- a/documentation/library-reference/source/language-extensions/numbers.rst
+++ b/documentation/library-reference/source/language-extensions/numbers.rst
@@ -1078,7 +1078,7 @@ not:
 
     5 ga/+ 4;
 
-The existing functions like ``+`` and ``-`` will only accept :drm:`<integer>`
+The existing functions like :drm:`+` and :drm:`-` will only accept :drm:`<integer>`
 instances and ``ga/<integer>`` instances small enough to be represented as
 :drm:`<integer>` instances.
 

--- a/documentation/library-reference/source/language-extensions/numbers.rst
+++ b/documentation/library-reference/source/language-extensions/numbers.rst
@@ -140,7 +140,7 @@ The following specific constructors are available for use with the class
 Equality comparisons
 --------------------
 
-The ``=`` function compares two objects and returns ``#t`` if the values of
+The :drm:`=` function compares two objects and returns :drm:`#t` if the values of
 the two objects are equal to each other, that is of the same magnitude.
 
 .. generic-function:: =

--- a/documentation/library-reference/source/logging/index.rst
+++ b/documentation/library-reference/source/logging/index.rst
@@ -242,13 +242,13 @@ Logs
    :keyword additive?:
       A :drm:`<boolean>` specifying whether log messages sent to this
       log should be passed along to its parent log.  The default
-      is ``#t``.
+      is :drm:`#t`.
    :keyword children:
       A :drm:`<sequence>` of :class:`<log>` objects.
    :keyword enabled?:
       :drm:`<boolean>` specifying whether this log is enabled.
       Note that the value of *additive?* will be respected even if the
-      log is disabled.  The default is ``#t``.
+      log is disabled.  The default is :drm:`#t`.
    :keyword parent:
       The parent of this log.
 
@@ -273,7 +273,7 @@ Logs
       An instance of :drm:`<string>`.  This is normally a
       dotted path name like "http.server.queries".
    :value log:
-      An instance of :class:`<abstract-log>` or ``#f``.
+      An instance of :class:`<abstract-log>` or :drm:`#f`.
 
 .. generic-function:: get-root-log
 

--- a/documentation/library-reference/source/network/index.rst
+++ b/documentation/library-reference/source/network/index.rst
@@ -76,7 +76,8 @@ socket function that blocks.
 .. macro:: with-socket-thread
    :statement:
 
-   :macrocall: with-socket-thread (#key *server?*) *body* end
+   :macrocall:
+      .. parsed-literal:: with-socket-thread (#key `server?`) `body` end
 
    :description:
 
@@ -478,7 +479,11 @@ The <server-socket> class
 
 .. macro:: with-server-socket
 
-   :macrocall: with-server-socket (*server-var* [:: *server-class* ], *keywords*) *body* end
+   :macrocall:
+      .. parsed-literal:: 
+         with-server-socket (`server-var` [:: `server-class` ], `keywords`)
+           `body`
+         end
 
    :description:
 
@@ -491,7 +496,11 @@ The <server-socket> class
 
 .. macro:: start-server
 
-   :macrocall: start-server ([*server-var* = ] *socket-server-instance*, *socket-var* [, *keywords* ]) *body* end
+   :macrocall:
+      .. parsed-literal:: 
+         start-server ([`server-var` = ] `socket-server-instance`, `socket-var` [, `keywords` ])
+           `body`
+         end
 
    :description:
 

--- a/documentation/library-reference/source/regular-expressions/index.rst
+++ b/documentation/library-reference/source/regular-expressions/index.rst
@@ -115,11 +115,11 @@ Reference
    :signature: compile-regex *pattern* #key *case-sensitive* *verbose* *multi-line* *dot-matches-all* *use-cache* => *regex*
 
    :parameter pattern: A :drm:`<string>`.
-   :parameter #key case-sensitive: A :drm:`<boolean>`, default ``#t``.
-   :parameter #key verbose: A :drm:`<boolean>`, default ``#f``.
-   :parameter #key multi-line: A :drm:`<boolean>`, default ``#f``.
-   :parameter #key dot-matches-all: A :drm:`<boolean>`, default ``#f``.
-   :parameter #key use-cache: A :drm:`<boolean>`, default ``#t``.  If true,
+   :parameter #key case-sensitive: A :drm:`<boolean>`, default :drm:`#t`.
+   :parameter #key verbose: A :drm:`<boolean>`, default :drm:`#f`.
+   :parameter #key multi-line: A :drm:`<boolean>`, default :drm:`#f`.
+   :parameter #key dot-matches-all: A :drm:`<boolean>`, default :drm:`#f`.
+   :parameter #key use-cache: A :drm:`<boolean>`, default :drm:`#t`.  If true,
      the resulting regular expression will be cached and re-used the
      next time the same string is compiled.
    :value regex: A :class:`<regex>`.
@@ -162,7 +162,7 @@ Reference
      to start the search.
    :parameter #key end: An :drm:`<integer>`, default ``*text*.size``.  The index
      at which to end the search.
-   :parameter #key case-sensitive: A :drm:`<boolean>`, default ``#t``.
+   :parameter #key case-sensitive: A :drm:`<boolean>`, default :drm:`#t`.
    :value regex-start: An instance of ``false-or(<integer>)``.
    :value #rest marks: An instance of :drm:`<object>`.
 
@@ -190,9 +190,9 @@ Reference
      at which to start searching.
    :parameter #key end: An :drm:`<integer>`, default ``*big*.size``.  The index
      at which to end the search.
-   :parameter #key case-sensitive: A :drm:`<boolean>`, default ``#t``.
-   :parameter #key count: An instance of ``false-or(<integer>)``, default ``#f``.
-     The number of matches to replace.  ``#f`` means to replace all.
+   :parameter #key case-sensitive: A :drm:`<boolean>`, default :drm:`#t`.
+   :parameter #key count: An instance of ``false-or(<integer>)``, default :drm:`#f`.
+     The number of matches to replace.  :drm:`#f` means to replace all.
    :value new-string: An instance of :drm:`<string>`.
 
    A match will only be found if it fits entirely within the range
@@ -207,7 +207,7 @@ Reference
 
    :parameter pattern: The :class:`<regex>` to search for.
    :parameter text: The :drm:`<string>` in which to search.
-   :parameter #key anchored: A :drm:`<boolean>`, default ``#f``.  Whether or
+   :parameter #key anchored: A :drm:`<boolean>`, default :drm:`#f`.  Whether or
      not the search should be anchored at the start position.  This is
      useful because "^..." will only match at the beginning of a string,
      or after \\n if the regex was compiled with multi-line = #t.
@@ -215,8 +215,8 @@ Reference
      at which to start searching.
    :parameter #key end: An :drm:`<integer>`, default ``*text*.size``.  The index
      at which to end the search.
-   :parameter #key case-sensitive: A :drm:`<boolean>`, default ``#t``.
-   :value match: An instance of ``false-or(<regex-match>)``.  ``#f`` is returned
+   :parameter #key case-sensitive: A :drm:`<boolean>`, default :drm:`#t`.
+   :value match: An instance of ``false-or(<regex-match>)``.  :drm:`#f` is returned
      if no match was found.
 
    A match will only be found if it fits entirely within the range
@@ -236,7 +236,7 @@ Reference
      at which to start searching.
    :parameter #key end: An :drm:`<integer>`, default ``*text*.size``.  The index
      at which to end the search.
-   :parameter #key case-sensitive: A :drm:`<boolean>`, default ``#t``.
+   :parameter #key case-sensitive: A :drm:`<boolean>`, default :drm:`#t`.
    :value #rest strings: An instance of :drm:`<object>`.
 
    A match will only be found if it fits entirely within the range
@@ -264,6 +264,6 @@ Reference
 
    Group 0 is always the entire regular expression match.
 
-   It is possible for the group identifier to be valid and for ``#f``
+   It is possible for the group identifier to be valid and for :drm:`#f`
    to be returned.  This can happen, for example, if the group was in
    the part of an ``|`` (or) expression that didn't match.

--- a/documentation/library-reference/source/sql/index.rst
+++ b/documentation/library-reference/source/sql/index.rst
@@ -504,7 +504,7 @@ type of the result set is determined by the result-set policy object.
 The type of the record object is determined by the :gf:`coercion-policy`
 slot of :class:`<sql-statement>`.
 
-If ``result-set-policy.scrollable?`` is ``#t``, the result set will be an
+If ``result-set-policy.scrollable?`` is :drm:`#t`, the result set will be an
 instance of :class:`<scrollable-result-set>` otherwise it will be an instance
 of :class:`<forward-only-result-set>`. If ``statement.coercion-policy ~=
 $no-coercion`` then the record will be an instance of :class:`<coercion-record>`;
@@ -515,9 +515,9 @@ otherwise, it will be an instance of :class:`<record>`.
     +-------------+-----------------+------------------------------------+
     | Scrollable? | Coercion policy | Result set class                   |
     +=============+=================+====================================+
-    | ``#f``      | ``#f``          | :class:`<forward-only-result-set>` |
+    | :drm:`#f`   | :drm:`#f`       | :class:`<forward-only-result-set>` |
     +-------------+-----------------+------------------------------------+
-    | ``#t``      | -               | :class:`<scrollable-result-set>`   |
+    | :drm:`#t`   | -               | :class:`<scrollable-result-set>`   |
     +-------------+-----------------+------------------------------------+
 
 See also:
@@ -1524,7 +1524,7 @@ The SQL module
    :keyword asynchronous:
    :keyword rowset-size: An instance of ``type-union(<integer>, #"all")``.
    :keyword scroll-window: An instance of :drm:`<integer>`. A cache size hint.
-   :keyword scrollable: An instance of :drm:`<boolean>`. Default value: ``#f``.
+   :keyword scrollable: An instance of :drm:`<boolean>`. Default value: :drm:`#f`.
 
    Specifies the behavior and performance characteristics of a result set.
 

--- a/documentation/library-reference/source/strings/index.rst
+++ b/documentation/library-reference/source/strings/index.rst
@@ -41,7 +41,7 @@ Character Class Predicates
 .. generic-function:: alphabetic?
    :sealed:
 
-   Return ``#t`` if the argument is alphabetic, else ``#f``.
+   Return :drm:`#t` if the argument is alphabetic, else :drm:`#f`.
 
    :signature: alphabetic? (string-or-character, #key) => (alphabetic?)
    :parameter string-or-character: An instance of ``type-union(<string>, <character>)``.
@@ -51,8 +51,8 @@ Character Class Predicates
    :specializer: <character>
    :sealed:
 
-   Returns ``#t`` if the given character is a member of the set a-z or
-   A-Z.  Otherwise returns ``#f``.
+   Returns :drm:`#t` if the given character is a member of the set a-z or
+   A-Z.  Otherwise returns :drm:`#f`.
 
    :signature: alphabetic? (character) => (alphabetic?)
    :parameter character: An instance of :drm:`<character>`.
@@ -68,8 +68,8 @@ Character Class Predicates
    :specializer: <string>
    :sealed:
 
-   Returns ``#t`` if every character in the string is a member of the
-   set a-z or A-Z.  Otherwise returns ``#f``.
+   Returns :drm:`#t` if every character in the string is a member of the
+   set a-z or A-Z.  Otherwise returns :drm:`#f`.
 
    :signature: alphabetic? (string, #key start, end) => (alphabetic?)
    :parameter string: An instance of :drm:`<string>`.
@@ -91,7 +91,7 @@ Character Class Predicates
 .. generic-function:: alphanumeric?
    :sealed:
 
-   Returns ``#t`` if the argument is alphanumeric, otherwise ``#f``.
+   Returns :drm:`#t` if the argument is alphanumeric, otherwise :drm:`#f`.
 
    :signature: alphanumeric? (string-or-character, #key) => (alphanumeric?)
    :parameter string-or-character: An instance of ``type-union(<string>, <character>)``.
@@ -101,8 +101,8 @@ Character Class Predicates
    :specializer: <character>
    :sealed:
 
-   Returns ``#t`` if the argument is a member of the set of characters
-   a-z, A-Z, or 0-9, otherwise ``#f``.
+   Returns :drm:`#t` if the argument is a member of the set of characters
+   a-z, A-Z, or 0-9, otherwise :drm:`#f`.
 
    :signature: alphanumeric? (character) => (alphanumeric?)
    :parameter character: An instance of :drm:`<character>`.
@@ -119,8 +119,8 @@ Character Class Predicates
    :specializer: <string>
    :sealed:
 
-   Returns ``#t`` if every character in the string is a member of the
-   set a-z, A-Z, or 0-9, otherwise ``#f``.
+   Returns :drm:`#t` if every character in the string is a member of the
+   set a-z, A-Z, or 0-9, otherwise :drm:`#f`.
 
    :signature: alphanumeric? (string) => (alphanumeric?)
    :parameter string: An instance of :drm:`<string>`.
@@ -138,8 +138,8 @@ Character Class Predicates
 .. generic-function:: control?
    :sealed:
 
-   Returns ``#t`` if the argument is entirely composed of control
-   characters, otherwise ``#f``.
+   Returns :drm:`#t` if the argument is entirely composed of control
+   characters, otherwise :drm:`#f`.
 
    :signature: control? (string-or-character, #key) => (control?)
    :parameter string-or-character: An instance of ``type-union(<string>, <character>)``.
@@ -149,8 +149,8 @@ Character Class Predicates
    :specializer: <character>
    :sealed:
 
-   Returns ``#t`` if the argument is not a graphic or whitespace
-   character, otherwise ``#f``.
+   Returns :drm:`#t` if the argument is not a graphic or whitespace
+   character, otherwise :drm:`#f`.
 
    :signature: control? (character) => (control?)
    :parameter character: An instance of :drm:`<character>`.
@@ -166,7 +166,7 @@ Character Class Predicates
    :specializer: <string>
    :sealed:
 
-   Returns ``#t`` if the argument is entirely composed of non-graphic,
+   Returns :drm:`#t` if the argument is entirely composed of non-graphic,
    non-whitespace characters.
 
    :signature: control? (string) => (control?)
@@ -189,7 +189,7 @@ Character Class Predicates
 .. generic-function:: graphic?
    :sealed:
 
-   Returns ``#t`` if the argument is entirely composed of
+   Returns :drm:`#t` if the argument is entirely composed of
    graphic characters.
 
    :signature: graphic? (string-or-character, #key) => (graphic?)
@@ -200,7 +200,7 @@ Character Class Predicates
    :specializer: <character>
    :sealed:
 
-   Returns ``#t`` if the argument is a graphic character, defined as
+   Returns :drm:`#t` if the argument is a graphic character, defined as
    those with character codes between 32 (Space) and 126 (~) in the US
    ASCII character set.
 
@@ -218,7 +218,7 @@ Character Class Predicates
    :specializer: <string>
    :sealed:
 
-   Returns ``#t`` if the argument is entirely composed of graphic
+   Returns :drm:`#t` if the argument is entirely composed of graphic
    characters, defined as those with character codes between 32
    (Space) and 126 (~).
 
@@ -242,7 +242,7 @@ Character Class Predicates
 .. generic-function:: printable?
    :sealed:
 
-   Returns ``#t`` if the argument is entirely composed of printable
+   Returns :drm:`#t` if the argument is entirely composed of printable
    characters, defined as either a graphic or whitespace character.
 
    :signature: printable? (string-or-character, #key) => (printable?)
@@ -253,8 +253,8 @@ Character Class Predicates
    :specializer: <character>
    :sealed:
 
-   Returns ``#t`` if the argument is a printable character, defined as
-   either a graphic or whitespace character.  Otherwise ``#f`` is
+   Returns :drm:`#t` if the argument is a printable character, defined as
+   either a graphic or whitespace character.  Otherwise :drm:`#f` is
    returned.
 
    :signature: printable? (character, #key) => (printable?)
@@ -272,9 +272,9 @@ Character Class Predicates
    :specializer: <string>
    :sealed:
 
-   Returns ``#t`` if the argument is entirely composed of printable
+   Returns :drm:`#t` if the argument is entirely composed of printable
    characters, defined as either a graphic or whitespace character.
-   Otherwise ``#f`` is returned.
+   Otherwise :drm:`#f` is returned.
 
    :signature: printable? (string, #key) => (printable?)
    :parameter string: An instance of :drm:`<string>`.
@@ -296,7 +296,7 @@ Character Class Predicates
 .. generic-function:: whitespace?
    :sealed:
 
-   Returns ``#t`` if the argument is entirely composed of whitespace
+   Returns :drm:`#t` if the argument is entirely composed of whitespace
    characters.
 
    :signature: whitespace? (string-or-character, #key) => (whitespace?)
@@ -307,8 +307,8 @@ Character Class Predicates
    :specializer: <character>
    :sealed:
 
-   Returns ``#t`` if the argument is ' ' (Space), '\\t' (Tab), '\\n'
-   (Newline), '\\f' (Formfeed), or '\\r' (Return).  Otherwise ``#f`` is
+   Returns :drm:`#t` if the argument is ' ' (Space), '\\t' (Tab), '\\n'
+   (Newline), '\\f' (Formfeed), or '\\r' (Return).  Otherwise :drm:`#f` is
    returned.
 
    :signature: whitespace? (character, #key) => (whitespace?)
@@ -326,9 +326,9 @@ Character Class Predicates
    :specializer: <string>
    :sealed:
 
-   Returns ``#t`` if the argument is entirely composed of whitespace
+   Returns :drm:`#t` if the argument is entirely composed of whitespace
    characters, defined as ' ' (Space), '\\t' (Tab), '\\n' (Newline),
-   '\\f' (Formfeed), or '\\r' (Return).  Otherwise ``#f`` is returned.
+   '\\f' (Formfeed), or '\\r' (Return).  Otherwise :drm:`#f` is returned.
 
    :signature: whitespace? (string, #key) => (whitespace?)
    :parameter string: An instance of :drm:`<string>`.
@@ -349,7 +349,7 @@ Character Class Predicates
 .. generic-function:: decimal-digit?
    :sealed:
 
-   Returns ``#t`` if the argument is a decimal digit, otherwise ``#f``.
+   Returns :drm:`#t` if the argument is a decimal digit, otherwise :drm:`#f`.
 
    :signature: decimal-digit? (string-or-character, #key) => (decimal-digit?)
    :parameter string-or-character: An instance of ``type-union(<string>, <character>)``.
@@ -359,8 +359,8 @@ Character Class Predicates
    :specializer: <character>
    :sealed:
 
-   Returns ``#t`` if the character is a member of the set [0-9],
-   otherwise ``#f`` is returned.
+   Returns :drm:`#t` if the character is a member of the set [0-9],
+   otherwise :drm:`#f` is returned.
 
    :signature: decimal-digit? (character, #key) => (decimal-digit?)
    :parameter character: An instance of :drm:`<character>`.
@@ -376,8 +376,8 @@ Character Class Predicates
    :specializer: <string>
    :sealed:
 
-   Returns ``#t`` if every character in the string is a member of the
-   set [0-9], otherwise ``#f`` is returned.
+   Returns :drm:`#t` if every character in the string is a member of the
+   set [0-9], otherwise :drm:`#f` is returned.
 
    :signature: decimal-digit? (string, #key) => (decimal-digit?)
    :parameter string: An instance of :drm:`<string>`.
@@ -399,8 +399,8 @@ Character Class Predicates
 .. generic-function:: hexadecimal-digit?
    :sealed:
 
-   Returns ``#t`` if the argument is entirely composed of hexadecimal
-   digits, otherwise ``#f`` is returned.
+   Returns :drm:`#t` if the argument is entirely composed of hexadecimal
+   digits, otherwise :drm:`#f` is returned.
 
    :signature: hexadecimal-digit? (string-or-character, #key) => (hexadecimal-digit?)
    :parameter string-or-character: An instance of ``type-union(<string>, <character>)``.
@@ -410,8 +410,8 @@ Character Class Predicates
    :specializer: <character>
    :sealed:
 
-   Returns ``#t`` if the character is a member of the set [0-9a-fA-F],
-   otherwise ``#f`` is returned.
+   Returns :drm:`#t` if the character is a member of the set [0-9a-fA-F],
+   otherwise :drm:`#f` is returned.
 
    :signature: hexadecimal-digit? (character, #key) => (hexadecimal-digit?)
    :parameter character: An instance of :drm:`<character>`.
@@ -428,8 +428,8 @@ Character Class Predicates
    :specializer: <string>
    :sealed:
 
-   Returns ``#t`` if every character in the string is a member of the
-   set [0-9a-fA-F], otherwise ``#f`` is returned.
+   Returns :drm:`#t` if every character in the string is a member of the
+   set [0-9a-fA-F], otherwise :drm:`#f` is returned.
 
    :signature: hexadecimal-digit? (string, #key) => (hexadecimal-digit?)
    :parameter string: An instance of :drm:`<string>`.
@@ -451,8 +451,8 @@ Character Class Predicates
 .. generic-function:: octal-digit?
    :sealed:
 
-   Returns ``#t`` if the argument is entirely composed of octal
-   digits, otherwise ``#f`` is returned.
+   Returns :drm:`#t` if the argument is entirely composed of octal
+   digits, otherwise :drm:`#f` is returned.
 
    :signature: octal-digit? (string-or-character, #key) => (octal-digit?)
    :parameter string-or-character: An instance of ``type-union(<string>, <character>)``.
@@ -462,8 +462,8 @@ Character Class Predicates
    :specializer: <character>
    :sealed:
 
-   Returns ``#t`` if the character is a member of the set [0-9a-fA-F],
-   otherwise ``#f`` is returned.
+   Returns :drm:`#t` if the character is a member of the set [0-9a-fA-F],
+   otherwise :drm:`#f` is returned.
 
    :signature: octal-digit? (character, #key) => (octal-digit?)
    :parameter character: An instance of :drm:`<character>`.
@@ -480,8 +480,8 @@ Character Class Predicates
    :specializer: <string>
    :sealed:
 
-   Returns ``#t`` if every character in the string is a member of the
-   set [0-9a-fA-F], otherwise ``#f`` is returned.
+   Returns :drm:`#t` if every character in the string is a member of the
+   set [0-9a-fA-F], otherwise :drm:`#f` is returned.
 
    :signature: octal-digit? (string, #key) => (octal-digit?)
    :parameter string: An instance of :drm:`<string>`.
@@ -515,7 +515,7 @@ Substring Functions
      Where to stop searching.  Note that if ``pattern``
      is not completely between the bounds of ``start`` (inclusive) and
      ``end`` (exclusive) it will not be counted.
-   :parameter #key ignore-case?: An instance of :drm:`<boolean>`, default ``#f``.
+   :parameter #key ignore-case?: An instance of :drm:`<boolean>`, default :drm:`#f`.
    :value count: An instance of :drm:`<integer>`.
    :example:
 
@@ -529,7 +529,7 @@ Substring Functions
    :sealed:
 
    Find the index of a substring pattern in a larger string.  Returns
-   ``#f`` if not found.
+   :drm:`#f` if not found.
 
    :signature: find-substring (big pattern #key start end ignore-case?) => (index)
    :parameter big: An instance of :drm:`<string>`.  The string in which to search.
@@ -539,7 +539,7 @@ Substring Functions
      Where to stop searching.  Note that if ``pattern``
      is not completely between the bounds of ``start`` (inclusive) and
      ``end`` (exclusive) it will not match.
-   :parameter #key ignore-case?: An instance of :drm:`<boolean>`, default ``#f``.
+   :parameter #key ignore-case?: An instance of :drm:`<boolean>`, default :drm:`#f`.
    :value index: An instance of ``false-or(<integer>)``.
    :example:
 
@@ -562,7 +562,7 @@ Substring Functions
    :parameter replacement: An instance of :drm:`<string>`.  The string
      with which to replace ``pattern``.
    :parameter #key count: An instance of ``false-or(<integer>)``.  The
-     number of occurrences to replace.  The default is ``#f``, meaning to
+     number of occurrences to replace.  The default is :drm:`#f`, meaning to
      replace all.  Replacements are performed from left to right
      within ``big`` until ``count`` has been reached.
    :parameter #key start: An instance of :drm:`<integer>`, default 0.  Where to
@@ -571,7 +571,7 @@ Substring Functions
      ``big.size``.  Where to stop searching.  Note that if ``pattern``
      is not completely between the bounds of ``start`` (inclusive) and
      ``end`` (exclusive) it will not be replaced.
-   :parameter #key ignore-case?: An instance of :drm:`<boolean>`, default ``#f``.
+   :parameter #key ignore-case?: An instance of :drm:`<boolean>`, default :drm:`#f`.
    :value new-string: An instance of :drm:`<string>`.
    :example:
 
@@ -690,7 +690,7 @@ Case Conversion Functions
 .. generic-function:: lowercase?
    :sealed:
 
-   Returns ``#t`` if the argument is entirely composed of
+   Returns :drm:`#t` if the argument is entirely composed of
    non-uppercase characters.
 
    :signature: lowercase? (string-or-character) => (is-lowercase?)
@@ -701,8 +701,8 @@ Case Conversion Functions
    :specializer: <character>
    :sealed:
 
-   Returns ``#t`` if the given character is not an uppercase alphabetic.
-   Otherwise ``#f`` is returned.
+   Returns :drm:`#t` if the given character is not an uppercase alphabetic.
+   Otherwise :drm:`#f` is returned.
 
    :signature: lowercase? (character) => (is-lowercase?)
    :parameter character: An instance of :drm:`<character>`.
@@ -719,8 +719,8 @@ Case Conversion Functions
    :specializer: <string>
    :sealed:
 
-   Returns ``#t`` if the argument does not contain any uppercase
-   alphabetic characters.  Otherwise ``#f`` is returned.
+   Returns :drm:`#t` if the argument does not contain any uppercase
+   alphabetic characters.  Otherwise :drm:`#f` is returned.
 
    :signature: lowercase? (string) => (is-lowercase?)
    :parameter string: An instance of :drm:`<string>`.
@@ -845,7 +845,7 @@ Case Conversion Functions
 .. generic-function:: uppercase?
    :sealed:
 
-   Returns ``#t`` if the argument is entirely composed of
+   Returns :drm:`#t` if the argument is entirely composed of
    non-lowercase characters.
 
    :signature: uppercase? (string-or-character) => (is-uppercase?)
@@ -856,8 +856,8 @@ Case Conversion Functions
    :specializer: <character>
    :sealed:
 
-   Returns ``#t`` if the given character is not a lowercase alphabetic.
-   Otherwise ``#f`` is returned.
+   Returns :drm:`#t` if the given character is not a lowercase alphabetic.
+   Otherwise :drm:`#f` is returned.
 
    :signature: uppercase? (character) => (is-uppercase?)
    :parameter character: An instance of :drm:`<character>`.
@@ -874,8 +874,8 @@ Case Conversion Functions
    :specializer: <string>
    :sealed:
 
-   Returns ``#t`` if the argument does not contain any lowercase
-   alphabetic characters.  Otherwise ``#f`` is returned.
+   Returns :drm:`#t` if the argument does not contain any lowercase
+   alphabetic characters.  Otherwise :drm:`#f` is returned.
 
    :signature: uppercase? (string) => (is-uppercase?)
    :parameter string: An instance of :drm:`<string>`.
@@ -936,8 +936,8 @@ convenience.  (See `DEP-0004
 
 .. function:: char-equal-ic?
 
-   Returns ``#t`` if char1 and char2 are the same, *ignoring case*.
-   Otherwise ``#f`` is returned.
+   Returns :drm:`#t` if char1 and char2 are the same, *ignoring case*.
+   Otherwise :drm:`#f` is returned.
 
    :signature: char-equal-ic? (char1 char2) => (equal?)
    :parameter char1: An instance of :drm:`<character>`.
@@ -979,8 +979,8 @@ convenience.  (See `DEP-0004
 .. generic-function:: string-equal?
    :sealed:
 
-   Returns ``#t`` if string1 and string2 are of equal length and
-   contain the same sequence of characters.  Otherwise returns ``#f``.
+   Returns :drm:`#t` if string1 and string2 are of equal length and
+   contain the same sequence of characters.  Otherwise returns :drm:`#f`.
 
    :signature: string-equal? (string1 string2 #key start1 end1 start2 end2 test) => (equal?)
    :parameter string1: An instance of :drm:`<string>`.
@@ -1008,9 +1008,9 @@ convenience.  (See `DEP-0004
 .. generic-function:: string-equal-ic?
    :sealed:
 
-   Returns ``#t`` if string1 and string2 are of equal length and
+   Returns :drm:`#t` if string1 and string2 are of equal length and
    contain the same sequence of characters, ignoring case.  Otherwise
-   returns ``#f``.
+   returns :drm:`#f`.
 
    :signature: string-equal-ic? (string1 string2 #key start1 end1 start2 end2) => (equal?)
    :parameter string1: An instance of :drm:`<string>`.
@@ -1035,7 +1035,7 @@ convenience.  (See `DEP-0004
 .. generic-function:: string-greater?
    :sealed:
 
-   Return ``#t`` if ``string1`` is greater than ``string2``, using
+   Return :drm:`#t` if ``string1`` is greater than ``string2``, using
    *case sensitive* comparison.
 
    :signature: string-greater? (string1 string2 #key start1 end1 start2 end2 test) => (greater?)
@@ -1062,7 +1062,7 @@ convenience.  (See `DEP-0004
 .. generic-function:: string-greater-ic?
    :sealed:
 
-   Return ``#t`` if ``string1`` is greater than ``string2``, using
+   Return :drm:`#t` if ``string1`` is greater than ``string2``, using
    *case insensitive* comparison.
 
    :signature: string-greater-ic? (string1 string2 #key start1 end1 start2 end2) => (greater?)
@@ -1088,7 +1088,7 @@ convenience.  (See `DEP-0004
 .. generic-function:: string-less?
    :sealed:
 
-   Return ``#t`` if ``string1`` is less than ``string2``, using
+   Return :drm:`#t` if ``string1`` is less than ``string2``, using
    *case sensitive* comparison.
 
    :signature: string-less? (string1 string2 #key start1 end1 start2 end2 test) => (less?)
@@ -1115,7 +1115,7 @@ convenience.  (See `DEP-0004
 .. generic-function:: string-less-ic?
    :sealed:
 
-   Return ``#t`` if ``string1`` is less than ``string2``, using
+   Return :drm:`#t` if ``string1`` is less than ``string2``, using
    *case insensitive* comparison.
 
    :signature: string-less-ic? (string1 string2 #key start1 end1 start2 end2) => (less?)
@@ -1141,7 +1141,7 @@ convenience.  (See `DEP-0004
 .. generic-function:: starts-with?
    :sealed:
 
-   Return ``#t`` if ``string1`` is starts with ``string2``, using
+   Return :drm:`#t` if ``string1`` is starts with ``string2``, using
    *case sensitive* comparison.
 
    :signature: starts-with? (string pattern #key test) => (starts-with?)
@@ -1160,7 +1160,7 @@ convenience.  (See `DEP-0004
 .. generic-function:: ends-with?
    :sealed:
 
-   Return ``#t`` if ``string1`` is ends with ``string2``, using *case
+   Return :drm:`#t` if ``string1`` is ends with ``string2``, using *case
    sensitive* comparison.
 
    :signature: ends-with? (string pattern #key test) => (ends-with?)
@@ -1194,10 +1194,10 @@ Miscellaneous Functions
                           to begin the search. Defaults to 0.
    :parameter #key end: An instance of :drm:`<integer>`. The index at which to
                         end the search. Defaults to the end of the string.
-   :parameter #key from-end?: An instance of :drm:`<boolean>`. If ``#t``,
+   :parameter #key from-end?: An instance of :drm:`<boolean>`. If :drm:`#t`,
                               search backward from ``end - 1``.
    :value index: An instance of ``false-or(<integer>)``. The index of the first
-                 character for which the predicate returns ``#t``, or ``#f`` if
+                 character for which the predicate returns :drm:`#t`, or :drm:`#f` if
                  no character matches.
 
    :example:
@@ -1299,7 +1299,7 @@ Miscellaneous Functions
    :parameter string: An instance of :drm:`<string>`.  The string to strip.
    :parameter #key test: An instance of :drm:`<function>`.  A function that
      accepts a character and returns #t if the character should be
-     removed and ``#f`` otherwise.
+     removed and :drm:`#f` otherwise.
    :parameter #key start: An instance of :drm:`<integer>`, default 0.  The
      index in ``string`` at which to start stripping.
    :parameter #key end: An instance of :drm:`<integer>`, default ``string.size``.
@@ -1321,7 +1321,7 @@ Miscellaneous Functions
    :parameter string: An instance of :drm:`<string>`.  The string to strip.
    :parameter #key test: An instance of :drm:`<function>`.  A function that
      accepts a character and returns #t if the character should be
-     removed and ``#f`` otherwise.
+     removed and :drm:`#f` otherwise.
    :parameter #key start: An instance of :drm:`<integer>`, default 0.  The
      index in ``string`` at which to start stripping.
    :parameter #key end: An instance of :drm:`<integer>`, default ``string.size``.
@@ -1343,7 +1343,7 @@ Miscellaneous Functions
    :parameter string: An instance of :drm:`<string>`.  The string to strip.
    :parameter #key test: An instance of :drm:`<function>`.  A function that
      accepts a character and returns #t if the character should be
-     removed and ``#f`` otherwise.
+     removed and :drm:`#f` otherwise.
    :parameter #key start: An instance of :drm:`<integer>`, default 0.  The
      index in ``string`` at which to start stripping.
    :parameter #key end: An instance of :drm:`<integer>`, default ``string.size``.

--- a/documentation/library-reference/source/system/date.rst
+++ b/documentation/library-reference/source/system/date.rst
@@ -348,11 +348,11 @@ Date module.
 
    :description:
 
-     A number of methods are defined for the ``+`` generic function to allow
+     A number of methods are defined for the :drm:`+` generic function to allow
      summing of various combinations of dates and durations. Note that there
      is not a method defined for every possible combination of date and
      duration. Specifically, you cannot sum two dates. The table below lists
-     the methods that are defined on ``+`` and :class:`<date>`.
+     the methods that are defined on :drm:`+` and :class:`<date>`.
 
      Methods defined for addition of dates and durations
 
@@ -386,11 +386,11 @@ Date module.
 
    :description:
 
-     A number of methods are defined for the ``+`` generic function to
+     A number of methods are defined for the :drm:`+` generic function to
      allow summing of durations. Note that there is not a method defined
      for every possible combination of duration. Specifically, you cannot
      sum different types of duration. The table below lists the methods
-     that are defined on ``+``.
+     that are defined on :drm:`+`.
 
      Methods defined for addition of durations
 
@@ -430,13 +430,13 @@ Date module.
 
    :description:
 
-     A number of methods are defined for the ``-`` generic function to allow
+     A number of methods are defined for the :drm:`-` generic function to allow
      subtraction of various combinations of dates and durations. Note that
      there is not a method defined for every possible combination of date and
      duration. Specifically, you cannot subtract a date from a duration, and
      you cannot subtract different types of duration. The return value can be
      either a date or a duration, depending on the arguments supplied. The
-     table below lists the methods that are defined on ``-``.
+     table below lists the methods that are defined on :drm:`-`.
 
      Methods defined for subtraction of dates and durations
                                                       
@@ -474,14 +474,14 @@ Date module.
 
    :description:
 
-     A number of methods are defined for the ``-`` generic function to allow
+     A number of methods are defined for the :drm:`-` generic function to allow
      subtraction of durations. Note that there is not a method defined for
      every possible combination of duration. Specifically, you cannot
      subtract different types of duration. The table below lists the
-     methods that are defined on ``-``.
+     methods that are defined on :drm:`-`.
 
      Methods defined for subtraction of dates and durations
-                                                      
+
      +--------------------------------+--------------------------------+--------------------------------+
      | arg1                           | arg2                           | difference                     |
      +================================+================================+================================+

--- a/documentation/library-reference/source/system/date.rst
+++ b/documentation/library-reference/source/system/date.rst
@@ -674,7 +674,7 @@ Date module.
    :superclasses: :drm:`<number>`
 
    :keyword iso8601-string: An instance of ``false-or(<string>)``.
-     Default value: ``#f``.
+     Default value: :drm:`#f`.
    :keyword year: An instance of ``limited(<integer>, min: 1800, max:
      2199)``.
    :keyword month: An instance of ``limited(<integer>, min: 1, max:
@@ -1179,7 +1179,7 @@ Date module.
    :superclasses: :drm:`<number>`
 
    :keyword iso8601-string: An instance of ``false-or(<string>)``.
-     Default value: ``#f``.
+     Default value: :drm:`#f`.
    :keyword year: An instance of ``limited(<integer>, min: 1800, max:
      2199)``.
    :keyword month: An instance of ``limited(<integer>, min: 1, max:
@@ -1340,8 +1340,8 @@ Date module.
 
    :description:
 
-     Returns ``#t`` if the local machine is using Daylight Savings Time,
-     and ``#f`` otherwise.
+     Returns :drm:`#t` if the local machine is using Daylight Savings Time,
+     and :drm:`#f` otherwise.
 
 .. function:: local-time-zone-name
 
@@ -1385,7 +1385,7 @@ Date module.
 
    :parameter date-class: The class :class:`<date>`.
    :parameter #key iso8601-string: An instance of
-     ``false-or(<string>)``. Default value: ``#f``.
+     ``false-or(<string>)``. Default value: :drm:`#f`.
    :parameter #key year: An instance of ``limited(<integer>, min: 1800,
      max: 2199)``.
    :parameter #key month: An instance of ``limited(<integer>, min: 1,
@@ -1456,7 +1456,7 @@ Date module.
    :signature: parse-iso8601-string *string* #key *strict?* => *date*
 
    :parameter string: An instance of :drm:`<string>`.
-   :parameter #key strict?: An instance of :drm:`<boolean>`, default ``#t``.
+   :parameter #key strict?: An instance of :drm:`<boolean>`, default :drm:`#t`.
    :value date: An instance of :class:`<date>`.
 
    :description:

--- a/documentation/library-reference/source/system/file-system.rst
+++ b/documentation/library-reference/source/system/file-system.rst
@@ -161,7 +161,7 @@ File-System module.
 
    :parameter directory: An instance of :type:`<pathname>`.
    :parameter #key recursive?: An instance of :type:`<boolean>`.
-                               Default value: ``#f``
+                               Default value: :drm:`#f`
 
    :description:
 
@@ -377,11 +377,11 @@ File-System module.
 
      Not all platforms implement all of the above keys. Some platforms
      may support additional keys. The ``#"author"`` key is supported on
-     all platforms but may return ``#f`` if it is not meaningful on a
+     all platforms but may return :drm:`#f` if it is not meaningful on a
      given platform. Use of an unsupported key signals an error.
 
      All keys listed above are implemented by Win32, though note that
-     ``#"author"`` always returns ``#f``.
+     ``#"author"`` always returns :drm:`#f`.
 
    :seealso:
 
@@ -600,7 +600,7 @@ File-System module.
      Returns the pathname of the temporary directory in use. The return
      value of this function can be used with :drm:`concatenate` to
      create pathnames of entities in the temporary directory. If no
-     temporary directory is defined, ``temp-directory`` returns ``#f``.
+     temporary directory is defined, ``temp-directory`` returns :drm:`#f`.
      On Windows the temporary directory is specified by the ``TMP``
      environment variable.
 

--- a/documentation/library-reference/source/system/locators.rst
+++ b/documentation/library-reference/source/system/locators.rst
@@ -207,7 +207,7 @@ The locators Module
    :value directory: An instance of :class:`false-or(<directory-locator>) <<directory-locator>`.
 
    :description:
-    Returns the enclosing directory of a locator, or ``#f`` if it
+    Returns the enclosing directory of a locator, or :drm:`#f` if it
     is not in a directory.
 
 .. function:: locator-error
@@ -229,7 +229,7 @@ The locators Module
    :description:
     Returns the extension part of the locator name. For example, if a file locator's
     path was ``a/b/c.txt``, the locator-extension would be ``txt``.
-    Returns ``#f`` if the locator does not have an extension.
+    Returns :drm:`#f` if the locator does not have an extension.
 
 .. generic-function:: locator-file
 

--- a/documentation/library-reference/source/system/operating-system.rst
+++ b/documentation/library-reference/source/system/operating-system.rst
@@ -91,7 +91,7 @@ System library's operating-system module.
      architecture is little-endian and false if it is big-endian. (A
      processor is little-endian if the rightmost bit in a word is the
      least-significant bit.) For processors implementing the Intel x86
-     architecture this value is ``#t``.
+     architecture this value is :drm:`#t`.
 
    :seealso:
 
@@ -125,12 +125,12 @@ System library's operating-system module.
    :signature: environment-variable *name* => *value*
 
    :parameter name: An instance of :drm:`<byte-string>`.
-   :value value: An instance of :drm:`<byte-string>`, or ``#f``.
+   :value value: An instance of :drm:`<byte-string>`, or :drm:`#f`.
 
    :description:
 
      Returns the value of the environment variable specified by *name*,
-     or ``#f`` if there is no such environment variable.
+     or :drm:`#f` if there is no such environment variable.
 
    :seealso:
 
@@ -142,14 +142,14 @@ System library's operating-system module.
 
    :signature: environment-variable-setter *new-value* *name* => *new-value*
 
-   :parameter new-value: An instance of :drm:`<byte-string>`, or ``#f``.
+   :parameter new-value: An instance of :drm:`<byte-string>`, or :drm:`#f`.
    :parameter name: An instance of :drm:`<byte-string>`.
-   :value new-value: An instance of :drm:`<byte-string>`, or ``#f``.
+   :value new-value: An instance of :drm:`<byte-string>`, or :drm:`#f`.
 
    :description:
 
      Changes the value of the environment variable specified by *name*
-     to *new-value*. If *new-value* is ``#f``, the environment variable
+     to *new-value*. If *new-value* is :drm:`#f`, the environment variable
      is undefined. If the environment variable does not already exist,
      *environment-variable-setter* creates it.
 
@@ -194,7 +194,7 @@ System library's operating-system module.
 .. function:: login-name
 
    Returns as an instance of :drm:`<string>` the name of the user logged on
-   to the current machine, or ``#f`` if unavailable.
+   to the current machine, or :drm:`#f` if unavailable.
 
    :signature: login-name () => *name-or-false*
 
@@ -203,7 +203,7 @@ System library's operating-system module.
    :description:
 
      Returns as an instance of :drm:`<string>` the name of the user logged
-     on to the current machine, or ``#f`` if unavailable.
+     on to the current machine, or :drm:`#f` if unavailable.
 
    :seealso:
 
@@ -219,7 +219,7 @@ System library's operating-system module.
 
      Returns as an instance of :drm:`<string>` the group (for example NT
      domain, or Windows Workgroup) of which the user logged on to the
-     current machine is a member, or ``#f`` if the group is unavailable.
+     current machine is a member, or :drm:`#f` if the group is unavailable.
 
    :seealso:
 
@@ -322,7 +322,7 @@ System library's operating-system module.
 
      Returns as an instance of :drm:`<string>` the name of the user who
      owns the current machine (that is, the name entered when the
-     machine was registered), or ``#f`` if the name is unavailable.
+     machine was registered), or :drm:`#f` if the name is unavailable.
 
 .. function:: owner-organization
 
@@ -336,7 +336,7 @@ System library's operating-system module.
    :description:
 
      Returns as an instance of :drm:`<string>` the organization to which
-     the user who owns the current machine belongs, or ``#f`` if the
+     the user who owns the current machine belongs, or :drm:`#f` if the
      name is unavailable.
 
 .. function:: parent-process-id
@@ -422,7 +422,7 @@ System library's operating-system module.
       to run in the same session and process group as the calling process and
       therefore retain the same controlling TTY. Essentially, whether or not to
       call ``setsid()``. If you want the subprocess to be a daemon process, pass
-      ``#f``. The default is ``#t``.
+      :drm:`#f`. The default is :drm:`#t`.
 
    :parameter #key outputter: An instance of :drm:`<function>`. A function with
       signature ``(buffer :: <string>, #key end)`` which will receive all output
@@ -432,14 +432,14 @@ System library's operating-system module.
       return immediately after creating the process. Otherwise, block until the
       command completes or is terminated by signal.
 
-   :parameter #key environment: ``#f`` or an instance of
+   :parameter #key environment: :drm:`#f` or an instance of
       :drm:`<explicit-key-collection>`.  A table mapping environment variable
       names (strings) to values (also strings). These values *augment* the
       environment in the current process. (There is currently no way to specify
       via this API that *environment* should be the only environment variables
       set in the subprocess.)
 
-   :parameter #key working-directory: ``#f`` or an instance of
+   :parameter #key working-directory: :drm:`#f` or an instance of
       :class:`<pathname>`. If not #f, the working directory of the subprocess
       is set to this directory.
 
@@ -473,35 +473,35 @@ System library's operating-system module.
         it to the subprocess's standard output.
 
    :parameter #key if-output-exists: As for the ``if-exists`` option when
-      creating an output :class:`<file-stream>` except that ``#f`` is not
+      creating an output :class:`<file-stream>` except that :drm:`#f` is not
       allowed.
 
    :parameter #key error: Possible values are the same as for the ``output``
       parameter except that they apply to :var:`*standard-error*`.
 
    :parameter #key if-error-exists: As for the ``if-exists`` option when
-      creating an output :class:`<file-stream>` except that ``#f`` is not
+      creating an output :class:`<file-stream>` except that :drm:`#f` is not
       allowed.
 
    :parameter #key activate?: An instance of :drm:`<boolean>`.  If the
-      *activate?* argument is ``#t``, the shell window becomes the active
-      window. The default is ``#t``. (**Ignored on Unix platforms.**)
+      *activate?* argument is :drm:`#t`, the shell window becomes the active
+      window. The default is :drm:`#t`. (**Ignored on Unix platforms.**)
 
-   :parameter #key minimize?: An instance of :drm:`<boolean>`. If ``#t``, the
+   :parameter #key minimize?: An instance of :drm:`<boolean>`. If :drm:`#t`, the
       command's shell window will appear minimized. The default is
-      ``#f``. (**Ignored on Unix platforms.**)
+      :drm:`#f`. (**Ignored on Unix platforms.**)
 
-   :parameter #key hide?: An instance of :drm:`<boolean>`.  If ``#t``, the
+   :parameter #key hide?: An instance of :drm:`<boolean>`.  If :drm:`#t`, the
       window associated with this process will be hidden. The default is
-      ``#f``. (**Ignored on Unix platforms.**)
+      :drm:`#f`. (**Ignored on Unix platforms.**)
 
    :value status: An instance of :drm:`<integer>`. The exit status returned by
       ``waitpid`` (Unix) or ``WaitForSingleObject`` (Windows).
 
-   :value signal: ``#f`` or an instance of :drm:`<integer>`. If the process
+   :value signal: :drm:`#f` or an instance of :drm:`<integer>`. If the process
       was terminated by a signal this value is the signal number.
 
-   :value process: ``#f`` or an instance of :class:`<application-process>`.  If
+   :value process: :drm:`#f` or an instance of :class:`<application-process>`.  If
       ``asynchronous?`` is true, :func:`run-application` returns immediately
       and this value identifies the running process. See
       :func:`wait-for-application-process`, which may be used to wait for this
@@ -544,6 +544,6 @@ System library's operating-system module.
    :value status: An instance of :drm:`<integer>`. The exit status returned by
       ``waitpid`` (Unix) or ``WaitForSingleObject`` (Windows).
 
-   :value signal: ``#f`` or an instance of :drm:`<integer>`. If the process
+   :value signal: :drm:`#f` or an instance of :drm:`<integer>`. If the process
       was terminated by a signal this value is the signal number.
 

--- a/documentation/library-reference/source/win32/index.rst
+++ b/documentation/library-reference/source/win32/index.rst
@@ -199,7 +199,7 @@ for frequently used types, such as ``$NULL-HANDLE``, ``NULL-RECT``, and
 by the expression :func:`null-pointer(<FOO>) <null-pointer>`. Use the function
 :func:`null-pointer?` to test whether a value is null. Do not use the
 expression ``if(ptr)...`` as is often done in C, since a null pointer is
-not the same as ``#f``. There are also functions :func:`null-handle` and
+not the same as :drm:`#f`. There are also functions :func:`null-handle` and
 :func:`null-handle?` for creating and testing handles, since conceptually they
 are not necessarily pointers.
 
@@ -225,7 +225,7 @@ they refer to the FFI designation of the C value representation, not to
 a Dylan data type.
 
 The C types ``BOOL`` and ``BOOLEAN`` are both mapped to :drm:`<boolean>` in
-Dylan. Use ``#t`` and ``#f`` instead of ``TRUE`` and ``FALSE``.
+Dylan. Use :drm:`#t` and :drm:`#f` instead of ``TRUE`` and ``FALSE``.
 
 .. note:: Beware that some functions, such as *TranslateAccelerator*,
    though documented to return ``TRUE`` or ``FALSE``, actually return ``int``
@@ -441,7 +441,7 @@ The Win32-Kernel library provides the following utility functions.
      functions).
 
      The function returns a text message (in a string) corresponding to
-     the error code, ``#f`` if the code is not recognized. The returned
+     the error code, :drm:`#f` if the code is not recognized. The returned
      string might have more than one line but does not have a newline at
      the end.
 
@@ -469,7 +469,7 @@ The Win32-Kernel library provides the following utility functions.
 
    :description:
 
-     Many Windows functions return ``#f`` or ``NULL`` to mean failure.
+     Many Windows functions return :drm:`#f` or ``NULL`` to mean failure.
      The function ``check-win32-result`` checks the result to see if it
      indicates failure, and if so it calls :func:`report-win32-error`.
 


### PR DESCRIPTION
Link lots of things and improve the formatting of `:macrocall:` markup.

Old:
<img width="864" alt="current-markup" src="https://user-images.githubusercontent.com/491829/235497428-c34d9218-52ee-4233-9dea-058e4fa02d99.png">

New:
<img width="877" alt="parsed-literal-markup" src="https://user-images.githubusercontent.com/491829/235497430-79bf22ac-57c9-4ecf-995a-6e77862f505f.png">
