### PR TITLE
dfmc-environment-projects: build-project: add type to error-handler

### DIFF
--- a/sources/environment/dfmc/projects/projects.dylan
+++ b/sources/environment/dfmc/projects/projects.dylan
@@ -311,7 +311,8 @@ define sealed method build-project
           abort-on-all-warnings? = #f,
           abort-on-serious-warnings? = #f,
           warning-callback :: false-or(<function>),
-          progress-callback :: false-or(<function>), error-handler,
+          progress-callback :: false-or(<function>),
+          error-handler :: <function>,
           save-databases? = #f,
           process-subprojects? = #t,
           messages = #"external")


### PR DESCRIPTION
`error-handler` is required to be a function since it's passed to `project-condition-handler` via `with-project-location-handler`. (Took me a while to track down given the backtrace doesn't help much when there's an error in the error handler.)