### PR TITLE
Package file and LID file "Platforms:" updates

### DIFF
--- a/dylan-package.json
+++ b/dylan-package.json
@@ -1,0 +1,21 @@
+{
+    "name": "opendylan",
+    "category": "compilers",
+    "description": "The Open Dylan compiler, IDE, and core libraries",
+    "dependencies": [
+        "collection-extensions@0.1",
+        "command-line-parser@3.2",
+        "dylan-tool@0.11",
+        "json@1.1",
+        "meta@0.1",
+        "regular-expressions@0.2",
+        "strings@1.2",
+        "xml-parser@0.2"
+    ],
+    "dev-dependencies": [
+        "sphinx-extensions",
+        "testworks"
+    ],
+    "url": "https://github.com/dylan-lang/opendylan",
+    "version": "2024.2.0"
+}

--- a/sources/collections/collections.lid
+++ b/sources/collections/collections.lid
@@ -15,4 +15,12 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: aarch64-linux
+           arm-linux
+           x86-freebsd
+           x86-linux
+           x86-netbsd
+           x86_64-darwin
+           x86_64-freebsd
+           x86_64-linux
+           x86_64-netbsd

--- a/sources/dfmc/mangling/mangling.lid
+++ b/sources/dfmc/mangling/mangling.lid
@@ -7,4 +7,12 @@ Copyright:   Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
              All rights reserved.
 License:     See License.txt in this distribution for details.
 Warranty:    Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: aarch64-linux
+           arm-linux
+           x86-freebsd
+           x86-linux
+           x86-netbsd
+           x86_64-darwin
+           x86_64-freebsd
+           x86_64-linux
+           x86_64-netbsd

--- a/sources/dylan/dylan.lid
+++ b/sources/dylan/dylan.lid
@@ -99,4 +99,11 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: arm-linux
+           x86-freebsd
+           x86-linux
+           x86-netbsd
+           x86_64-darwin
+           x86_64-freebsd
+           x86_64-linux
+           x86_64-netbsd

--- a/sources/lib/big-integers/big-integers.lid
+++ b/sources/lib/big-integers/big-integers.lid
@@ -8,4 +8,13 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
+Platforms: aarch64-linux
+           arm-linux
+           x86-freebsd
+           x86-linux
+           x86-netbsd
+           x86_64-darwin
+           x86_64-freebsd
+           x86_64-linux
+           x86_64-netbsd
 

--- a/sources/lib/channels/channels.lid
+++ b/sources/lib/channels/channels.lid
@@ -10,4 +10,12 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: aarch64-linux
+           arm-linux
+           x86-freebsd
+           x86-linux
+           x86-netbsd
+           x86_64-darwin
+           x86_64-freebsd
+           x86_64-linux
+           x86_64-netbsd

--- a/sources/lib/commands/commands.lid
+++ b/sources/lib/commands/commands.lid
@@ -12,4 +12,12 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: aarch64-linux
+           arm-linux
+           x86-freebsd
+           x86-linux
+           x86-netbsd
+           x86_64-darwin
+           x86_64-freebsd
+           x86_64-linux
+           x86_64-netbsd

--- a/sources/lib/generic-arithmetic/generic-arithmetic.lid
+++ b/sources/lib/generic-arithmetic/generic-arithmetic.lid
@@ -11,4 +11,12 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: aarch64-linux
+           arm-linux
+           x86-freebsd
+           x86-linux
+           x86-netbsd
+           x86_64-darwin
+           x86_64-freebsd
+           x86_64-linux
+           x86_64-netbsd

--- a/sources/lib/walker/walker.lid
+++ b/sources/lib/walker/walker.lid
@@ -12,4 +12,12 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
-
+Platforms: aarch64-linux
+           arm-linux
+           x86-freebsd
+           x86-linux
+           x86-netbsd
+           x86_64-darwin
+           x86_64-freebsd
+           x86_64-linux
+           x86_64-netbsd


### PR DESCRIPTION
These were on my `build-with-packages` branch but they'll be useful for making LSP work since it uses `dylan-tool` to find the package root and suchlike so I'm merging them separately. Essentially these changes make `dylan update` work for OD.