### PR TITLE
Include detailed Git info in Open Dylan version string

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# To actually use this filter you must run the following commands in the top-level repo
+# directory:
+#   git config filter.version.smudge ./tools/scripts/version-smudge.sh
+#   git config filter.version.clean ./tools/scripts/version-clean.sh
+# There is no way to configure that for all users of the repo.
+sources/lib/release-info/common-info.dylan filter=version

--- a/BUILDING.rst
+++ b/BUILDING.rst
@@ -11,6 +11,9 @@ Clone the git repository::
 .. note:: It does not work to download a ZIP file of the repository from github
    because it doesn't include git submodules.
 
+.. note:: If you plan to build official releases, or you care about the output of
+   ``dylan-compiler -version``, then you must enable Git filters. See the top-level
+   .gitattributes file.
 
 UNIX
 ====

--- a/documentation/source/hacker-guide/topics/making-a-release.rst
+++ b/documentation/source/hacker-guide/topics/making-a-release.rst
@@ -41,9 +41,11 @@ now here is a manual check-list.
 
 #. Update the version number in the sources
 
-   * In the release-info library
-   * In the configure.ac file
-   * Do a ``git grep 2019.\\d`` to see if anything else needs to be updated.
+   There are a few places that hard-code the major.minor release version.
+
+   * The configure.ac file.
+   * Do a ``git grep 2019.\\d`` to see if anything else needs to be updated. (Obviously
+     change the year.)
 
 #. Update version numbers in ``build/unix/release-with-batteries.sh``
    to the latest stable versions of the relevant software (Clang+LLVM,
@@ -57,29 +59,43 @@ now here is a manual check-list.
 
      git log --format=short --no-merges v2019.1.0..origin/master | grep '^Author: ' | sort | uniq -c | sort -n
 
-#. Create a draft release on GitHub
+#. Enable Git filters if you haven't already
 
-   This step is primarily to create the release tag in the git repo.
+   Run the commands shown in the top-level .gitattributes file. You must do this once per
+   clone of the opendylan repository so that the Git filters will update the Open Dylan
+   release version constant on checkout.
 
-   On https://github.com/dylan-lang/opendylan/releases click the "Draft a
-   release" button and create a release with name similar to "Open Dylan
-   2019.1", tag similar to "v2019.1.0", any description you like, and make sure
-   the "This is a pre-release" box is checked.
+   The filters ensure that the latest ``v*`` tag is included in the value of
+   ``$release-version`` and thereby also in ``dylan-compiler -version``.
 
-   The major version is always the current year, the minor version is a number
-   starting at 1 for the current year, and the patch version starts at 0.
+#. Create a Git tag for the release
+
+   .. note:: This step can be done via the GitHub UI if preferred, by drafting a release
+             in advance, but if you need to move the tag it can be a lot more cumbersome.
+
+   ::
+      git tag -a v2019.1.0
+      git push --tags [--force] origin master
+
+   It's important to match that exact tag format: ``vMAJOR.MINOR.PATCH`` The major
+   version is always the current year, the minor version is a number starting at 1 for
+   the current year, and the patch version starts at 0.
+
+   Add the ``-f`` flag to force tag creation if moving the tag after fixing a last-minute
+   bug.
 
 #. Build the binaries for supported platforms
 
-   It's best to build the release from a clean checkout to be sure that no
-   uncommitted files become part of the release tarball. In particular, the
-   entire "sources" directory is copied into the release, so any uncommitted
-   files or a "_build" directory could be copied.
+   It's best to build the release from a clean checkout to be sure that no uncommitted
+   files become part of the release tarball. In particular, the entire "sources"
+   directory is copied into the release, so any uncommitted files or a "_build" directory
+   could be copied.
 
    On unix platforms::
 
      $ git clone --recursive https://github.com/dylan-lang/opendylan
      $ cd opendylan
+     $ cat .gitattributes    # and run the commands it contains.
      $ git co v2019.1.0      # the tag you created above
      $ ./build/unix/release-with-batteries.sh
 
@@ -88,6 +104,13 @@ now here is a manual check-list.
    to indicate which version **can** be used to bootstrap the compiler.
 
    Ask Peter Housel to build the Windows release. :-)
+
+#. Create a release on GitHub
+
+   On https://github.com/dylan-lang/opendylan/releases click the "Draft a release" button
+   and create a release with name similar to "Open Dylan 2019.1", select the tag you
+   created above, any description you like, and make sure the "This is a pre-release" box
+   is checked.
 
 #. Upload the binaries to GitHub
 

--- a/sources/lib/release-info/common-info.dylan
+++ b/sources/lib/release-info/common-info.dylan
@@ -21,7 +21,9 @@ define constant $help-filename                = "opendylan.chm";
 /// Release constants
 define constant $release-product-name       = "Open Dylan";
 define constant $release-product-identifier = "opendylan";
-define constant $release-version            = "2025.1pre";
+
+// This string is replaced by Git filters on checkout. See the .gitattributes file.
+define constant $release-version = "DEVELOPMENT_VERSION";
 
 define constant $release-copyright
   = "Copyright (c) 1997-2004, Functional Objects, Inc.\n"
@@ -43,7 +45,7 @@ define method release-short-version () => (version :: <string>)
 end method release-short-version;
 
 define method release-version () => (version :: <string>)
-  concatenate("Version ", $release-version)
+  $release-version
 end method release-version;
 
 define method release-copyright () => (copyright :: <string>)

--- a/tools/scripts/version-clean.sh
+++ b/tools/scripts/version-clean.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sed "s,\"v.*built on.*\",\"DEVELOPMENT_VERSION\",g"

--- a/tools/scripts/version-smudge.sh
+++ b/tools/scripts/version-smudge.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+git_version="$(git describe --tags --always --match 'v*')"
+date="$(date -Iseconds)"
+sed "s,DEVELOPMENT_VERSION,${git_version} built on ${date},g"


### PR DESCRIPTION
This uses the same mechanism as Deft to maintain version info, so `dylan-compiler -version` displays something similar to "v2025.1.0-13-g7f7fdb9 built on 2025-01-08T21:05:44-05:00".

Besides more detail in the version, making it easier to pinpoint the commit from which Open Dylan was built, this also makes it so that we don't have to manually update the version string.

The release tag must be applied before the build, which is a minor change in how we've traditionally done releases.