### PR TITLE
ci: Migrate docker-run-action

### DIFF
--- a/.github/workflows/build-deploy-documentation.yml
+++ b/.github/workflows/build-deploy-documentation.yml
@@ -26,7 +26,7 @@ jobs:
           submodules: recursive
 
       - name: Build documentation
-        uses: addnab/docker-run-action@v3
+        uses: maus007/docker-run-action-fork@v1
         with:
           image: ghcr.io/fraya/dylan-docs
           options: -v ${{ github.workspace }}/documentation:/docs

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -31,7 +31,7 @@ jobs:
           submodules: recursive
 
       - name: Build documentation
-        uses: addnab/docker-run-action@v3
+        uses: maus007/docker-run-action-fork@v1
         with:
           image: ghcr.io/fraya/dylan-docs
           options: -v ${{ github.workspace }}/documentation:/docs


### PR DESCRIPTION
The 'addnab/docker-run-action' repository seems abandoned and the GH Actions building documentation are failing. It is proposed to migrate to the fork 'maus007/docker-run-action-fork'.