### PR TITLE
doc: Fix typo in example of define c-struct

### DIFF
--- a/documentation/source/library-reference/c-ffi/index.rst
+++ b/documentation/source/library-reference/c-ffi/index.rst
@@ -189,7 +189,7 @@ fundamental numeric types:
       slot statistic :: <C-double>;
       slot data :: <C-char*>;
       slot next :: <Example*>;
-      pointer-type-name :: <Example*>;
+      pointer-type-name: <Example*>;
     end C-struct;
 
 This example defines the two designator types ``<Example>`` and


### PR DESCRIPTION
Closes #1630

`pointer-type-name` is not a slot with type `<Example*>`. It's a keyword with parameter `<Example*>`.