### PR TITLE
Too few parameters to printf in ffi_no_result test function

### DIFF
--- a/sources/lib/c-ffi/test/main.c
+++ b/sources/lib/c-ffi/test/main.c
@@ -35,7 +35,7 @@ void simplest_foreign_function()
 
 void ffi_no_result(unsigned short i)
 {
-  printf("calling ffi_no_result %d\n");
+  printf("calling ffi_no_result %d\n", i);
 }
 
 unsigned short ffi_no_parameters()


### PR DESCRIPTION
Format for printf expects 1 arguments but given 0