### PR TITLE
dfmc-typist: fix DFM output of strings

### DIFF
--- a/sources/dfmc/typist/typist-types.dylan
+++ b/sources/dfmc/typist/typist-types.dylan
@@ -585,7 +585,14 @@ end;
 
 define method print-type-estimate-internals
     (teli :: <type-estimate-limited-instance>, #key stream) => ()
-  format(stream, "singleton(%s)", type-estimate-debug-name(type-estimate-singleton(teli)))
+  let singleton = type-estimate-singleton(teli);
+  if (instance?(singleton, <string>))
+    // Output quotes and prevent printing line breaks for strings.
+    // Should we limit the length?
+    format(stream, "singleton(%=)", singleton)
+  else
+    format(stream, "singleton(%s)", type-estimate-debug-name(singleton))
+  end
 end;
 
 ///


### PR DESCRIPTION
Just a small thing I noticed in the DFM.  Maybe adding a method on `type-estimate-debug-name` would be more proper but it seemed a bit silly to print a string to a string with `%=` and then print that string with `%s`.

```diff
--- /tmp/foop-before.dfm	2026-04-28 10:26:01
+++ /tmp/foop-after.dfm	2026-04-28 10:23:53
@@ -54,8 +54,7 @@
   *t2(0) := [CONGRUENT-CALLi ^{<&method> format-out (<string>)}(^"%=\n", Vt3)] // tail call @foop.dylan:27
   | ^{<&method> format-out (<string>)} :: singleton({<&method> format-out (format-string :: <string>, #next next-method, #rest args) => ()})
   | ^%=
- :: singleton(%=
-)
+ :: singleton("%=\n")
   \ *t2(0) :: values()
   return *t2(0) @foop.dylan:27
 END
```