### PR TITLE
Split build documentation workflow

### DIFF
--- a/.github/workflows/build-deploy-documentation.yaml
+++ b/.github/workflows/build-deploy-documentation.yaml
@@ -1,0 +1,180 @@
+#
+# Build HTML documentation and upload it to GitHub Pages
+#
+
+name: Build and deploy documentation
+
+on:
+  push:
+    paths:
+      - 'documentation/**/*.rst'
+      - 'documentation/**/conf.py'
+
+  # This enables the Run Workflow button on the Actions tab.
+  workflow_dispatch:
+
+jobs:
+  build-documentation:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      #
+      # Building with Duim
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/building-with-duim"
+
+      - name: Deploy Building with Duim
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/building-with-duim/build/html
+          target-folder: building-with-duim
+
+      #
+      # Corba guide
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/corba-guide"
+
+      - name: Deploy Corba Guide
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/corba-guide/build/html
+          target-folder: corba-guide
+
+      #
+      # Duim reference
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/duim-reference"
+
+      - name: Deploy Duim Reference
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/duim-reference/build/html
+          target-folder: duim-reference
+
+      #
+      # Getting started IDE
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/getting-started-ide"
+
+      - name: Deploy Getting started IDE
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/getting-started-ide/build/html
+          target-folder: getting-started-ide
+
+      #
+      # Hacker guide
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/hacker-guide"
+
+      - name: Deploy Hacker Guide
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/hacker-guide/build/html
+          target-folder: hacker-guide
+
+      #
+      # Intro Dylan
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/intro-dylan"
+
+      - name: Deploy Intro Dylan
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/intro-dylan/build/html
+          target-folder: intro-dylan
+
+      #
+      # Library reference
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/library-reference"
+
+      - name: Deploy Library Reference
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/library-reference/build/html
+          target-folder: library-reference
+
+      #
+      # Man pages
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/man-pages"
+
+      - name: Deploy Man pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/man-pages/build/html
+          target-folder: man-pages
+
+      #
+      # Project notebook
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/project-notebook"
+
+      - name: Deploy Project notebook
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/project-notebook/build/html
+          target-folder: project-notebook
+
+      #
+      # Release notes
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/release-notes"
+
+      - name: Deploy Release notes
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/release-notes/build/html
+          target-folder: release-notes
+
+      #
+      # Style guide
+      #
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "documentation/style-guide"
+
+      - name: Style Guide
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/style-guide/build/html
+          target-folder: style-guide

--- a/.github/workflows/build-documentation.yaml
+++ b/.github/workflows/build-documentation.yaml
@@ -1,14 +1,10 @@
 #
-# Build HTML documentation and upload it to GitHub Pages
+# Build HTML documentation on Pull Request
 #
 
 name: Build documentation
 
 on:
-  push:
-    paths:
-      - 'documentation/**/*.rst'
-      - 'documentation/**/conf.py'
   pull_request:
     paths:
       - 'documentation/**/*.rst'
@@ -23,161 +19,53 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
 
-      #
-      # Building with Duim
-      #
-
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "documentation/building-with-duim"
-
-      - name: Deploy Building with Duim
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: documentation/building-with-duim/build/html
-          target-folder: building-with-duim
-
-      #
-      # Corba guide
-      #
 
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "documentation/corba-guide"
 
-      - name: Deploy Corba Guide
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: documentation/corba-guide/build/html
-          target-folder: corba-guide
-
-      #
-      # Duim reference
-      #
-
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "documentation/duim-reference"
-
-      - name: Deploy Duim Reference
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: documentation/duim-reference/build/html
-          target-folder: duim-reference
-
-      #
-      # Getting started IDE
-      #
 
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "documentation/getting-started-ide"
 
-      - name: Deploy Getting started IDE
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: documentation/getting-started-ide/build/html
-          target-folder: getting-started-ide
-
-      #
-      # Hacker guide
-      #
-
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "documentation/hacker-guide"
-
-      - name: Deploy Hacker Guide
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: documentation/hacker-guide/build/html
-          target-folder: hacker-guide
-
-      #
-      # Intro Dylan
-      #
 
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "documentation/intro-dylan"
 
-      - name: Deploy Intro Dylan
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: documentation/intro-dylan/build/html
-          target-folder: intro-dylan
-
-      #
-      # Library reference
-      #
-
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "documentation/library-reference"
-
-      - name: Deploy Library Reference
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: documentation/library-reference/build/html
-          target-folder: library-reference
-
-      #
-      # Man pages
-      #
 
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "documentation/man-pages"
 
-      - name: Deploy Man pages
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: documentation/man-pages/build/html
-          target-folder: man-pages
-
-      #
-      # Project notebook
-      #
-
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "documentation/project-notebook"
-
-      - name: Deploy Project notebook
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: documentation/project-notebook/build/html
-          target-folder: project-notebook
-
-      #
-      # Release notes
-      #
 
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "documentation/release-notes"
 
-      - name: Deploy Release notes
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: documentation/release-notes/build/html
-          target-folder: release-notes
-
-      #
-      # Style guide
-      #
-
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "documentation/style-guide"
 
-      - name: Style Guide
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: documentation/style-guide/build/html
-          target-folder: style-guide

--- a/documentation/corba-guide/source/idl-app.rst
+++ b/documentation/corba-guide/source/idl-app.rst
@@ -1074,7 +1074,7 @@ Examples
 
    // Dylan
    define constant $E :: CORBA/<double> = 2.71828182845904523536;
-y   define constant $LYRS-TO-ALPHA-CENTAURI :: CORBA/<float> = 4.35;
+   define constant $LYRS-TO-ALPHA-CENTAURI :: CORBA/<float> = 4.35;
 
 
 Fixed-point decimals


### PR DESCRIPTION
When attempting to deploy to GH Pages, the workflow encounters failures due to the pull request that lacks the required permissions. In order to resolve (temporary) this issue, we have divided the documentation building workflow in two separate parts:

- On 'Push' ('build-deploy-documentation.yaml'), we build the documentation and deploy it to the GH pages' branch.

- On 'Pull Request' ('build-documentation.yaml'), only build the documentation, but not deploy it.

In addition:

- [doc] Fix error 'Explicit markup ends without a blank line; unexpected unindent'. Added here to test the action.