### PR TITLE
feat: Add 'symbolic-link' method for UNIX

### DIFF
--- a/documentation/source/library-reference/system/file-system.rst
+++ b/documentation/source/library-reference/system/file-system.rst
@@ -33,6 +33,7 @@ set any available properties for the file.
 - :func:`file-property-setter`
 - :gf:`expand-pathname`
 - :gf:`shorten-pathname`
+- :gf:`create-symbolic-link`
 - :macro:`with-open-file`
 
 Manipulating directories
@@ -407,6 +408,49 @@ File-System module.
 
      - :func:`delete-directory`
 
+.. generic-function:: create-symbolic-link
+
+   Creates a symbolic link
+
+   :signature: create-symbolic-link *target* *link* => ()
+
+   :param target: An instance of `<pathname>`:class:.
+   :param link:   An instance of `<pathname>`:class:.
+
+   :description:
+
+     Creates a symbolic link to *target*.
+
+   :example:
+
+     Creates a symbolic link named *whattimeislove* to the *date* 
+     utility.
+
+     .. code-block:: dylan
+
+        create-symbolic-link("/usr/bin/date", "/tmp/whattimeislove"); 
+
+.. method:: create-symbolic-link
+   :specializer: <pathname>, <pathname>
+   :no-contents-entry:
+
+   :parameter target: An instance of :class:`<pathname>`.
+   :parameter link:   An instance of :class:`<pathname>`.
+
+.. method:: create-symbolic-link
+   :specializer: <string>, <string>
+   :no-contents-entry:
+
+   :parameter target: An instance of :drm:`<string>`.
+   :parameter link:   An instance of :drm:`<string>`.
+
+.. method:: create-symbolic-link
+   :specializer: <file-system-locator>, <file-system-locator>
+   :no-contents-entry:
+
+   :parameter target: An instance of :class:`<file-system-locator>`.
+   :parameter link:   An instance of :class:`<file-system-locator>`.
+
 .. function:: delete-directory
 
    Deletes the specified directory.
@@ -458,7 +502,7 @@ File-System module.
       and ".." directories are not included in the result.
 
 .. generic-function:: directory-empty?
-   
+
    Checks whether a directory is empty or not.
 
    :signature: directory-empty? *directory* => *empty?*
@@ -471,7 +515,7 @@ File-System module.
 
    :param directory: An instance of :class:`<file-system-directory>`.
    :value empty?: An instance of :class:`<boolean>`.
-   
+
 .. function:: do-directory
 
    Executes the supplied function once for each entity in the specified
@@ -917,6 +961,10 @@ File-System module.
       Repeatedly follows symbolic links starting with *file* until it finds a
       non-link file or directory, or a non-existent link target.
 
+   :seealso:
+
+     - :gf:`create-symbolic-link`
+
 .. _make:
 
 .. method:: make
@@ -1074,6 +1122,7 @@ File-System module.
      - :func:`home-directory`
      - :func:`link-target`
      - :func:`rename-file`
+     - :gf:`create-symbolic-link`
 
 .. class:: <posix-file-system-locator>
    :abstract:

--- a/documentation/source/library-reference/system/file-system.rst
+++ b/documentation/source/library-reference/system/file-system.rst
@@ -420,6 +420,7 @@ File-System module.
    :description:
 
      Creates a symbolic link to *target*.
+     Not supported in Win32.
 
    :example:
 

--- a/documentation/source/library-reference/system/file-system.rst
+++ b/documentation/source/library-reference/system/file-system.rst
@@ -408,14 +408,14 @@ File-System module.
 
      - :func:`delete-directory`
 
-.. generic-function:: create-symbolic-link
+.. function:: create-symbolic-link
 
    Creates a symbolic link
 
    :signature: create-symbolic-link *target* *link* => ()
 
-   :param target: An instance of `<pathname>`:class:.
-   :param link:   An instance of `<pathname>`:class:.
+   :param target: An instance of :class:`<pathname>`.
+   :param link:   An instance of :class:`<pathname>`.
 
    :description:
 
@@ -428,28 +428,7 @@ File-System module.
 
      .. code-block:: dylan
 
-        create-symbolic-link("/usr/bin/date", "/tmp/whattimeislove"); 
-
-.. method:: create-symbolic-link
-   :specializer: <pathname>, <pathname>
-   :no-contents-entry:
-
-   :parameter target: An instance of :class:`<pathname>`.
-   :parameter link:   An instance of :class:`<pathname>`.
-
-.. method:: create-symbolic-link
-   :specializer: <string>, <string>
-   :no-contents-entry:
-
-   :parameter target: An instance of :drm:`<string>`.
-   :parameter link:   An instance of :drm:`<string>`.
-
-.. method:: create-symbolic-link
-   :specializer: <file-system-locator>, <file-system-locator>
-   :no-contents-entry:
-
-   :parameter target: An instance of :class:`<file-system-locator>`.
-   :parameter link:   An instance of :class:`<file-system-locator>`.
+        create-symbolic-link("/usr/bin/date", "/tmp/whattimeislove")
 
 .. function:: delete-directory
 
@@ -963,7 +942,7 @@ File-System module.
 
    :seealso:
 
-     - :gf:`create-symbolic-link`
+     - :func:`create-symbolic-link`
 
 .. _make:
 
@@ -1122,7 +1101,7 @@ File-System module.
      - :func:`home-directory`
      - :func:`link-target`
      - :func:`rename-file`
-     - :gf:`create-symbolic-link`
+     - :func:`create-symbolic-link`
 
 .. class:: <posix-file-system-locator>
    :abstract:

--- a/sources/system/file-system/file-system.dylan
+++ b/sources/system/file-system/file-system.dylan
@@ -519,22 +519,8 @@ end method list-locator;
 
 ///
 
-define generic create-symbolic-link
-  (target :: <pathname>, link :: <pathname>) => ();
-
-define method create-symbolic-link
-    (target :: <file-system-locator>, link :: <file-system-locator>) => ()
-  %create-symbolic-link(target, link)
-end method create-symbolic-link;
-
-define method create-symbolic-link
-    (target :: <string>, link :: <string>) => ()
-  create-symbolic-link(as(<file-system-locator>, target),
-                       as(<file-system-locator>, link))
-end method create-symbolic-link;
-
-define method create-symbolic-link
+define function create-symbolic-link
     (target :: <pathname>, link :: <pathname>) => ()
-  %create-symbolic-link(as(<file-system-Locator>, target),
+  %create-symbolic-link(as(<file-system-locator>, target),
                         as(<file-system-locator>, link))
-end method create-symbolic-link;
+end function create-symbolic-link;

--- a/sources/system/file-system/file-system.dylan
+++ b/sources/system/file-system/file-system.dylan
@@ -516,3 +516,25 @@ define sideways method list-locator
      locator);
   locators
 end method list-locator;
+
+///
+
+define generic create-symbolic-link
+  (target :: <pathname>, link :: <pathname>) => ();
+
+define method create-symbolic-link
+    (target :: <file-system-locator>, link :: <file-system-locator>) => ()
+  %create-symbolic-link(target, link)
+end method create-symbolic-link;
+
+define method create-symbolic-link
+    (target :: <string>, link :: <string>) => ()
+  create-symbolic-link(as(<file-system-locator>, target),
+                       as(<file-system-locator>, link))
+end method create-symbolic-link;
+
+define method create-symbolic-link
+    (target :: <pathname>, link :: <pathname>) => ()
+  %create-symbolic-link(as(<file-system-Locator>, target),
+                        as(<file-system-locator>, link))
+end method create-symbolic-link;

--- a/sources/system/file-system/unix-file-system.dylan
+++ b/sources/system/file-system/unix-file-system.dylan
@@ -682,3 +682,19 @@ end function %temp-directory;
 define function %root-directories () => (roots :: <sequence>)
   vector(as(<posix-directory-locator>, "/"))
 end function %root-directories;
+
+define function %create-symbolic-link
+    (target :: <posix-file-system-locator>, link :: <posix-file-system-locator>)
+ => ()
+  let target = %expand-pathname(target);
+  let link   = %expand-pathname(link);
+  if (primitive-raw-as-boolean
+        (%call-c-function("symlink") 
+             (target :: <raw-byte-string>, link :: <raw-byte-string>)
+          => (failed? :: <raw-c-signed-int>)
+           (primitive-string-as-raw(as(<byte-string>, target)),
+            primitive-string-as-raw(as(<byte-string>, link)))
+        end))
+    unix-file-error("symlink", "create symbolic link to %s from %s", target, link)
+  end
+end function %create-symbolic-link;

--- a/sources/system/file-system/win32-file-system.dylan
+++ b/sources/system/file-system/win32-file-system.dylan
@@ -630,5 +630,5 @@ end function %root-directories;
 define function %create-symbolic-link
     (target :: <microsoft-directory-locator>, link :: <microsoft-directory-locator>)
  => ()
-  win32-file-system-error("symlink", "create symbolic link. Not supported in Win32")
+  error("create-symbolic-link is not supported in Win32")
 end function %create-symbolic-link;

--- a/sources/system/file-system/win32-file-system.dylan
+++ b/sources/system/file-system/win32-file-system.dylan
@@ -626,3 +626,9 @@ define function %root-directories
     end
   end
 end function %root-directories;
+
+define function %create-symbolic-link
+    (target :: <microsoft-directory-locator>, link :: <microsoft-directory-locator>)
+ => ()
+  win32-file-system-error("symlink", "create symbolic link. Not supported in Win32")
+end function %create-symbolic-link;

--- a/sources/system/library.dylan
+++ b/sources/system/library.dylan
@@ -275,7 +275,8 @@ define module file-system
          home-directory,
          working-directory, working-directory-setter,
          temp-directory,
-         root-directories;
+         root-directories,
+         create-symbolic-link;
 end module file-system;
 
 define module file-system-internals

--- a/sources/system/tests/file-system.dylan
+++ b/sources/system/tests/file-system.dylan
@@ -69,14 +69,16 @@ define test test-file-exists? ()
   assert-true(file-exists?(file));
   assert-true(file-exists?(dir));
 
-  // TODO: Create a symbolic link and test the follow-symlinks? parameter. We
-  // don't currently have a function to create symlinks.
-  // I created symlinks by hand and ran this to test once:
-  //   $ ln -s /tmp/nothing /tmp/symlink-bad
-  //   $ ln -s /usr /tmp/symlink-good
-  // assert-true(file-exists?("/tmp/symlink-good"));
-  // assert-false(file-exists?("/tmp/symlink-bad"));
-  // assert-true(file-exists?("/tmp/symlink-bad", follow-links?: #f));
+  let tmp-nothing  = file-locator(dir, "nothing");
+  let symlink-bad  = file-locator(dir, "symlink-bad");
+  let symlink-good = file-locator(dir, "symlink-good");
+
+  create-symbolic-link(tmp-nothing, symlink-bad);
+  create-symbolic-link("/usr", symlink-good);
+
+  assert-true(file-exists?(symlink-good));
+  assert-false(file-exists?(symlink-bad));
+  assert-true(file-exists?(symlink-bad, follow-links?: #f));
 end test;
 
 define test test-file-type ()


### PR DESCRIPTION
Adds UNIX method to create a symbolic link in the module 'file-system' of 'system' library.