### PR TITLE
reader: Fix multi-line string literal escaping bug

### DIFF
--- a/sources/dfmc/reader/lexer-transitions.dylan
+++ b/sources/dfmc/reader/lexer-transitions.dylan
@@ -523,7 +523,7 @@ define constant $initial-state :: <state>
        state(#"3string", #f, // seen """
              #('"' . #"close-double-quote"),
              #('\\' . #"3string-escape"),
-             #(" !#-[]-~\r\n" . #"3string"),
+             #(" !#-[]-~\r\n" . #"3string"),  // Ranges #-[ and ]-~ exclude backslash
              pair($ascii-8-bit-extensions, #"3string")),
        state(#"3string-escape", #f,
              #("\\'\"abefnrt0" . #"3string"),

--- a/sources/dfmc/reader/tests/dfmc-reader-test-suite-app.dylan
+++ b/sources/dfmc/reader/tests/dfmc-reader-test-suite-app.dylan
@@ -2,4 +2,4 @@ Module: dfmc-reader-test-suite-app
 License: See License.txt in this distribution for details.
 
 
-run-test-application(dfmc-reader-test-suite);
+run-test-application();


### PR DESCRIPTION
Fixes: https://github.com/dylan-lang/opendylan/issues/1624

This new split/join way of processing multi-line string literals allocates more, but is far less complex. Since parsing multi-line string literals is likely to be a very small part of overall compile time I don't think we need to worry about it.