### PR TITLE
doc: List 'rsync' as a dependency to build the website

### DIFF
--- a/documentation/README.rst
+++ b/documentation/README.rst
@@ -14,6 +14,7 @@ Some system dependencies need to be satisfied first:
 - Python 3 and its package manager pip3.
 - Git
 - Make
+- rsync
 
 On a Debian-derivative, they're quite easy to fetch::
 


### PR DESCRIPTION
'update.sh' use rsync but it is not listed as a dependency.

Closes dylan-lang#1603