### PR TITLE
Implement DEP 12, string literals supporting Rectangle Rule

### DIFF
--- a/sources/dfmc/reader/reader-library.dylan
+++ b/sources/dfmc/reader/reader-library.dylan
@@ -12,6 +12,7 @@ define library dfmc-reader
   use dfmc-common;
   use dfmc-conditions;
   use source-records;
+  use strings;
   export dfmc-reader;
 end library dfmc-reader;
 
@@ -29,6 +30,7 @@ define module dfmc-reader
   use dfmc-imports;
   use dfmc-conditions;
   use source-records;
+  use strings;
 
   //// Token classes used externally.
 


### PR DESCRIPTION
See https://opendylan.org/proposals/dep-0012-string-literals.html#the-rectangle-rule for details.

This implements everything except for the ability to use three **or more** double quotes to start/end the multi-line string. Only exactly `"""` may be used at this point.