### PR TITLE
doc: fix "edit source" widget

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -45,7 +45,7 @@ html_theme_options = {
     # https://pradyunsg.me/furo/customisation/edit-button/
     'source_repository': 'https://github.com/dylan-lang/opendylan',
     'source_branch': 'master',
-    'source_directory': 'source/',
+    'source_directory': 'documentation/source',
 }
 html_theme_path = ['_themes']   # still needed? add furo submodule here?
 html_title = 'Open Dylan'


### PR DESCRIPTION
Without the submodules and separate builds, there is now a simple fix for the edit source widget.

fixes https://github.com/dylan-lang/website/issues/148