### PR TITLE
Unified executables fixes

### DIFF
--- a/documentation/release-notes/source/2024.2.rst
+++ b/documentation/release-notes/source/2024.2.rst
@@ -20,6 +20,12 @@ this release.
 Compiler
 ========
 
+* Unified executables now export symbols so that call stack dumping
+  works properly.
+
+* The build rules for unified executables now properly depend on
+  copying included run-time libraries such as libunwind.
+
 Tools
 =====
 

--- a/sources/jamfiles/posix-build.jam
+++ b/sources/jamfiles/posix-build.jam
@@ -486,7 +486,7 @@ rule LinkDLL {
 
 actions together LinkDLL bind NEEDLIBS {
   $(LINK) -shared -o $(<:Q) $(LINKFLAGS) $(>:Q) -L"$(LIBPATH)" $(NEEDLIBS:Q) $(LINKLIBS)
-  $(OBJCOPY) $(<:Q) $(<:Q).dbg
+  $(OBJCOPY) --only-keep-debug $(<:Q) $(<:Q).dbg
   $(STRIP) -s $(<:Q)
   $(OBJCOPY) --add-gnu-debuglink=$(<:Q).dbg $(<:Q)
 }
@@ -507,7 +507,7 @@ rule LinkEXE {
 
 actions LinkEXE bind NEEDLIBS {
   $(LINK) -o $(<:Q) $(LINKFLAGS) $(>:Q) -L"$(LIBPATH)" $(NEEDLIBS:Q) $(LINKLIBS)
-  $(OBJCOPY) $(<:Q) $(<:Q).dbg
+  $(OBJCOPY) --only-keep-debug $(<:Q) $(<:Q).dbg
   $(STRIP) -s $(<:Q)
   $(OBJCOPY) --add-gnu-debuglink=$(<:Q).dbg $(<:Q)
 }
@@ -518,9 +518,9 @@ rule UnifyEXE {
 }
 
 actions UnifyEXE bind NEEDLIBS {
-  $(UNIFYLINK) -o $(<:Q) $(LINKFLAGS) $(>:Q) -L"$(LIBPATH)" -Wl,--start-group $(NEEDLIBS:Q) $(LINKLIBS) -Wl,--end-group
-  $(OBJCOPY) $(<:Q) $(<:Q).dbg
-  $(STRIP) -s $(<:Q)
+  $(UNIFYLINK) -o $(<:Q) $(LINKFLAGS) -Wl,-E $(>:Q) -L"$(LIBPATH)" -Wl,--start-group $(NEEDLIBS:Q) $(LINKLIBS) -Wl,--end-group
+  $(OBJCOPY) --only-keep-debug $(<:Q) $(<:Q).dbg
+  $(STRIP) -g $(<:Q)
   $(OBJCOPY) --add-gnu-debuglink=$(<:Q).dbg $(<:Q)
 }
 

--- a/sources/jamfiles/posix-build.jam
+++ b/sources/jamfiles/posix-build.jam
@@ -156,7 +156,7 @@ rule DylanLibrary image : version {
       local _rtlib = $(_i:D=) ;
       MakeLocate $(_rtlib) : $(LIBDIR) ;
       File $(_rtlib) : $(_i) ;
-      Depends $(_dll) : $(_rtlib) ;
+      Depends $(_dll) $(_ulib) : $(_rtlib) ;
     }
   }
 


### PR DESCRIPTION
These changes ensure that runtime libraries are copied to the target for unified executables, and ensure that symbols in unified executables are still exported to allow backtraces.