### PR TITLE
dfmc-conversion: Minor fix to "Missing init keyword" error message

### DIFF
--- a/sources/dfmc/conversion/define-class.dylan
+++ b/sources/dfmc/conversion/define-class.dylan
@@ -595,7 +595,7 @@ define method compute-slot-initialization-code
             #{ ?keyword ?name = ?init }
           elseif (^init-keyword-required?(slotd))
             with-expansion-source-form (model-definition(slotd))
-              #{ ?keyword ?name = error("Missing init keyword \"%=:\"", ?keyword) }
+              #{ ?keyword ?name = error("Missing init keyword \"%s:\"", ?keyword) }
             end
           else
             #{ ?keyword ?name = ?$unbound }


### PR DESCRIPTION
Old: Missing init keyword "#"descriptor":"
New: Missing init keyword "descriptor:"