### PR TITLE
Fix #1389 file-system module missing documentation

### DIFF
--- a/documentation/library-reference/source/io/streams.rst
+++ b/documentation/library-reference/source/io/streams.rst
@@ -2977,68 +2977,6 @@ are exported from the *streams* module.
      * :class:`<indenting-stream>`
      * :gf:`indent`
 
-.. macro:: with-open-file
-   :statement:
-
-   Runs a body of code within the context of a file stream.
-
-   :macrocall:
-     .. parsed-literal:: 
-        with-open-file (`stream-var` = `filename`, #rest `keys`)
-          `body`
-        end => `values`
-
-   :parameter stream-var: An Dylan variable-name *bnf*.
-   :parameter filename: An instance of :drm:`<string>`.
-   :parameter keys: Instances of :drm:`<object>`.
-   :parameter body: A Dylan body *bnf*.
-   :value values: Instances of :drm:`<object>`.
-
-   :description:
-
-     Provides a safe mechanism for working with file streams. The macro
-     creates a file stream and binds it to *stream-var*, evaluates a
-     *body* of code within the context of this binding, and then closes
-     the stream. The macro calls :gf:`close` upon exiting *body*.
-
-     The values of the last expression in *body* are returned.
-
-     Any *keys* are passed to the :meth:`make <make(<file-stream>)>`
-     method on :class:`<file-stream>`.
-
-   :example:
-
-     The following expression yields the contents of file *foo.text* as
-     a :class:`<byte-vector>`:
-
-     .. code-block:: dylan
-
-       with-open-file (fs = "foo.text", element-type: <byte>)
-         read-to-end(fs)
-       end;
-
-     It is roughly equivalent to:
-
-     .. code-block:: dylan
-
-       begin
-         let hidden-fs = #f; // In case the user bashes fs variable
-         block ()
-           hidden-fs := make(<file-stream>,
-                             locator: "foo.text", element-type: <byte>);
-           let fs = hidden-fs;
-           read-to-end(fs);
-         cleanup
-           if (hidden-fs) close(hidden-fs) end;
-         end block;
-       end;
-
-   :seealso:
-
-     - :meth:`close(<file-stream>)`
-     - :class:`<file-stream>`
-     - :meth:`make(<file-stream>)`
-
 .. macro:: with-stream-locked
    :statement:
 

--- a/documentation/library-reference/source/system/locators.rst
+++ b/documentation/library-reference/source/system/locators.rst
@@ -38,26 +38,8 @@ The locators Module
    is useful for coercing an abstract locator into its corresponding
    physical counterpart.
 
-.. class:: <file-system-locator>
-   :open:
-   :abstract:
-
-   :superclasses: :class:`<physical-locator>`
-
-   A file system locator is a locator that refers to either a directory
-   or a file within the file system.
-
-.. class:: <file-system-file-locator>
-
-   :superclasses: :class:`<file-system-locator>`, :class:`<file-locator>`
-
-   This locator refers to a file within a file system.
-
-.. class:: <file-system-directory-locator>
-
-   :superclasses: :class:`<file-system-locator>`, :class:`<directory-locator>`
-
-   This locator refers to a directory within a file system.
+   .. note:: Locator classes representing file system objects are documented
+             in :doc:`file-system`.
    
 .. class:: <directory-locator>
    :open:
@@ -632,85 +614,6 @@ The locators Module
    A locator using the file protocol.
    
    :superclasses: :class:`<server-url>`
-
-.. class:: <microsoft-server-locator>
-   :sealed:
-   :abstract:
-
-   The abstract superclass of all servers using Microsoft protocols.
-
-   :superclasses: :class:`<server-locator>`
-
-   :seealso: :class:`<microsoft-unc-locator>`
-	     :class:`<microsoft-volume-locator>`
-
-.. class:: <microsoft-unc-locator>
-   :sealed:
-
-   A server located using Microsoft's Univeral Naming Convention,
-   for example ``\\ComputerName\Share``
-
-   :superclasses: :class:`<microsoft-server-locator>`
-
-.. class:: <microsoft-volume-locator>
-   :sealed:
-
-   A server located using a volume name (drive letter) on a Microsoft
-   system, for example ``C``.
-
-   :superclasses: :class:`<microsoft-server-locator>`
-
-.. class:: <microsoft-file-system-locator>
-   :abstract:
-
-   The abstract superclass of files and directories on Microsoft file systems.
-
-   :superclasses: :class:`<file-system-locator>`
-
-.. class:: <microsoft-directory-locator>
-
-   A directory on a Microsoft file system.
-
-   :superclasses: :class:`<microsoft-file-system-locator>`, :class:`<directory-locator>`
-
-   :slot locator-server: the server which holds this directory.
-
-.. class:: <microsoft-file-locator>
-
-   A file on a Microsoft file system.
-
-   :superclasses: :class:`<microsoft-file-system-locator>`, :class:`<file-locator>`
-
-   :slot locator-directory: the directory that holds this file.
-   :slot locator-base: the file name without extension.
-   :slot locator-extension: the file extension.
-   :slot locator-name: the file name.
-
-.. class:: <posix-file-system-locator>
-   :abstract:
-   :sealed:
-
-   The abstract superclass of files and directories on a posix-like file system.
-
-   :superclasses: :class:`<file-system-locator>`
-
-.. class:: <posix-directory-locator>
-   :sealed:
-
-   A directory on a posix-like file system.
-
-   :superclasses: :class:`<file-system-directory-locator>`, :class:`<posix-file-system-locator>`
-
-.. class:: <posix-file-locator>
-   :sealed:
-
-   A file on a posix-like file system.
-
-   :superclasses: :class:`<file-system-file-locator>`, :class:`<posix-file-system-locator>`
-
-   :slot locator-directory: the directory that holds this file.
-   :slot locator-base: the file name without extension.
-   :slot locator-extension: the file extension.
 
 .. generic-function:: locator-default-port
 


### PR DESCRIPTION
Add new documentation:

- `<file-error>`
- `<file-exists-error>`
- `<file-does-not-exists-error>`
- `<invalid-file-permissions-error>`
- `file-error-locator`
- `file-system-separator`
- `<native-file-system-locator>`
- `expand-pathname`
- `shorten-pathname`
- `directory-empty?`

Elements defined in this module, but documented in module `locators`:

- `<file-system-directory-locator>`
- `<file-system-locator>`
- Posix locators 
- Microsoft locators`
- `with-open-file` macro

Add new sections:

- List conditions signaled by `file-system` module.
- Sketch for file system locators.