### PR TITLE
environment: fix 'define command-line' macro

### DIFF
--- a/sources/environment/commands/command-line.dylan
+++ b/sources/environment/commands/command-line.dylan
@@ -816,14 +816,6 @@ define method command-line-loop
 end method command-line-loop;
 
 define macro command-line-definer
-  { define command-line ?name:name (?options:*)
-      ?parameters:*
-    end }
-    => { define command-line-class ?name (?options) ?parameters end;
-         define command-line-constant ?name => "<" ## ?name ## "-command>" (?options)
-           ?parameters
-         end }
-
   { define command-line ?name:name => ?command:name (?options:*)
       ?parameters:*
     end }


### PR DESCRIPTION
Remove a form of the macro that isn't used and expands to code that wouldn't work because `define command-line-class` doesn't exist.