### PR TITLE
fix: Copy static binaries in install stage

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -261,6 +261,9 @@ install-stage:
 	@install -d $(prefix)/bin $(prefix)/databases $(prefix)/lib $(DESTDIR)$(prefix)/lib/runtime
 	@install -d $(prefix)/share/opendylan $(DESTDIR)$(prefix)/include/opendylan
 	@cp -R $(abs_builddir)/Bootstrap.3/bin $(DESTDIR)$(prefix)
+	# Copy BOOTSTRAP_3_STATICS to /bin
+	@cp -R $(abs_builddir)/Bootstrap.3/sbin/* $(DESTDIR)$(prefix)/bin
+	@ln -sf $(DESTDIR)$(prefix)/bin/deft-app $(DESTDIR)$(prefix)/bin/deft
 	@cp -R $(abs_builddir)/Bootstrap.3/databases $(DESTDIR)$(prefix)
 	@-cp -R $(abs_builddir)/Bootstrap.3/include/opendylan $(DESTDIR)$(prefix)/include
 	@# We use force here because on macOS, the lib directory likely contains read-only


### PR DESCRIPTION
In the Makefile, in BOOTSTRAP_3_STATICS 'deft-app' and other are compiled, however this files are not copied in the 'install' stage, only in the 'dist' stage.

I add two lines to copy the binary files to /bin/ folder and add a symbolic link from 'deft-app' to 'deft'.