### PR TITLE
release-with-batteries.sh: use LLVM 16.0.5 and BDW 8.2.4

### DIFF
--- a/build/unix/release-with-batteries.sh
+++ b/build/unix/release-with-batteries.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 set -e
 
-LLVM_RELEASE=15.0.5
+LLVM_RELEASE=16.0.5
 LLVM_REL=$(echo $LLVM_RELEASE | sed s/-rc/rc/)
 
 LLVM_CLANG=$(echo $LLVM_RELEASE | sed 's/\([0-9]*\).*/\1/')
 
-BDWGC_RELEASE=8.2.2
+BDWGC_RELEASE=8.2.4
 
 srcdir=`dirname $0`
 test -z "$srcdir" && srcdir=.

--- a/documentation/release-notes/source/2023.1.rst
+++ b/documentation/release-notes/source/2023.1.rst
@@ -20,6 +20,10 @@ this release.
 Compiler
 ========
 
+* The "batteries included" installation includes `LLVM version 16.0.5
+  <https://github.com/llvm/llvm-project/releases/tag/llvmorg-16.0.5>`_ and `BDW
+  GC version 8.2.4 <https://github.com/ivmai/bdwgc/releases/tag/v8.2.4>`_.
+
 * `Dylan Enhancement Proposal (DEP) 12
   <https://opendylan.org/proposals/dep-0012-string-literals.html>`_ was
   implemented, adding multi-line and "raw" string literals.


### PR DESCRIPTION
These are the current stable revisions as of today.