### PR TITLE
Improve -help output for -internal-debug option

### DIFF
--- a/sources/environment/console/compiler-command-line.dylan
+++ b/sources/environment/console/compiler-command-line.dylan
@@ -43,7 +43,7 @@ define command-line main => <main-command>
   keyword personal-root :: <directory-locator> = "personal area root";
   keyword system-root   :: <directory-locator> = "system area root";
   keyword internal-debug :: $keyword-list-type
-                        = "show debug messages (e.g. for linker, project-manager)";
+    = "show debug messages (comma separated, e.g. linker,project-manager)";
   flag unify            = "combine libraries into a single executable";
   flag profile-commands = "profile the execution of each command";
   flag harp             = "generate HARP output";


### PR DESCRIPTION
I haven't used it enough to remember that it's comma-separated rather than a repeated option, so this is for Future Me.