### PR TITLE
Fix multi-line string warnings

### DIFF
--- a/sources/dfmc/reader/interface.dylan
+++ b/sources/dfmc/reader/interface.dylan
@@ -102,6 +102,11 @@ define serious-program-warning <character-code-too-large> (<invalid-token>)
   format-arguments token-string;
 end serious-program-warning;
 
+define serious-program-warning <invalid-multi-line-string-literal> (<invalid-token>)
+  format-string    "Invalid multi-line string literal: %s";
+  format-arguments detail;
+end serious-program-warning;
+
 define serious-program-warning <ratios-not-supported> (<invalid-token>)
   format-string
     "The ratio %s cannot be read because no ratio representation is "

--- a/sources/dfmc/reader/reader-library.dylan
+++ b/sources/dfmc/reader/reader-library.dylan
@@ -71,6 +71,7 @@ define module dfmc-reader
         <integer-too-large>,
         <character-code-too-large>,
         <ratios-not-supported>,
+        <invalid-multi-line-string-literal>,
       <invalid-end-of-input>,
       <parser-error>,
       <manual-parser-error>,

--- a/sources/dfmc/reader/tests/literal-test-suite.dylan
+++ b/sources/dfmc/reader/tests/literal-test-suite.dylan
@@ -289,17 +289,17 @@ def
 \<20>\<20>\<20>
    """},
              "\ndef\n");
-  assert-signals(<error>,
+  assert-signals(<invalid-multi-line-string-literal>,
                  read-fragment(#:string:{"""a  (only whitespace allowed after start delim)
 abc
 """}),
                  "junk on first line");
-  assert-signals(<error>,
+  assert-signals(<invalid-multi-line-string-literal>,
                  read-fragment(#:string:{"""
 abc
 xxx"""}),
                   "junk on last line");
-  assert-signals(<error>,
+  assert-signals(<invalid-multi-line-string-literal>,
                  read-fragment(#:string:{"""
    abc
   xxx  (this line not indented enough)


### PR DESCRIPTION
Signal an appropriate compiler warning instead of just calling error()