### PR TITLE
Make win32 run-application only accept a string

### DIFF
--- a/documentation/library-reference/source/system/operating-system.rst
+++ b/documentation/library-reference/source/system/operating-system.rst
@@ -413,6 +413,9 @@ System library's operating-system module.
       command as parsed by the shell. Example: ``"/bin/ls -l"`` or
       ``#["/bin/ls", "-l"]``
 
+      .. note:: On Windows this must be a :drm:`<string>`, not a sequence of
+                strings.
+
    :parameter #key under-shell?: An instance of :drm:`<boolean>`. If true (the
       default), use a shell to invoke the *command*. On Unix systems this is
       equivalent to ``/bin/sh -c '...command...'``. On Windows the

--- a/sources/system/x86-win32-operating-system.dylan
+++ b/sources/system/x86-win32-operating-system.dylan
@@ -614,7 +614,7 @@ define constant $null-device = "NUL:";
 // Note: streams are always returned in the order stdin, stdout, stderr
 //       even though not all of them are always returned.
 define function run-application
-    (command :: type-union(<string>, limited(<sequence>, of: <string>)),
+    (command :: <string>,
      #key under-shell? = #f,
           inherit-console? = #t,
           activate? = #t,


### PR DESCRIPTION
I had to update the sphinx-extensions submodule in order to rebuild the docs.