### PR TITLE
Fix and refactor file-system tests related with symbolic links

### DIFF
--- a/sources/system/tests/file-system.dylan
+++ b/sources/system/tests/file-system.dylan
@@ -70,7 +70,7 @@ define test test-file-exists? ()
   assert-true(file-exists?(dir));
 end test;
 
-define test test-symbolic-link ()
+define test test-create-symbolic-link ()
   let dir = test-temp-directory();
   let tmp-nothing  = file-locator(dir, "nothing");
   let tmp-something = write-test-file("something");
@@ -85,7 +85,7 @@ define test test-symbolic-link ()
   assert-true(file-exists?(symlink-bad, follow-links?: #f));
 end;
 
-define test test-hard-link ()
+define test test-create-hard-link ()
   let tmp-dir  = test-temp-directory();
   let old-path = write-test-file("hard-link", contents: "stuff");
   let new-path = file-locator(tmp-dir, "new-link");


### PR DESCRIPTION
- Remove Unix dependent path in tests
- Move partial test code from 'test-file-exits?' to 'test-symbolic-link'
- Simplify test 'test-hard-link'