### PR TITLE
Remove firing action on pull request

### DIFF
--- a/.github/workflows/build-documentation.yaml
+++ b/.github/workflows/build-documentation.yaml
@@ -9,10 +9,6 @@ on:
     paths:
       - 'documentation/**/*.rst'
       - 'documentation/**/conf.py'
-  pull_request:
-    paths:
-      - 'documentation/**/*.rst'
-      - 'documentation/**/conf.py'
 
   # This enables the Run Workflow button on the Actions tab.
   workflow_dispatch:
@@ -23,6 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+
     steps:
       - uses: actions/checkout@v3
         with:

--- a/documentation/corba-guide/source/idl-app.rst
+++ b/documentation/corba-guide/source/idl-app.rst
@@ -1074,7 +1074,7 @@ Examples
 
    // Dylan
    define constant $E :: CORBA/<double> = 2.71828182845904523536;
-y   define constant $LYRS-TO-ALPHA-CENTAURI :: CORBA/<float> = 4.35;
+   define constant $LYRS-TO-ALPHA-CENTAURI :: CORBA/<float> = 4.35;
 
 
 Fixed-point decimals


### PR DESCRIPTION
- Action fails on pull request not having permissions to write in gh-pages branch. Delete it until we have more information.

- [doc] Fix error 'Explicit markup ends without a blank line; unexpected unindent'. Added here to test the action.