### PR TITLE
Rename $machine-name to $machine-architecture

### DIFF
--- a/documentation/library-reference/source/system/operating-system.rst
+++ b/documentation/library-reference/source/system/operating-system.rst
@@ -20,7 +20,7 @@ environment variable in the system.
 The following constants contain machine-specific information:
 
 - :const:`$architecture-little-endian?`
-- :const:`$machine-name`
+- :const:`$machine-architecture`
 - :const:`$os-name`
 - :const:`$os-variant`
 - :const:`$os-version`
@@ -93,7 +93,7 @@ System library's operating-system module.
 
    :seealso:
 
-     - :const:`$machine-name`
+     - :const:`$machine-architecture`
      - :const:`$os-name`
      - :const:`$os-variant`
      - :const:`$os-version`
@@ -223,7 +223,7 @@ System library's operating-system module.
 
      - :func:`login-name`
 
-.. constant:: $machine-name
+.. constant:: $machine-architecture
 
    Constant specifying the type of hardware installed in the host machine.
 
@@ -243,6 +243,11 @@ System library's operating-system module.
      - :const:`$os-version`
      - :const:`$platform-name`
 
+.. constant:: $machine-name
+
+   This constant is the **deprecated** name for :const:`$machine-architecture`
+   and will be removed in a future release.
+
 .. constant:: $os-name
 
    Constant specifying the operating system running on the host machine.
@@ -258,7 +263,7 @@ System library's operating-system module.
    :seealso:
 
      - :const:`$architecture-little-endian?`
-     - :const:`$machine-name`
+     - :const:`$machine-architecture`
      - :const:`$os-variant`
      - :const:`$os-version`
      - :const:`$platform-name`
@@ -281,7 +286,7 @@ System library's operating-system module.
    :seealso:
 
      - :const:`$architecture-little-endian?`
-     - :const:`$machine-name`
+     - :const:`$machine-architecture`
      - :const:`$os-name`
      - :const:`$os-version`
      - :const:`$platform-name`
@@ -303,7 +308,7 @@ System library's operating-system module.
    :seealso:
 
      - :const:`$architecture-little-endian?`
-     - :const:`$machine-name`
+     - :const:`$machine-architecture`
      - :const:`$os-name`
      - :const:`$os-variant`
      - :const:`$platform-name`
@@ -367,9 +372,9 @@ System library's operating-system module.
    :description:
 
      Represents both the architecture and the operating system running on the
-     host machine. It is a concatenation of :const:`$machine-name`, ``"-"``,
-     and :const:`$os-name`.  See those constants to determine the full list of
-     possible values.
+     host machine. It is a concatenation of :const:`$machine-architecture`,
+     ``"-"``, and :const:`$os-name`.  See those constants to determine the full
+     list of possible values.
 
    :example:
 
@@ -377,7 +382,7 @@ System library's operating-system module.
 
    :seealso:
 
-     - :const:`$machine-name`
+     - :const:`$machine-architecture`
      - :const:`$os-name`
 
 .. function:: machine-concurrent-thread-count

--- a/sources/app/djam/djam.dylan
+++ b/sources/app/djam/djam.dylan
@@ -18,7 +18,7 @@ define function main(name, arguments)
 
   // Useful built-in variables
   jam-variable(state, "OS") := vector(as(<string>, $os-name));
-  jam-variable(state, "OSPLAT") := vector(as(<string>, $machine-name));
+  jam-variable(state, "OSPLAT") := vector(as(<string>, $machine-architecture));
   jam-variable(state, "TARGET_PLATFORM") := vector(as(<string>, target-platform-name()));
 
   select($os-name)

--- a/sources/system/aarch64-linux-operating-system.dylan
+++ b/sources/system/aarch64-linux-operating-system.dylan
@@ -2,5 +2,5 @@ Module:       system-internals
 
 define constant $architecture-little-endian? :: <boolean> = #t;
 
-define constant $machine-name = #"aarch64";
-define constant $os-name      = #"linux";
+define constant $machine-architecture = #"aarch64";
+define constant $os-name = #"linux";

--- a/sources/system/arm-linux-operating-system.dylan
+++ b/sources/system/arm-linux-operating-system.dylan
@@ -2,5 +2,5 @@ Module:       system-internals
 
 define constant $architecture-little-endian? :: <boolean> = #t;
 
-define constant $machine-name = #"arm";
-define constant $os-name      = #"linux";
+define constant $machine-architecture = #"arm";
+define constant $os-name = #"linux";

--- a/sources/system/library.dylan
+++ b/sources/system/library.dylan
@@ -55,7 +55,8 @@ define module operating-system
 
   create $architecture-little-endian?,
          $os-name, $os-variant, $os-version,
-         $platform-name, $machine-name,
+         $platform-name, $machine-architecture,
+         $machine-name, // Deprecated, use $machine-architecture
          login-name, login-group, owner-name, owner-organization,
          environment-variable, environment-variable-setter,
          tokenize-environment-variable,

--- a/sources/system/operating-system.dylan
+++ b/sources/system/operating-system.dylan
@@ -8,7 +8,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define constant $platform-name
     = as(<symbol>,
-         concatenate(as(<string>, $machine-name), "-",
+         concatenate(as(<string>, $machine-architecture), "-",
                      as(<string>, $os-name)));
 
 define macro with-application-output

--- a/sources/system/riscv64-linux-operating-system.dylan
+++ b/sources/system/riscv64-linux-operating-system.dylan
@@ -2,5 +2,5 @@ Module:       system-internals
 
 define constant $architecture-little-endian? :: <boolean> = #t;
 
-define constant $machine-name = #"riscv64";
-define constant $os-name      = #"linux";
+define constant $machine-architecture = #"riscv64";
+define constant $os-name = #"linux";

--- a/sources/system/tests/operating-system.dylan
+++ b/sources/system/tests/operating-system.dylan
@@ -10,7 +10,7 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define test test-$architecture-little-endian? ()
   check-true("$architecture-little-endian? is true if x86",
-             $machine-name ~== #"x86" | $architecture-little-endian?);
+             $machine-architecture ~== #"x86" | $architecture-little-endian?);
 end test;
 
 define test test-$os-name ()
@@ -29,7 +29,7 @@ define test test-$platform-name ()
   //---*** Fill this in...
 end test;
 
-define test test-$machine-name ()
+define test test-$machine-architecture ()
   //---*** Fill this in...
 end test;
 
@@ -388,7 +388,7 @@ define suite operating-system-test-suite ()
   test test-$os-variant;
   test test-$os-version;
   test test-$platform-name;
-  test test-$machine-name;
+  test test-$machine-architecture;
   test test-login-name;
   test test-login-group;
   test test-owner-name;

--- a/sources/system/tests/specification.dylan
+++ b/sources/system/tests/specification.dylan
@@ -184,7 +184,8 @@ define interface-specification-suite operating-system-specification-suite ()
   constant $os-variant :: <symbol>;
   constant $os-version :: <string>;
   constant $platform-name :: <symbol>;
-  constant $machine-name :: <symbol>;
+  constant $machine-architecture :: <symbol>;
+  constant $machine-name :: <symbol>; // Deprecated, use $machine-architecture
 
   // Operating System functions
   function login-name () => (false-or(<string>));

--- a/sources/system/unix-operating-system.dylan
+++ b/sources/system/unix-operating-system.dylan
@@ -41,6 +41,9 @@ end macro with-storage;
 define constant $os-variant = $os-name;
 define constant $os-version = "Unknown";
 
+// $machine-name is deprecated as of v2024.2 but is kept for backward compatibility.
+define constant $machine-name = $machine-architecture;
+
 define constant $command-line-option-prefix = '-';
 
 define function command-line-option-prefix

--- a/sources/system/x86-freebsd-operating-system.dylan
+++ b/sources/system/x86-freebsd-operating-system.dylan
@@ -2,5 +2,5 @@ Module:       system-internals
 
 define constant $architecture-little-endian? :: <boolean> = #t;
 
-define constant $machine-name = #"x86";
-define constant $os-name      = #"freebsd";
+define constant $machine-architecture = #"x86";
+define constant $os-name = #"freebsd";

--- a/sources/system/x86-linux-operating-system.dylan
+++ b/sources/system/x86-linux-operating-system.dylan
@@ -7,5 +7,5 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define constant $architecture-little-endian? :: <boolean> = #t;
 
-define constant $machine-name = #"x86";
-define constant $os-name      = #"linux";
+define constant $machine-architecture = #"x86";
+define constant $os-name = #"linux";

--- a/sources/system/x86-netbsd-operating-system.dylan
+++ b/sources/system/x86-netbsd-operating-system.dylan
@@ -2,5 +2,5 @@ Module:       system-internals
 
 define constant $architecture-little-endian? :: <boolean> = #t;
 
-define constant $machine-name = #"x86";
-define constant $os-name      = #"netbsd";
+define constant $machine-architecture = #"x86";
+define constant $os-name = #"netbsd";

--- a/sources/system/x86-win32-operating-system.dylan
+++ b/sources/system/x86-win32-operating-system.dylan
@@ -8,8 +8,11 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define constant $architecture-little-endian? :: <boolean> = #t;
 
-define constant $machine-name   = #"x86";
-define constant $os-name        = #"win32";
+define constant $machine-architecture = #"x86";
+define constant $os-name = #"win32";
+
+// $machine-name is deprecated as of v2024.2 but is kept for backward compatibility.
+define constant $machine-name = $machine-architecture;
 
 define constant $DWORD_SIZE = raw-as-integer(primitive-word-size());
 

--- a/sources/system/x86_64-darwin-operating-system.dylan
+++ b/sources/system/x86_64-darwin-operating-system.dylan
@@ -2,5 +2,5 @@ Module:       system-internals
 
 define constant $architecture-little-endian? :: <boolean> = #t;
 
-define constant $machine-name = #"x86_64";
-define constant $os-name      = #"darwin";
+define constant $machine-architecture = #"x86_64";
+define constant $os-name = #"darwin";

--- a/sources/system/x86_64-freebsd-operating-system.dylan
+++ b/sources/system/x86_64-freebsd-operating-system.dylan
@@ -2,5 +2,5 @@ Module:       system-internals
 
 define constant $architecture-little-endian? :: <boolean> = #t;
 
-define constant $machine-name = #"x86_64";
-define constant $os-name      = #"freebsd";
+define constant $machine-architecture = #"x86_64";
+define constant $os-name = #"freebsd";

--- a/sources/system/x86_64-linux-operating-system.dylan
+++ b/sources/system/x86_64-linux-operating-system.dylan
@@ -7,5 +7,5 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 define constant $architecture-little-endian? :: <boolean> = #t;
 
-define constant $machine-name = #"x86_64";
-define constant $os-name      = #"linux";
+define constant $machine-architecture = #"x86_64";
+define constant $os-name = #"linux";

--- a/sources/system/x86_64-netbsd-operating-system.dylan
+++ b/sources/system/x86_64-netbsd-operating-system.dylan
@@ -2,5 +2,5 @@ Module:       system-internals
 
 define constant $architecture-little-endian? :: <boolean> = #t;
 
-define constant $machine-name = #"x86_64";
-define constant $os-name      = #"netbsd";
+define constant $machine-architecture = #"x86_64";
+define constant $os-name = #"netbsd";


### PR DESCRIPTION
Keep old name for backward compatibility.  The uses in djam.dylan and jam-build.dylan were the only ones that couldn't be changed right away due to bootstrap requirements.