### PR TITLE
doc: Fix typo in '<C-void*>' class

### DIFF
--- a/documentation/source/library-reference/c-ffi/index.rst
+++ b/documentation/source/library-reference/c-ffi/index.rst
@@ -1242,7 +1242,7 @@ these classes.
    single: <C-void*> class
    single: classes; <C-void*>
 
-.. class:: <C-void\*>
+.. class:: <C-void*>
    :open:
    :concrete:
 


### PR DESCRIPTION
Closes #1608