### PR TITLE
feat: Update '%copy-file' shell copy

### DIFF
--- a/sources/system/unix-portability.c
+++ b/sources/system/unix-portability.c
@@ -2,7 +2,9 @@
 #define _DARWIN_C_SOURCE
 #endif
 
+#if defined(OPEN_DYLAN_PLATFORM_LINUX)
 #define _GNU_SOURCE
+#endif
 
 #include <unistd.h>
 #include <signal.h>
@@ -160,7 +162,14 @@ int system_copy_file_range(int in_fd, int out_fd, off_t in_size)
   return fcopyfile(in_fd, out_fd, NULL, COPYFILE_ALL);
 }
 
-#else
+#endif
+
+// FreeBSD needs <sys/types.h> for 'copy_file_range'
+#if defined(OPEN_DYLAN_PLATFORM_FREEBSD)
+#include <sys/types.h>
+#endif
+
+#if defined(OPEN_DYLAN_PLATFORM_LINUX) || defined(OPEN_DYLAN_PLATFORM_FREEBSD)
 
 int system_copy_file_range(int in_fd, int out_fd, off_t in_size)
 {


### PR DESCRIPTION
Replace shell copy with specialized copy.

Use 'copy_file_range' in Unix with fallback copy 'unix-copy-file' in case of error (e.g. cross-device copy).

Closes #1649