### PR TITLE
doc: Update documentation links

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -58,3 +58,21 @@ html_favicon = '_static/favicon.ico'
 
 # Skip line numbers and prompt characters
 copybutton_exclude = '.linenos, .gp'
+
+# -- Options for linkcheck --------------------------------------------------
+# Ignore links that work but cannot be checked with linkcheck
+
+linkcheck_ignore = [
+    r'https://zenodo.org/.*',
+    r'http://citeseerx.ist.psu.edu/.*',
+    r'https://citeseerx.ist.psu.edu/.*',
+    r'https://app.element.io/#/room/#dylan-language:matrix.org',
+    r'https://dl.acm.org/.*',
+    r'https://doi.org/.*',
+    r'https://www.researchgate.net/.*',
+    r'https://www.computerhope.com/issues/ch000549.htm',
+    r'https://software.intel.com/.*',
+    r'https://github.com/dylan-lang/opendylan/blob/.*',
+    r'https://wiki.gnome.org/.*',
+    r'https://matrix.to/.*'
+]

--- a/documentation/source/corba-guide/intro.rst
+++ b/documentation/source/corba-guide/intro.rst
@@ -59,7 +59,7 @@ Object Management Group, Inc. describe their CORBA architecture as follows:
 
 
 (At the time of writing, the text above was available at:
-http://www.omg.org/corba/whatiscorba.html
+https://www.omg.org/corba/
 It has been reproduced with permission.)
 
 About the Open Dylan ORB

--- a/documentation/source/documentation/index.rst
+++ b/documentation/source/documentation/index.rst
@@ -96,7 +96,7 @@ list. Below are a few highlighted publications.
 
   https://zenodo.org/records/3742567
 
-**Extending Dylan's type system for better type inference and error detection** (by Hannes Mehnert at ILC 2010 `pdf <http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.627.5175&rep=rep1&type=pdf>`__ `bib <../_static/documentation/mehnert2010.bib>`__)
+**Extending Dylan's type system for better type inference and error detection** (by Hannes Mehnert at ILC 2010 `dl.acm.org <https://doi.org/10.1145/1869643.1869645>`__ `bib <../_static/documentation/mehnert2010.bib>`__)
     Whereas dynamic typing enables rapid prototyping and easy
     experimentation, static typing provides early error detection and
     better compile time optimization. Gradual typing provides the best
@@ -116,7 +116,7 @@ list. Below are a few highlighted publications.
 
     https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.627.5175&rep=rep1&type=pdf
 
-**D-Expressions: Lisp Power, Dylan Style** [`pdf <http://people.csail.mit.edu/jrb/Projects/dexprs.pdf>`__] [`bib <../_static/documentation/bachrach1999.bib>`__]
+**D-Expressions: Lisp Power, Dylan Style** [`pdf <https://people.csail.mit.edu/jrb/Projects/dexprs.pdf>`__] [`bib <../_static/documentation/bachrach1999.bib>`__]
     This paper aims to demonstrate that it is possible for a language
     with a rich, conventional syntax to provide Lisp-style macro power
     and simplicity. We describe a macro system and syntax manipulation

--- a/documentation/source/documentation/publications.rst
+++ b/documentation/source/documentation/publications.rst
@@ -86,7 +86,7 @@ Publications about Dylan
 
     https://dl.acm.org/doi/book/10.5555/867862
 
-**Partial Dispatch: Optimizing Dynamically-Dispatched Multimethod Calls with Compile-Time Types and Runtime Feedback** (by Jonathan Bachrach and Glenn Burke - Technical Report 2000 `pdf <http://people.csail.mit.edu/jrb/Projects/pd.pdf>`__ `bib <../_static/documentation/bachrach2000.bib>`__)
+**Partial Dispatch: Optimizing Dynamically-Dispatched Multimethod Calls with Compile-Time Types and Runtime Feedback** (by Jonathan Bachrach and Glenn Burke - Technical Report 2000 `pdf <https://people.csail.mit.edu/jrb/Projects/pd.pdf>`__ `bib <../_static/documentation/bachrach2000.bib>`__)
     We presented an approach to gaining back complete class hierarchy
     information by delaying the construction of dispatch caches until
     the whole class hierarchy is available at run- time. Run-time
@@ -102,7 +102,7 @@ Publications about Dylan
     components, multi-threaded runtime, incremental development, “pay
     as you go philosophy”, and interoperability with standard tools.
 
-**D-Expressions: Lisp Power, Dylan Style** (by Jonathan Bachrach and Keith Playford - Technical Report 1999 `pdf <http://people.csail.mit.edu/jrb/Projects/dexprs.pdf>`__ `bib <../_static/documentation/bachrach1999.bib>`__)
+**D-Expressions: Lisp Power, Dylan Style** (by Jonathan Bachrach and Keith Playford - Technical Report 1999 `pdf <https://people.csail.mit.edu/jrb/Projects/dexprs.pdf>`__ `bib <../_static/documentation/bachrach1999.bib>`__)
     This paper aims to demonstrate that it is possible for a language
     with a rich, conventional syntax to provide Lisp-style macro power
     and simplicity. We describe a macro system and syntax manipulation

--- a/documentation/source/getting-started-cli/editor-support.rst
+++ b/documentation/source/getting-started-cli/editor-support.rst
@@ -38,7 +38,7 @@ Support for Dylan is available out of the box.
 However, enhanced support is available in
 `dylan-vim`_.
 
-.. _language-dylan: https://atom.io/packages/language-dylan
+.. _language-dylan: https://github.blog/news-insights/product-news/sunsetting-atom/
 .. _DeftIDEA: https://plugins.jetbrains.com/plugin/7325-deftidea
 .. _dylan.tmbundle: https://github.com/textmate/dylan.tmbundle
 .. _dylan-vim: https://github.com/dylan-lang/dylan-vim

--- a/documentation/source/hacker-guide/build-system.rst
+++ b/documentation/source/hacker-guide/build-system.rst
@@ -320,7 +320,7 @@ Editing Jam Files
 There is an `Emacs major mode`_ for editing Jam files.
 
 .. _Jam: https://www.perforce.com/resources/documentation/jam
-.. _Perforce Software: https://www.perforce.com/
+.. _Perforce Software: https://swarm.workshop.perforce.com/view/guest/perforce_software/jam/src/Jam.html
 .. _Jam manual page: https://swarm.workshop.perforce.com/view/guest/perforce_software/jam/src/Jam.html
 .. _Jambase: https://swarm.workshop.perforce.com/files/guest/perforce_software/jam/src/Jambase
 .. _Jambase reference: https://swarm.workshop.perforce.com/view/guest/perforce_software/jam/src/Jambase.html

--- a/documentation/source/hacker-guide/compiler/old/internals.rst
+++ b/documentation/source/hacker-guide/compiler/old/internals.rst
@@ -229,7 +229,7 @@ The main entry point for the definition library is
 The building of definition objects relies heavily on the
 macro-expander, especially on procedural macros described in
 `D-Expressions: Lisp Power, Dylan Style
-<http://people.csail.mit.edu/jrb/Projects/dexprs.pdf>`_. Open Dylan
+<https://people.csail.mit.edu/jrb/Projects/dexprs.pdf>`_. Open Dylan
 extends the definitions with compiler, optimizer, primitive and
 shared-symbols, mainly used internally in the compiler.
 

--- a/documentation/source/hacker-guide/duim/index.rst
+++ b/documentation/source/hacker-guide/duim/index.rst
@@ -61,6 +61,6 @@ Additional debug information can be obtained via the `GTK_DEBUG`_
 and `GDK_DEBUG`_ environment variables.
 
 .. _gir-dylan: https://github.com/dylan-foundry/gir-dylan
-.. _directions: https://wiki.gnome.org/GTK+/OSX/Building
-.. _GTK_DEBUG: https://developer.gnome.org/gtk3/3.8/gtk-running.html#GTK-Debug-Options
-.. _GDK_DEBUG: https://developer.gnome.org/gtk3/3.8/gtk-running.html#GDK-Debug-Options
+.. _directions: https://handbook.gnome.org
+.. _GTK_DEBUG: https://docs.gtk.org/gtk3/running.html
+.. _GDK_DEBUG: https://docs.gtk.org/gtk3/running.html

--- a/documentation/source/hacker-guide/topics/making-a-release.rst
+++ b/documentation/source/hacker-guide/topics/making-a-release.rst
@@ -97,7 +97,7 @@ now here is a manual check-list.
 #. Test the tarballs
 
    In your own branch, modify the `libraries-test-suite.yml workflow
-   <https://github.com/dylan-lang/opendylan/blob/master/.github/workflows/libraries-test-suite.yml#L28>`_
+   <https://github.com/dylan-lang/opendylan/blob/ee21ac1e65f8aa921a2d76e197fb4ba652f3b8a1/.github/workflows/libraries-test-suite.yml#L28>`_
    to explicitly specify the new release version and tag so that it will be
    installed and tested on a clean machine on multiple platforms. You'll have
    to go to your fork in the GitHub UI, click on Actions, and find the workflow

--- a/documentation/source/hacker-guide/topics/method-dispatch.rst
+++ b/documentation/source/hacker-guide/topics/method-dispatch.rst
@@ -30,7 +30,7 @@ Publications
 
 One paper has been written about the implementation of dispatch in Open Dylan:
 
-* **Partial Dispatch: Optimizing Dynamically-Dispatched Multimethod Calls with Compile-Time Types and Runtime Feedback** (by Jonathan Bachrach and Glenn Burke - Technical Report 2000 `pdf <http://people.csail.mit.edu/jrb/Projects/pd.pdf>`__)
+* **Partial Dispatch: Optimizing Dynamically-Dispatched Multimethod Calls with Compile-Time Types and Runtime Feedback** (by Jonathan Bachrach and Glenn Burke - Technical Report 2000 `pdf <https://people.csail.mit.edu/jrb/Projects/pd.pdf>`__)
 
 Generic Function Representation
 ===============================
@@ -236,4 +236,4 @@ Future Work
 .. _sources/dfmc/management/compilation-driver.dylan: https://github.com/dylan-lang/opendylan/blob/master/sources/dfmc/management/compilation-driver.dylan
 .. _sources/environment/deuce/dylanworks-mode.dylan: https://github.com/dylan-lang/opendylan/blob/master/sources/environment/deuce/dylanworks-mode.dylan
 .. _sources/project-manager/projects/implementation.dylan: https://github.com/dylan-lang/opendylan/blob/master/sources/project-manager/projects/implementation.dylan
-.. _sources/lib/dispatch-profiler: https://github.com/dylan-lang/opendylan/blob/master/sources/lib/dispatch-profiler
+.. _sources/lib/dispatch-profiler: https://github.com/dylan-lang/opendylan/tree/master/sources/lib/dispatch-profiler

--- a/documentation/source/intro-dylan/modules-libraries.rst
+++ b/documentation/source/intro-dylan/modules-libraries.rst
@@ -40,7 +40,7 @@ Like all normal modules, this one uses the ``dylan`` module, which
 contains all of the standard built-in functions and classes. In turn,
 the ``vehicles`` module exports all three of the vehicle classes, the
 generic function ``tax``, several getter functions, and a single
-:drm:`setter <setters>` function.
+:drm:`setter <slots>` function.
 
 To make a :drm:`slot <slots>` public export its getter and setter functions. To
 make the slot read-only, export just the getter function. To make it private,
@@ -61,7 +61,8 @@ Dylan allows very precise control over how bindings are imported from
 other modules. For example, individual bindings may be imported by
 name. They may be renamed, either one at a time, or by adding a prefix
 to all of a module's names at once. Some or all of them may be
-re-exported immediately. See the DRM for :drm:`specific examples <define module>`.
+re-exported immediately. See the DRM :drm:`define module` for specific
+examples.
 
 Dylan's module system has a number of advantages. Name conflicts
 occur rarely. Programmers don't need to define or maintain function

--- a/documentation/source/library-reference/collections/index.rst
+++ b/documentation/source/library-reference/collections/index.rst
@@ -7,7 +7,7 @@ The collections Library
 .. library:: collections
 
    The ``collections`` library source can be found `here
-   <https://github.com/dylan-lang/opendylan/sources/collections>`_.
+   <https://github.com/dylan-lang/opendylan/tree/master/sources/collections>`_.
 
    In addition to the modules documented here, the :lib:`collections` library also
    re-exports the :doc:`byte-vector <../common-dylan/byte-vector>` module, which is

--- a/documentation/source/library-reference/language-extensions/macro-system-extensions.rst
+++ b/documentation/source/library-reference/language-extensions/macro-system-extensions.rst
@@ -28,7 +28,7 @@ Template Calls
 
 .. note:: This extension was originally described in an appendix to
    `D-Expressions: Lisp Power, Dylan Style
-   <http://people.csail.mit.edu/jrb/Projects/dexprs.pdf>`_.
+   <https://people.csail.mit.edu/jrb/Projects/dexprs.pdf>`_.
    This text is largely copied from there.
 
 A number of limitations of local rewrite rules require resorting to

--- a/documentation/source/news/2011/12/10/new_release.rst
+++ b/documentation/source/news/2011/12/10/new_release.rst
@@ -39,7 +39,7 @@ This is the first joint release on all major platforms:
 
 The C back-end currently does not support multi-threaded programs.
 
-We also developed a SLIME (https://common-lisp.net/project/slime/)
+We also developed a SLIME (https://slime.common-lisp.dev/)
 back-end, so you can develop in Emacs and get cross references, M-.
 and arguments.
 

--- a/documentation/source/news/2011/12/12/dswank.rst
+++ b/documentation/source/news/2011/12/12/dswank.rst
@@ -61,5 +61,5 @@ Installation
 
 You need the following pieces:
 
-   * `dylan-mode <https://github.com/dylan-lang/dylan-mode>`_, and extend your ``~/.emacs`` as documented in the README
+   * `dylan-mode <https://github.com/dylan-lang/dylan-emacs-support>`_, and extend your ``~/.emacs`` as documented in the README
    * dswank itself is shipped with the 2011.1 release

--- a/documentation/source/proposals/dep-0001-dep-process.rst
+++ b/documentation/source/proposals/dep-0001-dep-process.rst
@@ -497,7 +497,7 @@ References and Footnotes
    This is still in flux.  When in doubt, ask in IRC on the #dylan
    channel or on the hackers list.
 
-.. _Open Publication License: http://www.opencontent.org/openpub/
+.. _Open Publication License: https://opencontent.org/openpub/
 
 .. _reStructuredText: https://web.archive.org/web/20120114014252/https://docutils.sourceforge.net/rst.html
 

--- a/documentation/source/release-notes/2014.1.rst
+++ b/documentation/source/release-notes/2014.1.rst
@@ -77,7 +77,7 @@ Compiler
   <https://github.com/hannesm/visualization-middleware>`_.  A
   screencast showing an earlier implementation of this optimization
   visualization `can be seen here
-  <https://opendylan.org/~hannes/test4.avi>`_.
+  <https://web.archive.org/web/20141003023757/https://opendylan.org/~hannes/test4.avi>`_.
 
 * The C back-end would emit character constants that current versions
   of clang considered an error. The C back-end now generates a better


### PR DESCRIPTION
Fix broken links to pass the linkcheck process.
Also update outdated URLs to their current addresses.