### PR TITLE
More <simple-condition> cleanups

### DIFF
--- a/documentation/source/getting-started-cli/debugging-with-gdb-lldb.rst
+++ b/documentation/source/getting-started-cli/debugging-with-gdb-lldb.rst
@@ -361,16 +361,16 @@ and will assist you in analyzing values.
 
 .. c:function:: bool dylan_simple_condition_p (D instance)
 
-   Tests whether instance is a ``<simple-condition>``.
+   Tests whether instance is a :class:`<simple-condition>`.
 
 .. c:function:: D dylan_simple_condition_format_string (D instance)
 
-   Returns the format string stored in the given ``<simple-condition>``.
+   Returns the format string stored in the given :class:`<simple-condition>`.
 
 .. c:function:: D dylan_simple_condition_format_args (D instance)
 
    Returns the format string arguments stored in the given
-   ``<simple-condition>``.
+   :class:`<simple-condition>`.
 
 .. c:function:: bool dylan_class_p (D instance)
 

--- a/documentation/source/hacker-guide/compiler/notes-warnings-errors.rst
+++ b/documentation/source/hacker-guide/compiler/notes-warnings-errors.rst
@@ -341,7 +341,7 @@ Program Conditions
    :open:
    :abstract:
 
-   :superclasses: :const:`<format-string-condition>`
+   :superclasses: :class:`<simple-condition>`
 
    :keyword compilation-stage: Defaults to the value of :var:`*current-stage*`.
    :keyword program-note-creator: Defaults to the value of :var:`*current-dependent*`.

--- a/documentation/source/library-reference/common-dylan/common-extensions.rst
+++ b/documentation/source/library-reference/common-dylan/common-extensions.rst
@@ -15,8 +15,7 @@ The extensions are:
 - Collection model: :class:`<stretchy-sequence>`, :class:`<string-table>`,
   :gf:`difference`, :func:`fill-table!`, :gf:`find-element`, :gf:`position`,
   :gf:`remove-all-keys!`, :macro:`define table`, :gf:`split`, and :gf:`join`.
-- Condition system: :class:`<format-string-condition>`,
-  :class:`<simple-condition>`, and :gf:`condition-to-string`.
+- Condition system: :class:`<simple-condition>`, and :gf:`condition-to-string`.
 - Control flow: :macro:`iterate` and :macro:`when`.
 - Development conveniences:
 
@@ -528,25 +527,6 @@ The extensions are:
      Formats a floating-point number to a string. It uses scientific
      notation where necessary.
 
-.. class:: <format-string-condition>
-   :sealed:
-   :instantiable:
-
-   The class of conditions that take a format string.
-
-   :superclasses: :drm:`<condition>`
-
-   :description:
-
-     The class of conditions that take a format string, as defined by
-     the DRM.
-
-     It is the superclass of Dylan's :class:`<simple-condition>`.
-
-   :seealso:
-
-     - The :doc:`Format module <../io/format>` in the :doc:`IO library <../io/index>`.
-
 .. function:: ignore
 
    A compiler directive that tells the compiler it must not issue a
@@ -783,19 +763,27 @@ The extensions are:
    :sealed:
    :instantiable:
 
-   The class of simple conditions.
+   The class of conditions that accept a format string and format arguments
+   with which to build a message describing the condition.
 
-   :superclasses: :class:`<format-string-condition>`
+   :superclasses: :class:`<condition>`
 
    :description:
 
-     The class of simple conditions. It is the superclass of :drm:`<simple-error>`,
-     :drm:`<simple-warning>`, and :drm:`<simple-restart>`.
+     As the superclass of :drm:`<simple-error>`, :drm:`<simple-warning>`, and
+     :drm:`<simple-restart>`, the :class:`<simple-condition>` class provides
+     the ``format-string:`` and ``format-arguments:`` init keywords described
+     in the DRM.
 
    :operations:
 
      - :drm:`condition-format-string`
      - :drm:`condition-format-arguments`
+
+   :seealso:
+
+     - The :doc:`format module <../io/format>` in the :doc:`IO library
+       <../io/index>`.
 
 .. class:: <stretchy-sequence>
    :open:

--- a/documentation/source/library-reference/io/print.rst
+++ b/documentation/source/library-reference/io/print.rst
@@ -349,7 +349,7 @@ IO library's *print* module.
          end;
 
    With the above method, an ``<account>`` object with name "foo" will print as
-   ``{<account> "foo" #xDEADBEEF}``.
+   ``{<account> "foo" 123}`` where ``123`` is a unique identifier for the object.
 
 
 The pprint Module

--- a/documentation/source/library-reference/network/index.rst
+++ b/documentation/source/library-reference/network/index.rst
@@ -731,7 +731,7 @@ This section lists the socket condition classes in the Network library.
    :description:
 
      The class of socket conditions. It inherits the ``format-string:``
-     and ``format-arguments:`` keywords from
+     and ``format-arguments:`` init keywords from
      :class:`<simple-condition>`.
 
      Slots:

--- a/documentation/source/library-reference/system/file-system.rst
+++ b/documentation/source/library-reference/system/file-system.rst
@@ -797,10 +797,10 @@ File-System module.
 
 .. class:: <file-system-error>
 
-   Error type signaled when any other functions in the File-System
+   Error type signaled when any of the functions in the File-System
    module signal an error.
 
-   :superclasses: :drm:`<error>`, :class:`<simple-condition>`
+   :superclasses: :drm:`<simple-error>`
 
    :description:
 

--- a/documentation/source/library-reference/system/locators.rst
+++ b/documentation/source/library-reference/system/locators.rst
@@ -85,8 +85,8 @@ The locators Module
 
    All errors raised by the locator system should be instances of
    this error.
-   
-   :superclasses: :class:`<format-string-condition>`, :drm:`<error>`
+
+   :superclasses: :class:`<simple-condition>`, :drm:`<error>`
 
 
 .. class:: <server-locator>
@@ -94,7 +94,7 @@ The locators Module
    :abstract:
 
    The abstract superclass of  locators for servers.
-   
+
    :superclasses: :class:`<locator>`
 
    :seealso:

--- a/documentation/source/library-reference/system/locators.rst
+++ b/documentation/source/library-reference/system/locators.rst
@@ -86,7 +86,7 @@ The locators Module
    All errors raised by the locator system should be instances of
    this error.
 
-   :superclasses: :class:`<simple-condition>`, :drm:`<error>`
+   :superclasses: :drm:`<simple-error>`
 
 
 .. class:: <server-locator>

--- a/sources/common-dylan/format.dylan
+++ b/sources/common-dylan/format.dylan
@@ -582,7 +582,7 @@ define method condition-to-string
 end method condition-to-string;
 
 define method condition-to-string
-    (condition :: <format-string-condition>) => (string :: <string>)
+    (condition :: <simple-condition>) => (string :: <string>)
   apply(format-to-string,
         condition-format-string(condition),
         condition-format-arguments(condition))

--- a/sources/common-dylan/library.dylan
+++ b/sources/common-dylan/library.dylan
@@ -66,7 +66,8 @@ end module byte-vector;
 define module common-extensions
   use dylan-extensions,
     export: { <bottom>,
-              <format-string-condition>,
+              <format-string-condition>, // Deprecated...
+              <simple-condition>,        // ...use this instead.
                 <stack-overflow-error>,
                 <arithmetic-error>,
                   <division-by-zero-error>,
@@ -75,7 +76,6 @@ define module common-extensions
                   <arithmetic-underflow-error>,
               <stretchy-object-vector>,
               <object-deque>,
-              <simple-condition>,
               <stretchy-sequence>,
               <string-table>,
               false-or,

--- a/sources/common-dylan/streams-protocol.dylan
+++ b/sources/common-dylan/streams-protocol.dylan
@@ -5,7 +5,7 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
-define open abstract class <stream-error> (<error>, <format-string-condition>)
+define open abstract class <stream-error> (<error>, <simple-condition>)
   constant slot stream-error-stream :: <stream>,
     required-init-keyword: stream:;
 end;
@@ -17,7 +17,7 @@ define generic stream-error-stream
 // TODO: yuck.  Would be nicer to just have a condition-to-string method..
 // andrewa: note that then you need to update the runtime manager to
 // know about the new class too, it is simpler to rely on subclassing
-// <format-string-condition>.
+// <simple-condition>.
 define method make
     (class :: subclass(<stream-error>),
      #rest args,

--- a/sources/common-dylan/tests/condition-test-utilities.dylan
+++ b/sources/common-dylan/tests/condition-test-utilities.dylan
@@ -31,7 +31,6 @@ end method make-condition;
 /// Condition test functions
 
 define method test-condition (condition :: <condition>) => ()
-  test-output("test-condition(<condition>)\n");
   do(method (function) function(condition) end,
      vector(// Functions on <condition>
             do-test-signal,
@@ -48,7 +47,6 @@ define method test-condition (condition :: <condition>) => ()
 end method test-condition;
 
 define method test-condition (condition :: <simple-error>) => ()
-  test-output("test-condition(<simple-error>)\n");
   next-method();
   do(method (function) function(condition) end,
      vector(// Functions on <simple-error>

--- a/sources/common-dylan/tests/condition-test-utilities.dylan
+++ b/sources/common-dylan/tests/condition-test-utilities.dylan
@@ -22,10 +22,16 @@ define constant $condition-arguments = #(1, 2);
 define method make-condition
     (class :: subclass(<condition>))
  => (condition :: <condition>)
+  make(class)
+end method;
+
+define method make-condition
+    (class :: subclass(<simple-condition>))
+ => (condition :: <simple-condition>)
   make(class,
        format-string: $condition-string,
        format-arguments: $condition-arguments)
-end method make-condition;
+end method;
 
 
 /// Condition test functions
@@ -46,22 +52,21 @@ define method test-condition (condition :: <condition>) => ()
             ))
 end method test-condition;
 
-define method test-condition (condition :: <simple-error>) => ()
+define method test-condition (condition :: <simple-condition>) => ()
   next-method();
   do(method (function) function(condition) end,
-     vector(// Functions on <simple-error>
+     vector(// Functions on <simple-condition>
             do-test-condition-format-string,
             do-test-condition-format-arguments
             ))
 end method test-condition;
 
 define method test-condition (condition :: <type-error>) => ()
-  next-method();
-  do(method (function) function(condition) end,
-     vector(// Functions on <type-error>
-            do-test-type-error-value,
-            do-test-type-error-expected-type
-            ))
+  // The purpose of this method is to prevent next-method() from being called.
+  // do-test-condition-format-{string,arguments} don't work for <type-error> because
+  // its format string and args are computed from the value and type init args.
+
+  //next-method();
 end method test-condition;
 
 define method make-condition (class == <type-error>) => (c :: <type-error>)
@@ -70,29 +75,11 @@ define method make-condition (class == <type-error>) => (c :: <type-error>)
        type: <string>)
 end method;
 
-define method test-condition (condition :: <simple-warning>) => ()
-  next-method();
-  do(method (function) function(condition) end,
-     vector(// Functions on <simple-warning>
-            do-test-condition-format-string,
-            do-test-condition-format-arguments
-            ))
-end method test-condition;
-
 define method test-condition (condition :: <restart>) => ()
   next-method();
   do(method (function) function(condition) end,
      vector(// Generic functions on <restart>
             do-test-restart-query
-            ))
-end method test-condition;
-
-define method test-condition (condition :: <simple-restart>) => ()
-  next-method();
-  do(method (function) function(condition) end,
-     vector(// Functions on <simple-restart>
-            do-test-condition-format-string,
-            do-test-condition-format-arguments
             ))
 end method test-condition;
 
@@ -129,7 +116,7 @@ define method do-test-return-description (condition :: <condition>) => ()
 end method;
 
 define method do-test-condition-format-string
-    (condition :: <condition>) => ()
+    (condition :: <simple-condition>) => ()
   let name = format-to-string("%= condition-format-string matches specified format string",
                               condition);
   check-equal(name,
@@ -138,20 +125,12 @@ define method do-test-condition-format-string
 end method;
 
 define method do-test-condition-format-arguments
-    (condition :: <condition>) => ()
+    (condition :: <simple-condition>) => ()
   let name = format-to-string("%= condition-format-arguments match specified format arguments",
                               condition);
   check-equal(name,
               condition-format-arguments(condition),
               $condition-arguments)
-end method;
-
-define method do-test-type-error-value (condition :: <condition>) => ()
-  //---*** Fill this in...
-end method;
-
-define method do-test-type-error-expected-type (condition :: <condition>) => ()
-  //---*** Fill this in...
 end method;
 
 define method do-test-restart-query (condition :: <condition>) => ()

--- a/sources/dfmc/conditions/hierarchy.dylan
+++ b/sources/dfmc/conditions/hierarchy.dylan
@@ -41,7 +41,7 @@ define function invoke-debugger (condition) end;
 // best to subclass one of <program-error>, <program-note>, or
 // <program-restart> instead.
 
-define open abstract class <program-condition> (<format-string-condition>)
+define open abstract class <program-condition> (<simple-condition>)
 
   // TODO: Make this class primary.
 

--- a/sources/dfmc/conditions/report.dylan
+++ b/sources/dfmc/conditions/report.dylan
@@ -23,8 +23,8 @@ define thread variable *detail-level* :: <detail-level> = #"normal";
 // specializable parameter.
 //
 // The default method for <program-condition>s takes advantage of the
-// fact that all program conditions obey the <format-string-condition>
-// (aka <simple-condition>) protocol of having a format string and its
+// fact that all program conditions obey the <simple-condition>
+// protocol of having a format string and its
 // arguments in the condition itself.  Methods for conditions outside
 // the program condition hierarchy just handle the default level by
 // using the %s/%= distinction in format.

--- a/sources/dfmc/modeling/namespaces.dylan
+++ b/sources/dfmc/modeling/namespaces.dylan
@@ -719,8 +719,8 @@ define &module dylan-extensions
 
   create
     \last-handler-definer,
-    <format-string-condition>,
-    <simple-condition>, // HACK: COMPATIBILITY
+    <format-string-condition>,  // Deprecated...
+    <simple-condition>,         // ...use this instead.
       <stack-overflow-error>,
       <arithmetic-error>,
         <division-by-zero-error>,

--- a/sources/dylan/condition.dylan
+++ b/sources/dylan/condition.dylan
@@ -62,6 +62,7 @@ define open abstract primary class <simple-condition> (<condition>)
   constant slot condition-format-arguments, init-keyword: format-arguments:, init-value: #[];
 end class <simple-condition>;
 
+// Deprecated. Use <simple-condition> instead. This will be removed in a future release.
 define constant <format-string-condition> = <simple-condition>;
 
 // debug-message and its C primitive require the arguments as a vector.

--- a/sources/dylan/number.dylan
+++ b/sources/dylan/number.dylan
@@ -100,7 +100,7 @@ define generic remainder
 
 //// CONDITIONS
 
-define open abstract class <arithmetic-error> (<error>, <format-string-condition>)
+define open abstract class <arithmetic-error> (<error>, <simple-condition>)
   inherited slot condition-format-string = "Arithmetic error";
 end class <arithmetic-error>;
 

--- a/sources/environment/commands/command-line.dylan
+++ b/sources/environment/commands/command-line.dylan
@@ -260,7 +260,7 @@ define open generic parse-next-argument
 
 /// Utilities
 
-define class <command-line-server-error> (<simple-condition>, <error>)
+define class <command-line-server-error> (<simple-error>)
 end class <command-line-server-error>;
 
 define class <command-error> (<command-line-server-error>)

--- a/sources/environment/commands/command-line.dylan
+++ b/sources/environment/commands/command-line.dylan
@@ -260,7 +260,7 @@ define open generic parse-next-argument
 
 /// Utilities
 
-define class <command-line-server-error> (<format-string-condition>, <error>)
+define class <command-line-server-error> (<simple-condition>, <error>)
 end class <command-line-server-error>;
 
 define class <command-error> (<command-line-server-error>)

--- a/sources/environment/commands/properties.dylan
+++ b/sources/environment/commands/properties.dylan
@@ -137,7 +137,7 @@ end method show-property;
 
 /// Errors
 
-define class <set-property-error> (<simple-condition>, <error>)
+define class <set-property-error> (<simple-error>)
 end class <set-property-error>;
 
 define method set-error

--- a/sources/environment/commands/properties.dylan
+++ b/sources/environment/commands/properties.dylan
@@ -137,7 +137,7 @@ end method show-property;
 
 /// Errors
 
-define class <set-property-error> (<format-string-condition>, <error>)
+define class <set-property-error> (<simple-condition>, <error>)
 end class <set-property-error>;
 
 define method set-error

--- a/sources/environment/dfmc/application/breakpoint-objects.dylan
+++ b/sources/environment/dfmc/application/breakpoint-objects.dylan
@@ -65,7 +65,7 @@ end class <class-breakpoint>;
 ///// <BREAKPOINT-ERROR>
 //    The class of all breakpoint errors
 
-define abstract class <breakpoint-error> (<format-string-condition>, <error>)
+define abstract class <breakpoint-error> (<simple-condition>, <error>)
 end class <breakpoint-error>;
 
 

--- a/sources/environment/protocols/condition-objects.dylan
+++ b/sources/environment/protocols/condition-objects.dylan
@@ -12,9 +12,9 @@ define user-object-class <condition-object> (<user-object>)
   binding <condition>, module: dylan, library: dylan;
 end user-object-class <condition-object>;
 
-define user-object-class <format-string-condition-object> (<condition-object>)
-  binding <format-string-condition>, module: dylan-extensions, library: dylan;
-end user-object-class <format-string-condition-object>;
+define user-object-class <simple-condition-object> (<condition-object>)
+  binding <simple-condition>, module: dylan-extensions, library: dylan;
+end user-object-class <simple-condition-object>;
 
 define constant $format-condition-string-id
   = make(<definition-id>,

--- a/sources/environment/tools/project-commands.dylan
+++ b/sources/environment/tools/project-commands.dylan
@@ -526,7 +526,7 @@ end method environment-open-file;
 
 /// Project error handling
 
-define class <project-error> (<format-string-condition>, <error>)
+define class <project-error> (<simple-condition>, <error>)
 end class <project-error>;
 
 define class <link-error> (<project-error>)

--- a/sources/environment/tools/project-commands.dylan
+++ b/sources/environment/tools/project-commands.dylan
@@ -526,7 +526,7 @@ end method environment-open-file;
 
 /// Project error handling
 
-define class <project-error> (<simple-condition>, <error>)
+define class <project-error> (<simple-error>)
 end class <project-error>;
 
 define class <link-error> (<project-error>)

--- a/sources/lib/dood/native-macros.dylan
+++ b/sources/lib/dood/native-macros.dylan
@@ -4,7 +4,7 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
-define class <dood-warning> (<simple-condition>, <warning>)
+define class <dood-warning> (<simple-warning>)
 end class;
 
 /*

--- a/sources/lib/dood/native-macros.dylan
+++ b/sources/lib/dood/native-macros.dylan
@@ -4,7 +4,7 @@ Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
 License:      See License.txt in this distribution for details.
 Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
-define class <dood-warning> (<format-string-condition>, <warning>)
+define class <dood-warning> (<simple-condition>, <warning>)
 end class;
 
 /*

--- a/sources/project-manager/user-projects/interactive-project.dylan
+++ b/sources/project-manager/user-projects/interactive-project.dylan
@@ -101,7 +101,7 @@ define method project-close-compilation-contexts
   next-method()
 end;
 
-define class <debug-target-not-set-error> (<simple-condition>, <error>) end;
+define class <debug-target-not-set-error> (<simple-error>) end;
 
 
 define function verify-execution-target (project :: <interactive-project>)

--- a/sources/system/file-system/file-system.dylan
+++ b/sources/system/file-system/file-system.dylan
@@ -22,7 +22,7 @@ end class <file-system-directory-locator>;
 define class <file-system-file-locator> (<file-system-locator>, <file-locator>)
 end class <file-system-file-locator>;
 
-define sealed class <file-system-error> (<error>, <simple-condition>)
+define sealed class <file-system-error> (<simple-error>)
 end class <file-system-error>;
 
 define sealed class <file-error> (<file-system-error>)

--- a/sources/system/locators/locators.dylan
+++ b/sources/system/locators/locators.dylan
@@ -113,7 +113,7 @@ end method as;
 
 /// Locator conditions
 
-define class <locator-error> (<simple-condition>, <error>)
+define class <locator-error> (<simple-error>)
 end class <locator-error>;
 
 define function locator-error

--- a/sources/system/locators/locators.dylan
+++ b/sources/system/locators/locators.dylan
@@ -113,7 +113,7 @@ end method as;
 
 /// Locator conditions
 
-define class <locator-error> (<format-string-condition>, <error>)
+define class <locator-error> (<simple-condition>, <error>)
 end class <locator-error>;
 
 define function locator-error

--- a/sources/system/tests/specification.dylan
+++ b/sources/system/tests/specification.dylan
@@ -73,7 +73,7 @@ define interface-specification-suite file-system-locators-specification-suite ()
     (subclass(<locator>), <string>) => (<locator>);
 
   // Locator conditions
-  instantiable class <locator-error> (<format-string-condition>, <error>);
+  instantiable class <locator-error> (<simple-condition>, <error>);
   function locator-error (<string>, #"rest") => (#"rest");
 
   // Utilities

--- a/sources/system/tests/specification.dylan
+++ b/sources/system/tests/specification.dylan
@@ -73,7 +73,7 @@ define interface-specification-suite file-system-locators-specification-suite ()
     (subclass(<locator>), <string>) => (<locator>);
 
   // Locator conditions
-  instantiable class <locator-error> (<simple-condition>, <error>);
+  instantiable class <locator-error> (<simple-error>);
   function locator-error (<string>, #"rest") => (#"rest");
 
   // Utilities


### PR DESCRIPTION
* Deprecate `<format-string-condition>` and replace uses of it with `<simple-condition>`.
* Use `<simple-error>` in some superclass lists where `(<error>, <simple-condition>)` was used.