### PR TITLE
CI: run libraries-test-suite on macOS

### DIFF
--- a/.github/workflows/libraries-test-suite.yaml
+++ b/.github/workflows/libraries-test-suite.yaml
@@ -2,15 +2,11 @@ name: libraries-test-suite
 
 on:
   push:
-    # all branches
-    paths-ignore:
-      - 'documentation/**'
+    paths-ignore: ['documentation/**', '**.rst', '**.md']
   pull_request:
     branches:
-      - main
       - master
-    paths-ignore:
-      - 'documentation/**'
+    paths-ignore: ['documentation/**', '**.rst', '**.md']
 
   # This enables the Run Workflow button on the Actions tab.
   workflow_dispatch:
@@ -20,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [macos-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -29,8 +25,8 @@ jobs:
 
       - uses: dylan-lang/install-opendylan@v3
         with:
-          version: 2022.1
-          tag: v2022.1.0
+          version: 2023.1
+          tag: v2023.1.0
 
       - name: Build libraries-test-suite-app
         run: |

--- a/sources/common-dylan/tests/transcendentals.dylan
+++ b/sources/common-dylan/tests/transcendentals.dylan
@@ -154,9 +154,7 @@ define test test-^ ()
 end test;
 
 
-define test test-sqrt
-    (expected-to-fail-test: method () $os-name == #"darwin" end,
-     expected-to-fail-reason: "https://github.com/dylan-lang/opendylan/issues/1295")
+define test test-sqrt ()
   check-condition("sqrt(-1) errors",
                   <error>,
                   sqrt(-1));
@@ -168,8 +166,6 @@ define test test-sqrt
   check-condition("sqrt(-1.d0) errors",
                   <error>,
                   sqrt(-1.d0));
-
-
 end test;
 
 define test test-isqrt ()


### PR DESCRIPTION
* Use 2023.1 in the workflow.
* Fix test-sqrt, which was unexpectedly succeeding.
* Ignore more documentation paths.
