### PR TITLE
common-dylan-test-suite: don't do output to terminal

### DIFF
--- a/sources/common-dylan/tests/threads/simple-locks.dylan
+++ b/sources/common-dylan/tests/threads/simple-locks.dylan
@@ -8,11 +8,14 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 
 define constant *print-lock* = make(<lock>);
+define constant $debug-threads-tests = #f;
 
 define method format-l (#rest args)
-  with-lock (*print-lock*)
-    apply(test-output, args);
-  end with-lock;
+  if ($debug-threads-tests)
+    with-lock (*print-lock*)
+      apply(test-output, args);
+    end;
+  end;
 end method;
 
 


### PR DESCRIPTION
There is still one call to debug-message("Hello") but I don't know if capturing its output is doable.