### PR TITLE
Fix 1426 build docs

### DIFF
--- a/.github/workflows/bootstrap.yaml
+++ b/.github/workflows/bootstrap.yaml
@@ -1,6 +1,12 @@
 name: Bootstrap
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'documentation/**'
+  pull_request:
+    paths-ignore:
+      - 'documentation/**'
 
 jobs:
   build:

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -1,0 +1,183 @@
+#
+# Build HTML documentation and upload it to GitHub Pages
+#
+
+name: Build documentation
+
+on:
+  push:
+    paths:
+      - 'documentation/**/*.rst'
+      - 'documentation/**/conf.py'
+  pull_request:
+    paths:
+      - 'documentation/**/*.rst'
+      - 'documentation/**/conf.py'
+
+  # This enables the Run Workflow button on the Actions tab.
+  workflow_dispatch:
+
+jobs:
+  build-documentation:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      #
+      # Building with Duim
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/building-with-duim"
+
+      - name: Deploy Building with Duim
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/building-with-duim/build/html
+          target-folder: building-with-duim
+
+      #
+      # Corba guide
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/corba-guide"
+
+      - name: Deploy Corba Guide
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/corba-guide/build/html
+          target-folder: corba-guide
+
+      #
+      # Duim reference
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/duim-reference"
+
+      - name: Deploy Duim Reference
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/duim-reference/build/html
+          target-folder: duim-reference
+
+      #
+      # Getting started IDE
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/getting-started-ide"
+
+      - name: Deploy Getting started IDE
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/getting-started-ide/build/html
+          target-folder: getting-started-ide
+
+      #
+      # Hacker guide
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/hacker-guide"
+
+      - name: Deploy Hacker Guide
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/hacker-guide/build/html
+          target-folder: hacker-guide
+
+      #
+      # Intro Dylan
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/intro-dylan"
+
+      - name: Deploy Intro Dylan
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/intro-dylan/build/html
+          target-folder: intro-dylan
+
+      #
+      # Library reference
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/library-reference"
+
+      - name: Deploy Library Reference
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/library-reference/build/html
+          target-folder: library-reference
+
+      #
+      # Man pages
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/man-pages"
+
+      - name: Deploy Man pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/man-pages/build/html
+          target-folder: man-pages
+
+      #
+      # Project notebook
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/project-notebook"
+
+      - name: Deploy Project notebook
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/project-notebook/build/html
+          target-folder: project-notebook
+
+      #
+      # Release notes
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/release-notes"
+
+      - name: Deploy Release notes
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/release-notes/build/html
+          target-folder: release-notes
+
+      #
+      # Style guide
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/style-guide"
+
+      - name: Style Guide
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/style-guide/build/html
+          target-folder: style-guide

--- a/.github/workflows/libraries-test-suite.yaml
+++ b/.github/workflows/libraries-test-suite.yaml
@@ -3,10 +3,14 @@ name: libraries-test-suite
 on:
   push:
     # all branches
+    paths-ignore:
+      - 'documentation/**'
   pull_request:
     branches:
       - main
       - master
+    paths-ignore:
+      - 'documentation/**'
 
   # This enables the Run Workflow button on the Actions tab.
   workflow_dispatch:

--- a/documentation/library-reference/source/index.rst
+++ b/documentation/library-reference/source/index.rst
@@ -38,4 +38,9 @@ published Dylan packages.
    t-lists/index
    win32/index
 
+.. toctree::
+   :caption: About
+
+   copyright
+
 :ref:`Full Index <genindex>`

--- a/documentation/man-pages/source/index.rst
+++ b/documentation/man-pages/source/index.rst
@@ -12,7 +12,6 @@ Contents:
    :maxdepth: 2
 
    dylan-compiler
-   dylan
 
 
 Indices and tables

--- a/documentation/release-notes/source/2019.1.rst
+++ b/documentation/release-notes/source/2019.1.rst
@@ -36,7 +36,7 @@ installed Clang 7.0 or later, you can edit
 ``share/opendylan/build-scripts/config.jam`` and set the CC variable
 to point to your Clang executable:
 
-.. code-block:: jam
+.. code-block::
 
    CC                ?= clang-7 ;
    CCFLAGS           ?= -w -g -O2 ;

--- a/documentation/release-notes/source/2020.1.rst
+++ b/documentation/release-notes/source/2020.1.rst
@@ -21,7 +21,7 @@ Compiler
   ``SUPPORTED_COMPILER_BACK_ENDS`` build system variable, normally set
   at configuration time within the ``config.jam`` build script:
 
-  .. code-block:: jam
+  .. code-block::
 
       SUPPORTED_COMPILER_BACK_ENDS ?= llvm c ;
 


### PR DESCRIPTION
- Triggered on '.rst' or 'conf.py' change.
- Disable other actions on changes in 'documents' folder.
- Using https://github.com/marketplace/actions/sphinx-build to build sphinx docs, it shows in   the actions tab the warnings and errors.
- Not uploading artifacts yet.