### PR TITLE
Fix #1426: Automate docs build on change

### DIFF
--- a/.github/workflows/bootstrap.yaml
+++ b/.github/workflows/bootstrap.yaml
@@ -1,6 +1,12 @@
 name: Bootstrap
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'documentation/**'
+  pull_request:
+    paths-ignore:
+      - 'documentation/**'
 
 jobs:
   build:

--- a/.github/workflows/build-documentation.yaml
+++ b/.github/workflows/build-documentation.yaml
@@ -1,0 +1,183 @@
+#
+# Build HTML documentation and upload it to GitHub Pages
+#
+
+name: Build documentation
+
+on:
+  push:
+    paths:
+      - 'documentation/**/*.rst'
+      - 'documentation/**/conf.py'
+  pull_request:
+    paths:
+      - 'documentation/**/*.rst'
+      - 'documentation/**/conf.py'
+
+  # This enables the Run Workflow button on the Actions tab.
+  workflow_dispatch:
+
+jobs:
+  build-documentation:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      #
+      # Building with Duim
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/building-with-duim"
+
+      - name: Deploy Building with Duim
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/building-with-duim/build/html
+          target-folder: building-with-duim
+
+      #
+      # Corba guide
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/corba-guide"
+
+      - name: Deploy Corba Guide
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/corba-guide/build/html
+          target-folder: corba-guide
+
+      #
+      # Duim reference
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/duim-reference"
+
+      - name: Deploy Duim Reference
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/duim-reference/build/html
+          target-folder: duim-reference
+
+      #
+      # Getting started IDE
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/getting-started-ide"
+
+      - name: Deploy Getting started IDE
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/getting-started-ide/build/html
+          target-folder: getting-started-ide
+
+      #
+      # Hacker guide
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/hacker-guide"
+
+      - name: Deploy Hacker Guide
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/hacker-guide/build/html
+          target-folder: hacker-guide
+
+      #
+      # Intro Dylan
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/intro-dylan"
+
+      - name: Deploy Intro Dylan
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/intro-dylan/build/html
+          target-folder: intro-dylan
+
+      #
+      # Library reference
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/library-reference"
+
+      - name: Deploy Library Reference
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/library-reference/build/html
+          target-folder: library-reference
+
+      #
+      # Man pages
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/man-pages"
+
+      - name: Deploy Man pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/man-pages/build/html
+          target-folder: man-pages
+
+      #
+      # Project notebook
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/project-notebook"
+
+      - name: Deploy Project notebook
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/project-notebook/build/html
+          target-folder: project-notebook
+
+      #
+      # Release notes
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/release-notes"
+
+      - name: Deploy Release notes
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/release-notes/build/html
+          target-folder: release-notes
+
+      #
+      # Style guide
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/style-guide"
+
+      - name: Style Guide
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/style-guide/build/html
+          target-folder: style-guide

--- a/.github/workflows/libraries-test-suite.yaml
+++ b/.github/workflows/libraries-test-suite.yaml
@@ -3,10 +3,14 @@ name: libraries-test-suite
 on:
   push:
     # all branches
+    paths-ignore:
+      - 'documentation/**'
   pull_request:
     branches:
       - main
       - master
+    paths-ignore:
+      - 'documentation/**'
 
   # This enables the Run Workflow button on the Actions tab.
   workflow_dispatch:


### PR DESCRIPTION
- Modify 'bootstrap.yaml' and 'libraries-test-suite.yaml'. When changes are made to the documentation folder, deactivate the build and test actions.

- Add 'build-documentation.yaml'. Automatically generate documentation whenever any file with the extension '.rst' or 'conf.py' is modified within the 'documentation' folder. It generates the HTML documentation and deploys it to GH pages.