### PR TITLE
ci: remove automated Sphinx link check workflow

### DIFF
--- a/.github/workflows/build-deploy-documentation.yml
+++ b/.github/workflows/build-deploy-documentation.yml
@@ -25,13 +25,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Check links
-        uses: addnab/docker-run-action@v3
-        with:
-          image: ghcr.io/fraya/dylan-docs
-          options: -v ${{ github.workspace }}/documentation:/docs
-          run: make linkcheck
-
       - name: Build documentation
         uses: addnab/docker-run-action@v3
         with:

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -30,14 +30,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Check links
-        uses: addnab/docker-run-action@v3
-        continue-on-error: true
-        with:
-          image: ghcr.io/fraya/dylan-docs
-          options: -v ${{ github.workspace }}/documentation:/docs
-          run: SPHINXOPTS='--quiet' make linkcheck
-
       - name: Build documentation
         uses: addnab/docker-run-action@v3
         with:


### PR DESCRIPTION
This commit removes the linkcheck step from the CI workflow due to persistent false positives and non-deterministic failures.

Investigation suggests the failures stem from two main issues:

- Bot Mitigation: Automated requests from GitHub Actions runners are being throttled or blocked by host servers (likely via 403/429 errors or JS challenges).

- SSL Verification Issues: Recurrent SSLError: CERTIFICATE_VERIFY_FAILED errors, potentially caused by network latency or environment-specific certificate store limitations.

While SSL verification could be bypassed, it would not resolve the bot-blocking issues. To ensure a stable and predictable CI pipeline, link validation is now shifted to a manual developer task during the documentation review process.