### PR TITLE
Mods to bootstrap on M3 macOS with arch x86_64

### DIFF
--- a/sources/lib/run-time/Makefile.in
+++ b/sources/lib/run-time/Makefile.in
@@ -104,7 +104,7 @@ endif
 CC = @CC@
 AR = ar -rcs
 
-CFLAGS		= $(PLATFORM_CFLAGS) -Wall -O -g -I$(srcdir) @DEFS@ @CPPFLAGS@
+CFLAGS		= $(PLATFORM_CFLAGS) -Wall -Wno-nullability-completeness -O -g -I$(srcdir) @DEFS@ @CPPFLAGS@ @CFLAGS@
 LFLAGS		= $(PLATFORM_LFLAGS)
 
 HARP_CFLAGS     = -DOPEN_DYLAN_BACKEND_HARP


### PR DESCRIPTION
Using this configuration:

`DYLANCOMPILER=/Users/cgay/dylan/opendylan-2024.1/bin/dylan-compiler ./configure --prefix=${DYLAN}/opendylan-master --host=x86_64-darwin CFLAGS="-O2 -arch x86_64 -L$(xcrun --show-sdk-path)/usr/lib -I$(xcrun --show-sdk-path)/usr/include"`

I get this error while building the run-time for bootstrap stage 1:

```
mkdir -p obj-x86_64-darwin-c
clang-16 -arch x86_64 -D_REENTRANT=1 -DOPEN_DYLAN_PLATFORM_DARWIN -DOPEN_DYLAN_PLATFORM_UNIX -DOPEN_DYLAN_ARCH_X86_64 -Wno-unknown-attributes -Wall -O -g -I. -DPACKAGE_NAME=\"Open\ Dylan\" -DPACKAGE_TARNAME=\"open-dylan\" -DPACKAGE_VERSION=\"2024.1\" -DPACKAGE_STRING=\"Open\ Dylan\ 2024.1\" -DPACKAGE_BUGREPORT=\"\" -DPACKAGE_URL=\"\" -DPACKAGE=\"open-dylan\" -DVERSION=\"2024.1\" -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_LIBGC=1 -DHAVE_SIGINFO_T=1 -DHAVE_LIBUNWIND_H=1  -O2 -arch x86_64 -L/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include -DOPEN_DYLAN_BACKEND_C -DGC_THREADS -DGC_USE_BOEHM -MMD -c -o obj-x86_64-darwin-c/debug-print.o debug-print.c
clang-16: warning: argument unused during compilation: '-L/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib' [-Wunused-command-line-argument]
In file included from debug-print.c:1:
In file included from ./run-time.h:36:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/AvailabilityMacros.h:212:5: error: 'TARGET_OS_OSX' is not defined, evaluates to 0 [-Werror,-Wundef-prefix=TARGET_OS_]
    ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/AvailabilityMacros.h:214:7: error: 'TARGET_OS_MACCATALYST' is not defined, evaluates to 0 [-Werror,-Wundef-prefix=TARGET_OS_]
      ^
```

```
$ clang --version
Apple clang version 15.0.0 (clang-1500.1.0.2.5)
Target: arm64-apple-darwin23.3.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```
