### PR TITLE
Remove references to testworks-test-suite-app

### DIFF
--- a/sources/Library-Packs/TestWorks/testworks.dlp
+++ b/sources/Library-Packs/TestWorks/testworks.dlp
@@ -23,12 +23,5 @@
       </sources>
       <description>The Testworks test suite</description>
     </library>
-    <library name="testworks-test-suite-app" title="Testworks test suite application">
-      <category>TestWorks</category>
-      <sources location="qa/test-apps/testworks-test-suite">
-        <project>testworks-test-suite-app.lid</project>
-      </sources>
-      <description>The standalone version of the Testworks test suite</description>
-    </library>
   </test-suites>
 </library-pack>

--- a/sources/registry/generic/testworks-test-suite-app
+++ b/sources/registry/generic/testworks-test-suite-app
@@ -1,1 +1,0 @@
-abstract://dylan/lib/testworks/tests/testworks-test-suite-app.lid


### PR DESCRIPTION
testworks-test-suite-app will soon be removed from testworks. Instead, testworks-run and/or `deft test` can be used.