### PR TITLE
build-system: Export build-root-directory-name

### DIFF
--- a/sources/lib/build-system/build.dylan
+++ b/sources/lib/build-system/build.dylan
@@ -11,6 +11,14 @@ define constant $build-log-file = "build.log";
 define constant $platform-variable = "OPEN_DYLAN_TARGET_PLATFORM";
 define constant $default-platform = $platform-name;
 
+define function build-root-directory-name () => (name :: <string>)
+  if ($os-name == #"win32")
+    "Open-Dylan"
+  else
+    "_build"
+  end
+end function;
+
 define function target-platform-name ()
  => (platform-name :: <symbol>)
   as(<symbol>, environment-variable($platform-variable) | $default-platform)

--- a/sources/lib/build-system/library.dylan
+++ b/sources/lib/build-system/library.dylan
@@ -44,6 +44,7 @@ define module build-system
     build-system-variable,
 
     $build-system-makefile-name,
+    build-root-directory-name,
 
     target-platform-name,
 

--- a/sources/lib/build-system/paths.dylan
+++ b/sources/lib/build-system/paths.dylan
@@ -140,8 +140,10 @@ define function user-root-path()
           as(<directory-locator>, appdata);
         end;
       end;
-    subdirectory-locator(path | home-directory() | temp-directory(), "Open-Dylan")
+    subdirectory-locator(path | home-directory() | temp-directory(),
+                         build-root-directory-name())
   else
-    subdirectory-locator(working-directory(), "_build")
+    subdirectory-locator(working-directory(),
+                         build-root-directory-name())
   end
 end;


### PR DESCRIPTION
External programs need to know where the compiler puts build products and shouldn't assume "_build".

You might think Deft could use `user-root-path` but it specifically needs to deal with the case where the build root is in a workspace directory so it can skip scanning that directory.  Even if `user-root-path` is currently pointing somewhere outside the workspace we want to avoid scanning "_build" or "Open-Dylan", because that value can change across builds and a _build directory may have already been created in the workspace.

In other words, `OPEN_DYLAN_USER_ROOT` should not be trusted for Deft's purposes.  I guess Deft could remove that from the environment temporarily while it calls `user-root-path`, but that's a little unsavory.