### PR TITLE
Fix typo assignation

### DIFF
--- a/documentation/source/about/examples/limited_types.rst
+++ b/documentation/source/about/examples/limited_types.rst
@@ -48,7 +48,7 @@ vectors of floating point numbers for this code:
 	 output :: <audio-buffer>)
      => ()
       for (i from 0 below $audio-buffer-size)
-	output[i] = 0.5 * input1[i] + 0.5 * input2[i];
+	output[i] := 0.5 * input1[i] + 0.5 * input2[i];
       end;
     end;
 


### PR DESCRIPTION
The example shows an equal sign but it should be an assignment.