### PR TITLE
feat: Add create-hard-link in system:file-system

### DIFF
--- a/documentation/source/library-reference/system/file-system.rst
+++ b/documentation/source/library-reference/system/file-system.rst
@@ -33,7 +33,8 @@ set any available properties for the file.
 - :func:`file-property-setter`
 - :gf:`expand-pathname`
 - :gf:`shorten-pathname`
-- :gf:`create-symbolic-link`
+- :function:`create-symbolic-link`
+- :function:`create-hard-link`
 - :macro:`with-open-file`
 
 Manipulating directories
@@ -575,6 +576,36 @@ File-System module.
      .. code-block:: dylan
 
         create-symbolic-link("/usr/bin/date", "/tmp/whattimeislove")
+
+    :seealso:
+
+      - :func:`create-hard-link`
+
+.. function:: create-hard-link
+
+   Creates a hard link
+
+   :signature: create-hard-link *target* *link* => ()
+
+   :param target: An instance of :class:`<pathname>`.
+   :param link:   An instance of :class:`<pathname>`.
+
+   :description:
+
+     Creates a directory entry that associates *link* with *target*.
+     Not yet supported in Win32.
+
+   :example:
+
+     Creates a hard link named *my-hard-link* to *myfile.txt*.
+
+     .. code-block:: dylan
+
+        create-hard-link("myfile.txt", "my-hard-link")
+
+    :seealso:
+
+      - :func:`create-symbolic-link`
 
 .. function:: delete-directory
 

--- a/sources/system/file-system/file-system.dylan
+++ b/sources/system/file-system/file-system.dylan
@@ -524,3 +524,9 @@ define function create-symbolic-link
   %create-symbolic-link(as(<file-system-locator>, target),
                         as(<file-system-locator>, link))
 end function create-symbolic-link;
+
+define function create-hard-link
+    (target :: <pathname>, link :: <pathname>) => ()
+  %create-hard-link(as(<file-system-locator>, target),
+                    as(<file-system-locator>, link))
+end function create-hard-link;

--- a/sources/system/file-system/unix-file-system.dylan
+++ b/sources/system/file-system/unix-file-system.dylan
@@ -688,8 +688,9 @@ define function %create-symbolic-link
  => ()
   let target = %expand-pathname(target);
   let link   = %expand-pathname(link);
+
   if (primitive-raw-as-boolean
-        (%call-c-function("symlink") 
+        (%call-c-function("symlink")
              (target :: <raw-byte-string>, link :: <raw-byte-string>)
           => (failed? :: <raw-c-signed-int>)
            (primitive-string-as-raw(as(<byte-string>, target)),
@@ -698,3 +699,20 @@ define function %create-symbolic-link
     unix-file-error("symlink", "create symbolic link to %s from %s", target, link)
   end
 end function %create-symbolic-link;
+
+define function %create-hard-link
+    (target :: <posix-file-system-locator>, link :: <posix-file-system-locator>)
+ => ()
+  let target = %expand-pathname(target);
+  let link   = %expand-pathname(link);
+
+  if (primitive-raw-as-boolean
+        (%call-c-function("link")
+             (target :: <raw-byte-string>, link :: <raw-byte-string>)
+          => (failed? :: <raw-c-signed-int>)
+           (primitive-string-as-raw(as(<byte-string>, target)),
+            primitive-string-as-raw(as(<byte-string>, link)))
+        end))
+    unix-file-error("link", "create link to %s from %s", target, link)
+  end
+end function %create-hard-link;

--- a/sources/system/file-system/win32-file-system.dylan
+++ b/sources/system/file-system/win32-file-system.dylan
@@ -630,5 +630,11 @@ end function %root-directories;
 define function %create-symbolic-link
     (target :: <microsoft-directory-locator>, link :: <microsoft-directory-locator>)
  => ()
-  error("create-symbolic-link is not supported in Win32")
-end function %create-symbolic-link;
+  error("create-symbolic-link is not yet supported in Win32")
+end;
+
+define function %create-hard-link
+    (target :: <microsoft-directory-locator>, link :: <microsoft-directory-locator>)
+ => ()
+  error("create-hard-link is not yet supported in Win32")
+end;

--- a/sources/system/library.dylan
+++ b/sources/system/library.dylan
@@ -276,7 +276,8 @@ define module file-system
          working-directory, working-directory-setter,
          temp-directory,
          root-directories,
-         create-symbolic-link;
+         create-symbolic-link,
+         create-hard-link;
 end module file-system;
 
 define module file-system-internals

--- a/sources/system/tests/file-system.dylan
+++ b/sources/system/tests/file-system.dylan
@@ -81,6 +81,27 @@ define test test-file-exists? ()
   assert-true(file-exists?(symlink-bad, follow-links?: #f));
 end test;
 
+define test test-symbolic-link ()
+  let tmp-dir = test-temp-directory();
+  let symlink = file-locator(tmp-dir, "symlink-to-tmp");
+
+  create-symbolic-link("/tmp", symlink);
+  assert-true(file-exists?(symlink));
+end;
+
+define test test-hard-link ()
+  let tmp-dir  = test-temp-directory();
+  let old-path = file-locator(tmp-dir, "hard-link");
+  let new-path = file-locator(tmp-dir, "new-link");
+
+  with-open-file (fs = old-path, direction: #"output")
+    write(fs, "stuff")
+  end;
+
+  create-hard-link(old-path, new-path);
+  assert-true(file-exists?(new-path));
+end;
+
 define test test-file-type ()
   //---*** Fill this in.
 end;


### PR DESCRIPTION
Code is duplicated between 'create-symbolic-link' and 'create-hard-link' because '%call-c-function' only transform the name of the C function at compile time, so it is not possible pass a variable with the function name to execute.