### PR TITLE
Thread Environment Block based Thread-Local Variable access

### DIFF
--- a/sources/app/llvm-runtime-generator/llvm-runtime-c-header.dylan
+++ b/sources/app/llvm-runtime-generator/llvm-runtime-c-header.dylan
@@ -100,7 +100,7 @@ define method print-runtime-variable-declaration
 
   let thread-local?
     = member?(#"thread-local", descriptor.runtime-variable-attributes)
-    & llvm-thread-local-support?(be);
+    & llvm-runtime-thread-local-support?(be);
   if (thread-local?)
     format(stream, "__thread ");
   end if;

--- a/sources/dfmc/flow-graph/computation.dylan
+++ b/sources/dfmc/flow-graph/computation.dylan
@@ -51,12 +51,12 @@ define abstract dood-class <computation> (<queueable-item-mixin>)
     reinit-expression: #f;
 end dood-class <computation>;
 
-define method environment (c :: <computation>)
+define sealed inline method environment (c :: <computation>)
  => (res :: false-or(<lambda-lexical-environment>))
   c.%environment
 end;
 
-define method environment-setter
+define sealed method environment-setter
     (e :: false-or(<lambda-lexical-environment>), c :: <computation>)
  => (res :: false-or(<lambda-lexical-environment>))
   if (slot-initialized?(c, %environment) & (c.environment ~= e))

--- a/sources/dfmc/flow-graph/temporary.dylan
+++ b/sources/dfmc/flow-graph/temporary.dylan
@@ -26,12 +26,12 @@ define dood-class <temporary> (<value-reference>)
     reinit-expression: #f;
 end dood-class;
 
-define method environment (c :: <temporary>)
+define sealed inline method environment (c :: <temporary>)
  => (res :: false-or(<lambda-lexical-environment>))
   c.%environment
 end;
 
-define method environment-setter
+define sealed method environment-setter
     (e :: false-or(<lambda-lexical-environment>), c :: <temporary>)
  => (res :: false-or(<lambda-lexical-environment>))
   c.%environment := e;
@@ -39,11 +39,11 @@ define method environment-setter
   e
 end;
 
-define method generator (t :: <temporary>) => (res :: false-or(<computation>))
+define inline method generator (t :: <temporary>) => (res :: false-or(<computation>))
   t.%generator
 end;
 
-define method generator-setter
+define sealed method generator-setter
     (g :: false-or(<computation>), t :: <temporary>)
  => (res :: false-or(<computation>))
   trace-dfm-connection(#"generator-setter", t, g);

--- a/sources/dfmc/llvm-back-end/llvm-back-end-library.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-back-end-library.dylan
@@ -44,6 +44,7 @@ define module dfmc-llvm-back-end
     llvm-back-end-dbg-compile-unit,
     llvm-back-end-dbg-compile-unit-setter,
 
+    llvm-runtime-thread-local-support?,
     llvm-thread-local-support?,
     llvm-teb-struct-type,
 

--- a/sources/dfmc/llvm-back-end/llvm-back-end-types.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-back-end-types.dylan
@@ -252,29 +252,27 @@ define method llvm-reference-type
     type
   else
     let elements = make(<stretchy-object-vector>);
-    do(curry(add-llvm-struct-member, back-end, elements),
-       o.raw-aggregate-members);
+    let elements
+      = map(curry(llvm-aggregate-member-type, back-end),
+            o.raw-aggregate-members);
     element(type-table, name)
       := make(<llvm-struct-type>, name: name, elements: elements)
   end
 end method;
 
-define method add-llvm-struct-member
-    (back-end :: <llvm-back-end>, elements :: <stretchy-object-vector>,
-     member :: <raw-aggregate-member>)
- => ();
-  add!(elements, llvm-reference-type(back-end, member.member-raw-type));
+define method llvm-aggregate-member-type
+    (back-end :: <llvm-back-end>, member :: <raw-aggregate-member>)
+ => (type :: <llvm-type>);
+  llvm-reference-type(back-end, member.member-raw-type);
 end method;
 
-define method add-llvm-struct-member
-    (back-end :: <llvm-back-end>, elements :: <stretchy-object-vector>,
-     member :: <raw-aggregate-array-member>)
- => ();
+define method llvm-aggregate-member-type
+    (back-end :: <llvm-back-end>, member :: <raw-aggregate-array-member>)
+ => (type :: <llvm-type>);
   let element-type = llvm-reference-type(back-end, member.member-raw-type);
-  add!(elements,
-       make(<llvm-array-type>,
-	    size: member.member-array-length,
-	    element-type: element-type));
+  make(<llvm-array-type>,
+       size: member.member-array-length,
+       element-type: element-type)
 end method;
 
 // References to most objects use the object pointer type

--- a/sources/dfmc/llvm-back-end/llvm-emit-computation.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-emit-computation.dylan
@@ -668,18 +668,18 @@ define method emit-computation
   let global = llvm-builder-global(back-end, name);
   llvm-constrain-type(global.llvm-value-type,
 		      llvm-pointer-to(back-end, $llvm-object-pointer-type));
-  let value = ins--load(back-end, global);
   let result
     = if (c.referenced-binding.binding-thread?)
         if (llvm-thread-local-support?(back-end))
           op--initialize-thread-variables(back-end);
-          value
+          ins--load(back-end, global)
         else
+          let handle = ins--load(back-end, global);
           call-primitive(back-end, primitive-read-thread-variable-descriptor,
-                         value)
+                         handle)
         end if
       else
-	value
+	ins--load(back-end, global)
       end if;
   computation-result(back-end, c, result);
 end method;

--- a/sources/dfmc/llvm-back-end/llvm-primitives-thread.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-primitives-thread.dylan
@@ -99,7 +99,15 @@ define runtime-variable %teb-chain :: <raw-address>
 define method op--teb
     (be :: <llvm-back-end>) => (teb :: <llvm-value>);
   let module = be.llvm-builder-module;
-  llvm-runtime-variable(be, module, %teb-descriptor)
+  let teb-var = llvm-runtime-variable(be, module, %teb-descriptor);
+  if (*interactive-mode?*)
+    // The interactive downloader currently can't handle linking
+    // thread-local storage, so we emit a call to the run-time
+    let tebp = call-primitive(be, dylan-teb-descriptor);
+    ins--bitcast(be, tebp, teb-var.llvm-value-type)
+  else
+    teb-var
+  end if
 end method;
 
 define method op--teb

--- a/sources/dfmc/llvm-back-end/llvm-primitives-thread.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-primitives-thread.dylan
@@ -94,7 +94,13 @@ define method op--teb-getelementptr
   apply(ins--gep-inbounds, be, teb, 0, index, indices)
 end method;
 
+define c-callable auxiliary &runtime-primitive-descriptor dylan-teb
+  () => (teb :: <raw-pointer>);
+  let raw-pointer-type = llvm-reference-type(be, dylan-value(#"<raw-pointer>"));
+  ins--bitcast(be, op--teb(be), raw-pointer-type)
+end;
 
+
 /// Thread-local variables
 
 define runtime-variable %tlv-initializations :: <simple-object-vector> = #[],

--- a/sources/dfmc/llvm-back-end/llvm-primitives-thread.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-primitives-thread.dylan
@@ -278,17 +278,101 @@ define method op--initialize-thread-variables
   ins--block(back-end, common-bb);
 end method;
 
+define side-effecting stateful dynamic-extent auxiliary &runtime-primitive-descriptor primitive-expand-thread-local-variables
+    (old-tlv-vector :: <simple-object-vector>, old-tlv-size :: <raw-integer>)
+ => (tlv-vector :: <simple-object-vector>);
+  let word-size = back-end-word-size(be);
+  let m = be.llvm-builder-module;
+
+  let cursor
+    = ins--load(be, llvm-runtime-variable(be, m, %tlv-initializations-cursor-descriptor),
+                alignment: word-size);
+  let new-tlv = op--allocate-vector(be, cursor);
+
+  // Copy elements of the old TLV vector into the new one
+  let sov-class :: <&class> = dylan-value(#"<simple-object-vector>");
+  let new-tlv-cast
+    = op--object-pointer-cast(be, new-tlv, sov-class);
+  begin
+    let dst-slot-ptr
+      = op--getslotptr(be, new-tlv-cast, sov-class, #"vector-element");
+    let dst-byte-ptr = ins--bitcast(be, dst-slot-ptr, $llvm-i8*-type);
+
+    let old-tlv-cast = op--object-pointer-cast(be, old-tlv-vector, sov-class);
+    let src-slot-ptr
+      = op--getslotptr(be, old-tlv-cast, sov-class, #"vector-element");
+    let src-byte-ptr = ins--bitcast(be, src-slot-ptr, $llvm-i8*-type);
+
+    let old-tlv-byte-size = ins--mul(be, old-tlv-size, word-size);
+    op--memcpy(be, dst-byte-ptr, src-byte-ptr, old-tlv-byte-size, $llvm-false,
+               dst-alignment: word-size, src-alignment: word-size);
+  end;
+
+  // Copy remaining elements from the initializations vector
+  let initializations
+    = ins--load(be, llvm-runtime-variable(be, m, %tlv-initializations-descriptor),
+                alignment: word-size);
+  let initializations-cast = op--object-pointer-cast(be, initializations, sov-class);
+  begin
+    let dst-slot-ptr
+      = op--getslotptr(be, new-tlv-cast, sov-class, #"vector-element", old-tlv-size);
+    let dst-byte-ptr = ins--bitcast(be, dst-slot-ptr, $llvm-i8*-type);
+
+    let src-slot-ptr
+      = op--getslotptr(be, initializations-cast, sov-class, #"vector-element", old-tlv-size);
+    let src-byte-ptr = ins--bitcast(be, src-slot-ptr, $llvm-i8*-type);
+
+    let remaining-size = ins--sub(be, cursor, old-tlv-size);
+    let remaining-byte-size = ins--mul(be, remaining-size, word-size);
+    op--memcpy(be, dst-byte-ptr, src-byte-ptr, remaining-byte-size, $llvm-false,
+               dst-alignment: word-size, src-alignment: word-size);
+  end;
+
+  new-tlv
+end;
+
 define side-effecting stateful indefinite-extent &c-primitive-descriptor primitive-allocate-thread-variable
     (initial-value :: <object>) => (handle :: <raw-pointer>);
 
-define side-effect-free dynamic-extent stateless &unimplemented-primitive-descriptor primitive-read-thread-variable
+define method op--tlv-vector
+    (back-end :: <llvm-back-end>, index :: <llvm-value>)
+ => (tlv-vector :: <llvm-value>);
+  let word-size = back-end-word-size(back-end);
+
+  let tlv-slot
+    = op--teb-getelementptr(back-end, #"teb-thread-local-variables");
+  let tlv-vector = ins--load(back-end, tlv-slot, alignment: word-size);
+  let tlv-vector-cast
+    = op--object-pointer-cast(back-end, tlv-vector, #"<simple-object-vector>");
+  let tlv-vector-size
+    = call-primitive(back-end, primitive-vector-size-descriptor,
+                     tlv-vector-cast);
+  ins--if(back-end, ins--icmp-ult(back-end, index, tlv-vector-size))
+    // This thread's vector already has this entry
+    tlv-vector-cast
+  ins--else
+    // Expand this thread's vector with missing initializations
+    let new-tlv
+      = call-primitive(back-end, primitive-expand-thread-local-variables-descriptor,
+                       tlv-vector, tlv-vector-size);
+    ins--store(back-end, new-tlv, tlv-slot, alignment: word-size);
+    op--object-pointer-cast(back-end, new-tlv, #"<simple-object-vector>")
+  end ins--if
+end method;
+
+define side-effect-free dynamic-extent stateless &primitive-descriptor primitive-read-thread-variable
     (handle :: <raw-pointer>) => (value :: <object>);
-  //---*** Fill this in...
+  let index = ins--ptrtoint(be, handle, be.%type-table["iWord"]);
+  let tlv-vector = op--tlv-vector(be, index);
+  call-primitive(be, primitive-vector-element-descriptor, tlv-vector, index)
 end;
 
-define side-effecting stateless dynamic-extent &unimplemented-primitive-descriptor primitive-write-thread-variable
+define side-effecting stateless dynamic-extent &primitive-descriptor primitive-write-thread-variable
     (handle :: <raw-pointer>, newval :: <object>) => (newval);
-  //---*** Fill this in...
+  let index = ins--ptrtoint(be, handle, be.%type-table["iWord"]);
+  let tlv-vector = op--tlv-vector(be, index);
+  call-primitive(be, primitive-vector-element-setter-descriptor,
+                 newval, tlv-vector, index)
 end;
 
 define side-effecting stateful dynamic-extent &c-primitive-descriptor primitive-initialize-current-thread

--- a/sources/dfmc/llvm-back-end/llvm-primitives.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-primitives.dylan
@@ -704,7 +704,7 @@ define macro runtime-variable-definer
            = make(<llvm-runtime-variable-descriptor>,
 		  name: ?#"name",
                   type-name: ?#"type-name",
-                  init-function: method() ?init end,
+                  init-function: method(?=be :: <llvm-back-end>) ?init end,
 		  attributes: #[?adjectives],
                   section: ?section);
          do-define-llvm-runtime-variable-descriptor
@@ -755,12 +755,16 @@ define method llvm-runtime-variable
 	     type: llvm-pointer-to(back-end, type),
 	     initializer:
 	       if (initialized?)
-		 let init-value = descriptor.runtime-variable-init-function();
-		 if (init-value)
-		   emit-reference(back-end, module, init-value)
-		 else
-		   make(<llvm-null-constant>, type: type)
-		 end if
+		 let init-value
+                   = descriptor.runtime-variable-init-function(back-end);
+                 select (init-value by instance?)
+                   singleton(#f) =>
+                     make(<llvm-null-constant>, type: type);
+                   <llvm-constant-value> =>
+                     init-value;
+                   otherwise =>
+                     emit-reference(back-end, module, init-value)
+		 end select
 	       end,
 	     constant?: #f,
 	     linkage: linkage,

--- a/sources/dfmc/llvm-back-end/llvm-primitives.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-primitives.dylan
@@ -745,7 +745,7 @@ define method llvm-runtime-variable
     let attributes = descriptor.runtime-variable-attributes;
     let thread-local?
       = member?(#"thread-local", attributes)
-      & llvm-thread-local-support?(back-end);
+      & llvm-runtime-thread-local-support?(back-end);
     let section
       = llvm-section-name(back-end, descriptor.runtime-variable-section,
                           thread-local?: thread-local?);

--- a/sources/dfmc/llvm-back-end/llvm-targets.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-targets.dylan
@@ -310,6 +310,12 @@ end method;
 
 /// LLVM Thread-local storage platform support
 
+define method llvm-runtime-thread-local-support?
+    (back-end :: <llvm-back-end>)
+ => (support? :: <boolean>)
+  #t
+end method;
+
 define method llvm-thread-local-support?
     (back-end :: <llvm-back-end>)
  => (support? :: <boolean>)

--- a/sources/dfmc/llvm-back-end/llvm-targets.dylan
+++ b/sources/dfmc/llvm-back-end/llvm-targets.dylan
@@ -319,7 +319,7 @@ end method;
 define method llvm-thread-local-support?
     (back-end :: <llvm-back-end>)
  => (support? :: <boolean>)
-  #t
+  #f
 end method;
 
 define method llvm-thread-local-support?

--- a/sources/lib/run-time/llvm-posix-threads.c
+++ b/sources/lib/run-time/llvm-posix-threads.c
@@ -18,7 +18,7 @@
 #  include <gc/gc.h>
 #endif
 
-#define USE_NATIVE_TLV
+//#define USE_NATIVE_TLV
 
 /* Error codes returned by the primitives. These correspond to the codes
  *  defined in dylan/return-codes.dylan


### PR DESCRIPTION
The initial implementation of thread-local variables in the LLVM back-end made use of the platform-native thread-local storage facilities provided by Linux, FreeBSD, and macOS. This requires that every block of Dylan-defined thread-local variables needs to be registered with the garbage collector as GC roots. For the debugger, it also requires a high level of support for access to thread-local storage.

These changes modify the LLVM back-end and associated run-time routines to use a variant of the original HARP scheme for thread-local variables, namely a `<simple-object-vector>` stored in the Dylan Thread Environment Block accessed using dynamically-assigned vector indices. This has the advantages that only one GC root per thread, the TEB itself, needs to be a GC root. It also simplifies the interface used by the debugger and interactor, which now uses the `dylan_teb` run-time routine to gain access to all of the thread-local variables.
