### PR TITLE
Fix socket shutdown bug

### DIFF
--- a/sources/network/sockets/abstract-sockets.dylan
+++ b/sources/network/sockets/abstract-sockets.dylan
@@ -140,7 +140,7 @@ end method;
 define method close-all-sockets (manager :: <socket-manager>) => ()
   let sockets
     = with-lock (socket-manager-lock(manager))
-        map-as(<vector>, identity, socket-manager-sockets(manager))
+        key-sequence(socket-manager-sockets(manager))
       end;
   block (exit-loop)
     for (socket in sockets)
@@ -159,7 +159,7 @@ end method;
 define method shutdown-all-sockets (manager :: <socket-manager>) => ()
   let sockets
     = with-lock (socket-manager-lock(manager))
-        map-as(<vector>, identity, socket-manager-sockets(manager))
+        key-sequence(socket-manager-sockets(manager))
       end;
   block (exit-loop)
     for (socket in sockets)


### PR DESCRIPTION
```
  Test test-repeated-start-stop-with-connection: PASSED in 5.058714s and 1012KiB
Cannot add an element with key {<byte-char-tcp-socket>} to a sequence of type {<class>: <vector>}
Backtrace:
  error:dylan:dylan##0 + 0x2a
  convert-accumulator-as:internal:dylan##2 + 0x333
  map-as-one:internal:dylan##6 + 0x1cb
  shutdown-all-sockets:sockets-internals:network##0 + 0x198
  stop-sockets:sockets-internals:network + 0x29
  ...
  exit-application:common-extensions:common-dylan + 0xa
  run-test-application:testworks:testworks + 0x458
```

See https://github.com/dylan-lang/opendylan/issues/1743#issuecomment-3332322941

I don't think this needs a release note because it just fixes a problem that was created after the most recent release.