### PR TITLE
Remove duplicate code in tool-interface

### DIFF
--- a/sources/app/tool-invoke/tool-invoke.dylan
+++ b/sources/app/tool-invoke/tool-invoke.dylan
@@ -1,5 +1,5 @@
 Module:    tool-invoke
-Synopsis:  A standalone program to invoke Functional Developer tools on 
+Synopsis:  A standalone program to invoke Functional Developer tools on
 	   specification files.
 Author:    7/98 Seth LaForge
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
@@ -15,7 +15,7 @@ define method main () => ()
         exit-application(2);
       end if;
     end method;
-  local method yn-handler (c :: <tool-yes-no-question>, next :: <function>) 
+  local method yn-handler (c :: <tool-yes-no-question>, next :: <function>)
 		       => (answer :: <boolean>)
     format-out("%s (y/n) ", c);
     force-output(*standard-output*);
@@ -30,7 +30,7 @@ define method main () => ()
 
   let args = application-arguments();
   if (size(args) < 1 | size(args) > 2)
-    format-out("Usage: %s <specification-file-name> [<project-file-name>]\n", 
+    format-out("Usage: %s <specification-file-name> [<project-file-name>]\n",
       	       application-name());
     exit-application(1);
   end if;
@@ -39,7 +39,7 @@ define method main () => ()
   if (project-file)
     project-file := as(<file-locator>, project-file);
   end if;
-  
+
   let tool-name = tool-name-from-specification(spec-file);
   let tool = tool-find(tool-name);
   if (tool)

--- a/sources/corba/scepter/tool/tool-scepter-library.dylan
+++ b/sources/corba/scepter/tool/tool-scepter-library.dylan
@@ -9,6 +9,7 @@ define library tool-scepter
   use dylan;
   use common-dylan;
   use collections;
+  use file-source-records;
   use system;
   use io;
   use tools-interface;

--- a/sources/corba/scepter/tool/tool-scepter-module.dylan
+++ b/sources/corba/scepter/tool/tool-scepter-module.dylan
@@ -7,6 +7,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define module tool-scepter
   use common-dylan;
+  use file-source-records;
   use format;
   use streams;
   use table-extensions;

--- a/sources/corba/scepter/tool/tool-scepter.dylan
+++ b/sources/corba/scepter/tool/tool-scepter.dylan
@@ -138,7 +138,7 @@ end method;
 
 define inline-only function read-spec-file (file :: <file-locator>)
  => (specification)
-  read-keyword-pair-file(file);
+  read-file-header(file);
 end function;
 
 define function date-as-string (date :: false-or(<date>)) => (r :: <string>)

--- a/sources/lib/motley/tool-iface.dylan
+++ b/sources/lib/motley/tool-iface.dylan
@@ -16,7 +16,7 @@ define function motley-invoke
   debug-message("Motley invoked.  Spec: %=, project: %=, last: %=, clean: %=\n",
   		spec-file, project-file, last-run & date-as-string(last-run),
 		clean-build?);
-  let spec-keys = read-keyword-pair-file(spec-file);
+  let spec-keys = read-file-header(spec-file);
   motley-process-spec(spec-keys, spec-file, project-file, last-run, 
 		      clean-build?: clean-build?);
 end function motley-invoke;

--- a/sources/lib/parser-generator/tool/library.dylan
+++ b/sources/lib/parser-generator/tool/library.dylan
@@ -8,6 +8,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 define library tool-parser-generator
   use dylan;
   use common-dylan;
+  use file-source-records;
   use io;
   use system;
   use tools-interface;

--- a/sources/lib/parser-generator/tool/module.dylan
+++ b/sources/lib/parser-generator/tool/module.dylan
@@ -9,6 +9,7 @@ define module tool-parser-generator
   use common-dylan;
   use simple-debugging, import: { debug-out };
   use date;
+  use file-source-records;
   use file-system;
   use format;
   use streams;

--- a/sources/lib/parser-generator/tool/tool-parser-generator.dylan
+++ b/sources/lib/parser-generator/tool/tool-parser-generator.dylan
@@ -19,7 +19,7 @@ define method parser-generator-invoke
 
   let keyval = keyword-file-element-value;
   let keyline = keyword-file-element-line;
-  let spec = read-keyword-pair-file(spec-file);
+  let spec = read-file-header(spec-file);
   local method key (sym :: <symbol>) element(spec, sym, default: #()) end;
   local method single (sym :: <symbol>, #key default = $unsupplied)
     if (sym.key.size = 1)

--- a/sources/project-manager/tools-interface/library.dylan
+++ b/sources/project-manager/tools-interface/library.dylan
@@ -10,8 +10,9 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 define library tools-interface
   use dylan;
   use common-dylan;
-  use system;
+  use file-source-records;
   use io;
+  use system;
 
   export tools-interface;
 end library tools-interface;
@@ -21,6 +22,7 @@ define module tools-interface
   use dylan;
   use common-extensions;
   use machine-words;
+  use file-source-records;
   use format;
   use format-out;
   use locators;
@@ -59,7 +61,6 @@ define module tools-interface
          project-information-base-address-setter,
          project-information-remaining-keys-setter;
 
-  export read-keyword-pair-file, read-keyword-pair-stream;
   export write-keyword-pair-file, write-keyword-pair-stream;
   export <keyword-file-element>,
            keyword-file-element-value, keyword-file-element-value-setter,

--- a/sources/project-manager/tools-interface/project-files.dylan
+++ b/sources/project-manager/tools-interface/project-files.dylan
@@ -20,13 +20,16 @@ define class <project-information> (<object>)
     init-keyword: files:;
   slot project-information-subprojects :: <sequence> /* of: <locator> */ = #(),
     init-keyword: subprojects:;
-  slot project-information-library :: <string>, init-keyword: library:;
-  slot project-information-target-type :: one-of(#"executable", #"dll")
-    = #"dll", init-keyword: target-type:;
+  // TODO(cgay): this is the only slot without a default value. Mark it required.
+  //             (The value actually stored here is acquired with required-key().)
+  slot project-information-library :: <string>,
+    init-keyword: library:;
+  slot project-information-target-type :: one-of(#"executable", #"dll") = #"dll",
+    init-keyword: target-type:;
   slot project-information-executable :: false-or(<string>) = #f,
     init-keyword: executable:;
-  slot project-information-compilation-mode :: one-of(#"tight", #"loose")
-    = #"loose", init-keyword: compilation-mode:;
+  slot project-information-compilation-mode :: one-of(#"tight", #"loose") = #"loose",
+    init-keyword: compilation-mode:;
   slot project-information-major-version :: <integer> = 0,
     init-keyword: major-version:;
   slot project-information-minor-version :: <integer> = 0,
@@ -68,41 +71,44 @@ end function write-project-file;
 
 // Write a project to a stream.  version specifies the format version to write -
 // currently it has little effect (since the 1.0 format is basically the same).
-
 define function write-project-to-stream
     (s :: <stream>, p :: <project-information>,
      #key version :: <integer> = $current-project-file-version)
  => ()
-  let t :: <table> =
-          if (p.project-information-remaining-keys)
-            shallow-copy(p.project-information-remaining-keys)
-          else
-            make(<table>)
-          end if;
+  let t :: <table>
+    = if (p.project-information-remaining-keys)
+        shallow-copy(p.project-information-remaining-keys)
+      else
+        make(<table>)
+      end if;
   remove-key!(t, comment:);
   remove-key!(t, format-version:);
-  t[files:] := map(
-          method (locator :: <file-locator>)
-          as(<string>, make(<file-locator>,
-                            directory: locator-directory(locator),
-                            base: locator-base(locator)))
-        end method,
-        p.project-information-files);
-  t[subprojects:] :=
-          map(curry(as, <string>), p.project-information-subprojects);
+  t[files:]
+    := map(method (locator :: <file-locator>)
+             as(<string>, make(<file-locator>,
+                               directory: locator-directory(locator),
+                               base: locator-base(locator)))
+           end method,
+           p.project-information-files);
+  t[subprojects:]
+    := map(curry(as, <string>), p.project-information-subprojects);
   t[library:] := p.project-information-library;
   t[target-type:] := as(<string>, p.project-information-target-type);
   if (p.project-information-executable)
     t[executable:] := p.project-information-executable;
-  else remove-key!(t, executable:); end if;
+  else
+    remove-key!(t, executable:);
+  end if;
   t[compilation-mode:] := as(<string>, p.project-information-compilation-mode);
   t[major-version:] := integer-to-string(p.project-information-major-version);
   t[minor-version:] := integer-to-string(p.project-information-minor-version);
   t[library-pack:] := integer-to-string(p.project-information-library-pack);
   if (p.project-information-base-address)
-    t[base-address:] := machine-word-to-string(
-                            p.project-information-base-address, prefix: "0x");
-  else remove-key!(t, base-address:); end if;
+    t[base-address:]
+      := machine-word-to-string(p.project-information-base-address, prefix: "0x");
+  else
+    remove-key!(t, base-address:);
+  end if;
 
   if (version ~= 1 & version ~= 2)
     error("attempt to write unknown project version: %d", version);
@@ -131,65 +137,62 @@ define function read-project-from-stream
     (s :: <stream>) => (p :: <project-information>, version :: <integer>)
   let t :: <table> = read-keyword-pair-stream(s, 1);
   let error? :: <boolean> = #f;
-
   let keyval = keyword-file-element-value;
   let keyline = keyword-file-element-line;
   local method err (form :: <string>, args :: <sequence>, #rest keys) => ()
-    apply(tool-warning, form, format-arguments: args, serious?: #t, keys);
-    error? := #t;
-  end method err;
+          apply(tool-warning, form, format-arguments: args, serious?: #t, keys);
+          error? := #t;
+        end;
   local method key (k :: <symbol>) => (r :: <sequence>)
-    let r = element(t, k, default: #()); remove-key!(t, k); r
-  end method key;
-  local method required-key (s :: <sequence>, k :: <symbol>)
-   => (r :: <sequence>)
-    if (s.size = 0)
-      err("required keyword \"%s\" not found", list(as(<string>, k)));
-    end if; s
-  end method required-key;
+          let r = element(t, k, default: #()); remove-key!(t, k); r
+        end;
+  local method required-key (s :: <sequence>, k :: <symbol>) => (r :: <sequence>)
+          if (s.size = 0)
+            err("required keyword \"%s\" not found", list(as(<string>, k)));
+          end if; s
+        end;
   local method single-key (s :: <sequence>, k :: <symbol>)
-                          => (r :: false-or(<string>), l :: <integer>)
-    if (s.size > 1)
-      err("keyword \"%s\" does not accept multiple values",
-          list(as(<string>, k)), line: s.second.keyword-file-element-line);
-    end if;
-    if (s.size > 0)
-      values(s.first.keyval, s.first.keyline)
-    else
-      values(#f, 0)
-    end if;
-  end method single-key;
+                       => (r :: false-or(<string>), l :: <integer>)
+          if (s.size > 1)
+            err("keyword \"%s\" does not accept multiple values",
+                list(as(<string>, k)), line: s.second.keyword-file-element-line);
+          end if;
+          if (s.size > 0)
+            values(s.first.keyval, s.first.keyline)
+          else
+            values(#f, 0)
+          end if;
+        end;
 
   let version-string = single-key((format-version:).key, format-version:);
-  let version :: <integer> =
-    if (~version-string)
-      1 // 1.0 file format.
-    elseif (string-to-integer(version-string, default: #f) ~=
-            $current-project-file-version)
-      tool-error("unknown project file format", serious?: #t);
-    else
-      2
-    end if;
-
-  let files = map(
-          method (s)
-          let locator = as(<file-locator>, s.keyval);
-          if (~locator.locator-extension
-                | empty?(locator.locator-extension))
-            make(<file-locator>,
-                 directory: locator-directory(locator),
-                 base: locator-base(locator),
-                 extension: "dylan")
-          else
-            locator
-          end
-        end method, key(files:));
-  let subprojects =
-          map(compose(curry(as, <file-locator>), keyval), (subprojects:).key);
+  let version :: <integer>
+    = if (~version-string)
+        1 // 1.0 file format.
+      elseif (string-to-integer(version-string, default: #f) ~=
+              $current-project-file-version)
+        tool-error("unknown project file format", serious?: #t);
+      else
+        2
+      end if;
+  let files = map(method (s)
+                    let locator = as(<file-locator>, s.keyval);
+                    if (~locator.locator-extension
+                          | empty?(locator.locator-extension))
+                      make(<file-locator>,
+                           directory: locator-directory(locator),
+                           base: locator-base(locator),
+                           extension: "dylan")
+                    else
+                      locator
+                    end
+                  end method,
+                  key(files:));
+  let subprojects = map(compose(curry(as, <file-locator>), keyval),
+                        (subprojects:).key);
   let executable = single-key((executable:).key, executable:);
-  let p :: <project-information> =
-          make(<project-information>, files: files, subprojects: subprojects,
-               executable: executable, remaining-keys: t);
+  let p :: <project-information>
+    = make(<project-information>, files: files, subprojects: subprojects,
+           executable: executable, remaining-keys: t);
 
   let library = single-key(required-key((library:).key, library:), library:);
   if (library) p.project-information-library := library; end if;
@@ -201,7 +204,7 @@ define function read-project-from-stream
       #"executable", #"dll" => p.project-information-target-type := sym;
       otherwise => err("invalid target-type \"%s\"",
                        list(as(<string>, sym)), line: line);
-    end select;
+    end;
   end if;
 
   let (val, line) = single-key((compilation-mode:).key, compilation-mode:);
@@ -211,41 +214,45 @@ define function read-project-from-stream
       #"tight", #"loose" => p.project-information-compilation-mode := sym;
       otherwise => err("invalid compilation-mode \"%s\"",
                        list(as(<string>, sym)), line: line);
-    end select;
+    end;
   end if;
 
   let (major-version, line) = single-key((major-version:).key, major-version:);
   if (major-version)
     let i = string-to-integer(major-version, default: #f);
-    if (i) p.project-information-major-version := i;
-    else err("major-version \"%s\" is not a number", list(major-version),
-             line: line);
+    if (i)
+      p.project-information-major-version := i;
+    else
+      err("major-version \"%s\" is not a number", list(major-version), line: line);
     end if;
   end if;
   let (minor-version, line) = single-key((minor-version:).key, minor-version:);
   if (minor-version)
     let i = string-to-integer(minor-version, default: #f);
-    if (i) p.project-information-minor-version := i;
-    else err("minor-version \"%s\" is not a number", list(minor-version),
-             line: line);
+    if (i)
+      p.project-information-minor-version := i;
+    else
+      err("minor-version \"%s\" is not a number", list(minor-version), line: line);
     end if;
   end if;
 
   let (library-pack, line) = single-key((library-pack:).key, library-pack:);
   if (library-pack)
     let i = string-to-integer(library-pack, default: #f);
-    if (i) p.project-information-library-pack := i;
-    else err("library-pack \"%s\" is not a number", list(library-pack),
-             line: line);
+    if (i)
+      p.project-information-library-pack := i;
+    else
+      err("library-pack \"%s\" is not a number", list(library-pack), line: line);
     end if;
   end if;
 
   let (base-address, line) = single-key((base-address:).key, base-address:);
   if (base-address)
     let i = string-to-machine-word(base-address, default: #f);
-    if (i) p.project-information-base-address := i;
-    else err("base-address \"%s\" is not a hex number", list(base-address),
-             line: line);
+    if (i)
+      p.project-information-base-address := i;
+    else
+      err("base-address \"%s\" is not a hex number", list(base-address), line: line);
     end if;
   end if;
 
@@ -258,9 +265,10 @@ end function read-project-from-stream;
 
 
 define class <keyword-file-element> (<object>)
-  slot keyword-file-element-value :: <string>, init-keyword: value:;
+  slot keyword-file-element-value :: <string>,
+    init-keyword: value:;
   slot keyword-file-element-line :: false-or(<integer>) = #f,
-          init-keyword: line:;
+    init-keyword: line:;
 end class <keyword-file-element>;
 
 
@@ -277,12 +285,15 @@ define function write-keyword-pair-stream (s :: <stream>, keys :: <table>) => ()
   for (vals keyed-by key in keys)
     let prefix :: <string> = concatenate(as(<string>, key), ":\t");
     local method write-key (val) => ()
-      write(s, prefix);
-      write(s, if (instance?(val, <string>)) val
-               else val.keyword-file-element-value end if);
-      new-line(s);
-      prefix := "\t";
-    end method write-key;
+            write(s, prefix);
+            write(s, if (instance?(val, <string>))
+                       val
+                     else
+                       val.keyword-file-element-value
+                     end if);
+            new-line(s);
+            prefix := "\t";
+          end;
     if (instance?(vals, <sequence>) & ~ instance?(vals, <string>))
       for (val in vals)
         write-key(val);
@@ -308,18 +319,20 @@ define function read-keyword-pair-stream
     (s :: <stream>, first-line-no :: <integer>)
  => (keys :: <table>, last-line-no :: <integer>)
   let keys = make(<table>);
-  local method loop (line-no :: <integer>) => (keys, last-line-no :: <integer>)
-    let (key, strings, eoh?, line-no) = read-file-header-component(s, line-no);
-    if (key)
-      let old-strings = element(keys, key, default: #());
-      keys[key] := concatenate!(old-strings, strings);
-    end if;
-    if (eoh?)
-      values(keys, line-no)
-    else
-      loop(line-no)
-    end if
-  end method loop;
+  local
+    method loop (line-no :: <integer>) => (keys, last-line-no :: <integer>)
+      let (key, strings, eoh?, line-no)
+        = read-file-header-component(s, line-no);
+      if (key)
+        let old-strings = element(keys, key, default: #());
+        keys[key] := concatenate!(old-strings, strings);
+      end if;
+      if (eoh?)
+        values(keys, line-no)
+      else
+        loop(line-no)
+      end if
+    end method;
   loop(first-line-no)
 end function read-keyword-pair-stream;
 
@@ -331,22 +344,23 @@ define function read-file-header-component
   if (header-end-marker-line?(key-line))
     values(#f, #f, #t, line-no)
   else
-    local method loop (text-strings :: <list>)
-      line-no := line-no + 1;
-      let char = read-element(s, on-end-of-stream: #f);
-      if (char == ' ' | char == '\t')
-        let (continuation-line, nl?) = read-line(s, on-end-of-stream: "");
-        if (header-end-marker-line?(continuation-line))
-          values(text-strings, #t, line-no)
+    local
+      method loop (text-strings :: <list>)
+        line-no := line-no + 1;
+        let char = read-element(s, on-end-of-stream: #f);
+        if (char == ' ' | char == '\t')
+          let (continuation-line, nl?) = read-line(s, on-end-of-stream: "");
+          if (header-end-marker-line?(continuation-line))
+            values(text-strings, #t, line-no)
+          else
+            let text = parse-header-continuation-line(continuation-line, line-no);
+            loop(pair(text, text-strings))
+          end;
         else
-          let text = parse-header-continuation-line(continuation-line, line-no);
-          loop(pair(text, text-strings))
+          if (char) unread-element(s, char) end;
+          values(text-strings, #f, line-no)
         end;
-      else
-        if (char) unread-element(s, char) end;
-        values(text-strings, #f, line-no)
-      end;
-    end method;
+      end method;
     let (key, text) = parse-header-keyword-line(key-line, line-no);
     let (text-strings, past-eoh?) = loop(list(text));
     values(key, reverse!(text-strings), past-eoh?, line-no)
@@ -362,13 +376,15 @@ define function parse-header-keyword-line
   end;
   values(as(<symbol>, copy-sequence(line, end: colon)),
          make(<keyword-file-element>,
-              value: trim-whitespace(line, colon + 1), line: line-no))
+              value: trim-whitespace(line, colon + 1),
+              line: line-no))
 end function parse-header-keyword-line;
 
 define function parse-header-continuation-line
     (line :: <string>, line-no :: <integer>)
   make(<keyword-file-element>,
-       value: trim-whitespace(line, 0), line: line-no)
+       value: trim-whitespace(line, 0),
+       line: line-no)
 end function parse-header-continuation-line;
 
 define function header-end-marker-line? (line :: <string>)
@@ -379,15 +395,22 @@ define function trim-whitespace (line :: <string>, start)
   local method bwd (line, start, len)
           let last = len - 1;
           let c = line[last];
-          if (c == ' ' | c == '\t') bwd(line, start, last)
-          else copy-sequence(line, start: start, end: len) end;
+          if (c == ' ' | c == '\t')
+            bwd(line, start, last)
+          else
+            copy-sequence(line, start: start, end: len)
+          end;
         end method;
   local method fwd (line, start, len)
-          if (start == len) ""
+          if (start == len)
+            ""
           else
             let c = line[start];
-            if (c == ' ' | c == '\t') fwd(line, start + 1, len)
-            else bwd(line, start, len) end;
+            if (c == ' ' | c == '\t')
+              fwd(line, start + 1, len)
+            else
+              bwd(line, start, len)
+            end;
           end;
         end method;
   fwd(line, start, size(line))

--- a/sources/project-manager/tools-interface/tools-interface.dylan
+++ b/sources/project-manager/tools-interface/tools-interface.dylan
@@ -82,7 +82,7 @@ define function tool-name-from-specification
   //---*** andrewa: bootstrapping nastiness, only the first should be necessary
   if (extsym == #"spec" | extsym == #".spec")
     // Read the header of the file:
-    let h = read-keyword-pair-file(spec-file);
+    let h = read-file-header(spec-file);
     let tool = element(h, origin:, default: #());
     if (tool.size ~= 1)
       tool-error("specification file must contain a single \"origin:\" "


### PR DESCRIPTION
Three stage bootstrap succeeds.

Definitely look at the whitespace diff and the substantive diff as separate commits, not the merged diffs in the GitHub UI.