### PR TITLE
doc: fix uses of http: and /documentation/

### DIFF
--- a/documentation/source/getting-started-cli/dylan-compiler.rst
+++ b/documentation/source/getting-started-cli/dylan-compiler.rst
@@ -10,8 +10,8 @@ example::
     $ dylan-compiler
     Welcome to Open Dylan!
 
-    For documentation on Open Dylan, see http://opendylan.org/documentation/.
-    See http://opendylan.org/documentation/getting-started-cli/ for an introduction to the command line tools.
+    For documentation on Open Dylan, see https://opendylan.org.
+    See https://opendylan.org/getting-started-cli/ for an introduction to the command line tools.
 
     Type "help" for more information.
     >

--- a/documentation/source/getting-started-cli/index.rst
+++ b/documentation/source/getting-started-cli/index.rst
@@ -5,8 +5,8 @@ Getting Started with the Open Dylan Command Line Tools
 This guide explains how to use the Open Dylan command-line tools to develop and
 deliver Dylan applications.
 
-For help getting started with the IDE (Windows only), see :doc:`Getting Started
-with the Open Dylan IDE </getting-started-ide/index>`.
+For help getting started with the IDE (Windows only), see
+:doc:`/getting-started-ide/index`.
 
 The compiler executable is called ``dylan-compiler``.  There is a helper
 application called :program:`dylan`, which can be used to generate some

--- a/documentation/source/getting-started-ide/preface.rst
+++ b/documentation/source/getting-started-ide/preface.rst
@@ -6,8 +6,7 @@ This guide explains how to use the Open Dylan IDE (Windows only) to develop
 and deliver Dylan applications.
 
 For help getting started with the command-line
-tools, see the :doc:`Getting Started with the Open Dylan Command Line Tools
-</getting-started-cli/index>` guide.
+tools, see the :doc:`/getting-started-cli/index` guide.
 
 .. index::
    single: Dylan Reference Manual, the

--- a/documentation/source/hacker-guide/topics/debugging.rst
+++ b/documentation/source/hacker-guide/topics/debugging.rst
@@ -30,8 +30,5 @@ optimizing Dylan code in general since it shows (for example) where
 the compiler wasn't able to optimize method dispatch.
 
 The main point you need to know is to add the ``-dfm`` flag when you
-invoke ``dylan-compiler``.  This will generate DFM output files in
+invoke :program:`dylan-compiler`.  This will generate DFM output files in
 your ``_build/build/`` directory.
-
-
-.. _Debugging with GDB or LLDB: https://opendylan.org/documentation/getting-started-cli/debugging-with-gdb-lldb.html

--- a/documentation/source/library-reference/language-extensions/index.rst
+++ b/documentation/source/library-reference/language-extensions/index.rst
@@ -3,7 +3,7 @@ Dylan Language Extensions
 *************************
 
 The Dylan language is described in `The Dylan Reference Manual
-<http://opendylan.org/books/drm/>`_ by Andrew Shalit (Addison-Wesley,
+<https://opendylan.org/books/drm/>`_ by Andrew Shalit (Addison-Wesley,
 1996). We call this book "the DRM" hereafter.
 
 Open Dylan provides an implementation of the Dylan language

--- a/documentation/source/library-reference/language-extensions/parser-expansions.rst
+++ b/documentation/source/library-reference/language-extensions/parser-expansions.rst
@@ -20,7 +20,7 @@ The ``<text>`` part can be either *delimited* or *undelimited*. Undelimited
 text can contain anything but commas, semicolons, brackets of any kind, and
 whitespace. All the following are valid::
 
-    #:http://opendylan.org/
+    #:https://opendylan.org/
     #:time:12:30am
     #:date:12/3/2000
     #:file:D:\dylan\sources\

--- a/documentation/source/release-notes/2013.1.rst
+++ b/documentation/source/release-notes/2013.1.rst
@@ -8,7 +8,7 @@ Introduction
 This document describes the 2013.1 release of Open Dylan, released
 July 11, 2013.
 
-* `Download the release <http://opendylan.org/download/index.html>`_
+* `Download the release <https://opendylan.org/download/index.html>`_
 * `Report bugs <https://github.com/dylan-lang/opendylan/issues>`_
 * `Source code <https://github.com/dylan-lang/opendylan/tree/v2013.1>`_
 

--- a/documentation/source/release-notes/2013.2.rst
+++ b/documentation/source/release-notes/2013.2.rst
@@ -8,7 +8,7 @@ Introduction
 This document describes the 2013.2 release of Open Dylan, released
 December 23, 2013.
 
-* `Download the release <http://opendylan.org/download/index.html>`_
+* `Download the release <https://opendylan.org/download/index.html>`_
 * `Report bugs <https://github.com/dylan-lang/opendylan/issues>`_
 * `Source code <https://github.com/dylan-lang/opendylan/tree/v2013.2>`_
 

--- a/documentation/source/release-notes/2014.1.rst
+++ b/documentation/source/release-notes/2014.1.rst
@@ -8,7 +8,7 @@ Introduction
 This document describes the 2014.1 release of Open Dylan, released
 December 29, 2014.
 
-* `Download the release <http://opendylan.org/download/index.html>`_
+* `Download the release <https://opendylan.org/download/index.html>`_
 * `Report bugs <https://github.com/dylan-lang/opendylan/issues>`_
 * `Source code <https://github.com/dylan-lang/opendylan/tree/v2014.1>`_
 

--- a/documentation/source/release-notes/2019.1.rst
+++ b/documentation/source/release-notes/2019.1.rst
@@ -278,7 +278,7 @@ system Library
   their omission led to possible confusion for users.
 
 .. _issue #899: https://github.com/dylan-lang/opendylan/issues/899
-.. _documented in the library reference: http://opendylan.org/documentation/library-reference/coloring-stream/
+.. _documented in the library reference: https://opendylan.org/library-reference/coloring-stream/
 
 * A problem with constructing ``<date>`` objects for ``time_t`` values
   with more than 30 bits (i.e., any time after Sat Jan 10 13:37:04 UTC 2004)

--- a/documentation/source/release-notes/2020.1.rst
+++ b/documentation/source/release-notes/2020.1.rst
@@ -9,8 +9,8 @@ of which are listed below.  For complete details see `the opendylan commit logs
 that some commit logs, for example for testworks and other libraries that are
 included in Open Dylan as git submodules, may be in other repositories.)
 
-* Download the release: http://opendylan.org/download
-* Read documentation: http://opendylan.org/documentation
+* Download the release: https://opendylan.org/download
+* Read documentation: https://opendylan.org
 * Report problems: https://github.com/dylan-lang/opendylan/issues
 
 

--- a/documentation/source/release-notes/2022.1.rst
+++ b/documentation/source/release-notes/2022.1.rst
@@ -12,8 +12,8 @@ commit logs
           are included in Open Dylan as git submodules, may be in other
           repositories.
 
-* Download the release: http://opendylan.org/download
-* Read documentation: http://opendylan.org/documentation
+* Download the release: https://opendylan.org/download
+* Read documentation: https://opendylan.org
 * Report problems: https://github.com/dylan-lang/opendylan/issues
 
 

--- a/documentation/source/release-notes/2023.1.rst
+++ b/documentation/source/release-notes/2023.1.rst
@@ -12,8 +12,8 @@ this release.
           are included in Open Dylan as git submodules, may be in other
           repositories.
 
-* Download the release: http://opendylan.org/download
-* Read documentation: http://opendylan.org/documentation
+* Download the release: https://opendylan.org/download
+* Read documentation: https://opendylan.org
 * Report problems: https://github.com/dylan-lang/opendylan/issues
 
 

--- a/documentation/source/release-notes/2024.1.rst
+++ b/documentation/source/release-notes/2024.1.rst
@@ -12,8 +12,8 @@ this release.
           are included in Open Dylan as git submodules, may be in other
           repositories.
 
-* Download the release: http://opendylan.org/download
-* Read documentation: http://opendylan.org/documentation
+* Download the release: https://opendylan.org/download
+* Read documentation: https://opendylan.org
 * Report problems: https://github.com/dylan-lang/opendylan/issues
 
 

--- a/documentation/source/release-notes/2024.2.rst
+++ b/documentation/source/release-notes/2024.2.rst
@@ -12,8 +12,8 @@ this release.
           are included in Open Dylan as git submodules, may be in other
           repositories.
 
-* Download the release: http://opendylan.org/download
-* Read documentation: http://opendylan.org/documentation
+* Download the release: https://opendylan.org/download
+* Read documentation: https://opendylan.org
 * Report problems: https://github.com/dylan-lang/opendylan/issues
 
 


### PR DESCRIPTION
fixes #1586