### PR TITLE
common-dylan/timers.dylan: new function microsecond-counter

### DIFF
--- a/sources/common-dylan/library.dylan
+++ b/sources/common-dylan/library.dylan
@@ -47,7 +47,8 @@ define module simple-timers
          timer-start,
          timer-stop,
          timer-accumulated-time,
-         timer-running?;
+         timer-running?,
+         microsecond-counter;
 end module simple-timers;
 
 define module byte-vector

--- a/sources/common-dylan/tests/common-dylan-test-suite.lid
+++ b/sources/common-dylan/tests/common-dylan-test-suite.lid
@@ -12,6 +12,7 @@ Files: library
        streams
        byte-vector
        machine-words
+       timers-tests
        transcendentals
        regressions
        threads/simple-locks

--- a/sources/common-dylan/tests/library.dylan
+++ b/sources/common-dylan/tests/library.dylan
@@ -40,6 +40,7 @@ define module common-dylan-test-suite
   use simple-format;
   use simple-random;
   use simple-profiling;
+  use simple-timers;
   use file-system,
     import: { file-exists? };
   use operating-system,

--- a/sources/common-dylan/tests/timers-tests.dylan
+++ b/sources/common-dylan/tests/timers-tests.dylan
@@ -1,0 +1,14 @@
+Module: common-dylan-test-suite
+
+
+define test test-microsecond-counter ()
+  let t1 = microsecond-counter();
+  sleep(0.1);
+  let t2 = microsecond-counter();
+  let diff = t2 - t1;
+  // I need slop to be at least 5200 on my macOS M3 Pro. Be more generous than
+  // that since the main point is simply to exercise the function at all. --cgay
+  let slop = 50_000;
+  assert-true(diff >= (100_000 - slop) & diff < (100_000 + slop),
+              diff);
+end test;


### PR DESCRIPTION
I needed some kind of low-level system counter to implement a clock() built-in while writing the interpreter in Crafting Interpreters and common-dylan:timers has almost the right thing and seems a natural place to add one.

This is for review...I'll modify the comments at a minimum before merging but for now they reflect some of my thought process.