### PR TITLE
Improve thread safety and date functionality in the system library

### DIFF
--- a/documentation/source/release-notes/2026.2.rst
+++ b/documentation/source/release-notes/2026.2.rst
@@ -57,6 +57,16 @@ System
   :class:`<file-system-error>` if the target file exists and ``if-exists: #"signal"`` (the
   default) is used.
 
+* On Unix platforms, the :gf:`current-date` function now returns
+  :class:`<date>` objects providing microsecond precision. Similarly,
+  the :gf:`current-timestamp` function now properly reflects
+  millisecond precision.
+
+* Several functions in the :lib:`system` library were previously
+  implemented on Unix platforms using C library routines that used
+  static storage, potentially compromising thread safety. These have
+  been replaced with thread-safe alternatives.
+
 Submoduled Library Updates
 ==========================
 

--- a/sources/io/unix-interface.dylan
+++ b/sources/io/unix-interface.dylan
@@ -117,16 +117,24 @@ define function unix-isatty
   (res == 1)
 end function unix-isatty;
 
-define function get-unix-error (errno :: <integer>) => (message :: <string>)
-  let message :: <byte-string>
-    = primitive-raw-as-string
-       (%call-c-function ("strerror")
-            (errno :: <raw-c-signed-int>) => (message :: <raw-byte-string>)
-          (integer-as-raw(errno))
-        end);
-  // Make a copy to avoid it being overwritten ...
-  copy-sequence(message)
-end function get-unix-error;
+define function unix-error-message
+    (errno :: <integer>)
+ => (message :: <string>)
+  let message-size = 256;
+  with-stack-byte-storage (message-storage, message-size)
+    primitive-raw-as-string
+      (%call-c-function ("io_strerror")
+           (errno :: <raw-c-signed-int>,
+            buffer :: <raw-byte-string>,
+            size :: <raw-c-unsigned-int>)
+        => (message :: <raw-byte-string>)
+         (integer-as-raw(errno),
+          primitive-cast-raw-as-pointer
+            (primitive-unwrap-machine-word(message-storage)),
+          integer-as-raw(message-size))
+       end)
+  end with-stack-byte-storage
+end function unix-error-message;
 
 
 /// HIGHER LEVEL INTERFACE
@@ -134,7 +142,7 @@ end function get-unix-error;
 define function unix-error
     (syscall :: <string>, #key errno = #f)
  => (does-not-return :: <bottom>);
-  let message :: <string> = get-unix-error (errno | unix-errno());
+  let message :: <string> = unix-error-message(errno | unix-errno());
   error("%s: %s", syscall, message);
 end function unix-error;
 

--- a/sources/io/unix-portability.c
+++ b/sources/io/unix-portability.c
@@ -1,11 +1,26 @@
+#define _XOPEN_SOURCE 600L
+
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <string.h>
 
 int io_errno(void)
 {
   return errno;
+}
+
+char *io_strerror(int errnum, char *buffer, size_t size)
+{
+#if defined(__GLIBC__) && defined(_GNU_SOURCE)
+  // GNU-specific
+  return strerror_r(errnum, buffer, size);
+#else
+  // POSIX/XSI standard
+  strerror_r(errnum, buffer, size);
+  return buffer;
+#endif
 }
 
 long io_lseek (int fd, long offset, int whence) {

--- a/sources/system/aarch64-darwin-magic-numbers.dylan
+++ b/sources/system/aarch64-darwin-magic-numbers.dylan
@@ -16,12 +16,15 @@ define constant $st-mode-offset :: <integer> = 4;
 define constant $st-uid-offset :: <integer> = 16;
 define constant $st-gid-offset :: <integer> = 20;
 define constant $st-size-offset :: <integer> = 96;
-define constant $st-atime-offset :: <integer> = 32;
-define constant $st-mtime-offset :: <integer> = 48;
-define constant $st-ctime-offset :: <integer> = 64;
+define constant $st-atim-offset :: <integer> = 32;
+define constant $st-mtim-offset :: <integer> = 48;
+define constant $st-ctim-offset :: <integer> = 64;
 
-define constant $gr-name-offset :: <integer> = 0;
+define constant $timespec-size :: <integer> = 16;
+define constant $tv-sec-offset :: <integer> = 0;
+define constant $tv-nsec-offset :: <integer> = 8;
 
+define constant $tm-size :: <integer> = 56;
 define constant $tm-sec-offset :: <integer> = 0;
 define constant $tm-min-offset :: <integer> = 4;
 define constant $tm-hour-offset :: <integer> = 8;

--- a/sources/system/aarch64-linux-magic-numbers.dylan
+++ b/sources/system/aarch64-linux-magic-numbers.dylan
@@ -16,12 +16,15 @@ define constant $st-mode-offset :: <integer> = 16;
 define constant $st-uid-offset :: <integer> = 24;
 define constant $st-gid-offset :: <integer> = 28;
 define constant $st-size-offset :: <integer> = 48;
-define constant $st-atime-offset :: <integer> = 72;
-define constant $st-mtime-offset :: <integer> = 88;
-define constant $st-ctime-offset :: <integer> = 104;
+define constant $st-atim-offset :: <integer> = 72;
+define constant $st-mtim-offset :: <integer> = 88;
+define constant $st-ctim-offset :: <integer> = 104;
 
-define constant $gr-name-offset :: <integer> = 0;
+define constant $timespec-size :: <integer> = 16;
+define constant $tv-sec-offset :: <integer> = 0;
+define constant $tv-nsec-offset :: <integer> = 8;
 
+define constant $tm-size :: <integer> = 56;
 define constant $tm-sec-offset :: <integer> = 0;
 define constant $tm-min-offset :: <integer> = 4;
 define constant $tm-hour-offset :: <integer> = 8;

--- a/sources/system/date.dylan
+++ b/sources/system/date.dylan
@@ -44,6 +44,8 @@ define method make (class == <date>, #rest init-keywords,
   if (iso8601-string)
     parse-iso8601-string(iso8601-string)
   elseif (native-clock)
+    // native-clock is a <machine-word> representing a pointer to a
+    // struct timespec on Unix, or to a FILETIME structure (Windows)
     encode-native-clock-as-date(native-clock)
   else
     next-method()

--- a/sources/system/dump-magic-numbers.c
+++ b/sources/system/dump-magic-numbers.c
@@ -1,3 +1,7 @@
+#ifdef __APPLE__
+#define _DARWIN_C_SOURCE
+#endif
+
 #include <limits.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -5,8 +9,6 @@
 /* TARGET HEADERS */
 #include <errno.h>
 #include <dirent.h>
-#include <pwd.h>
-#include <grp.h>
 #include <time.h>
 #include <sys/stat.h>
 
@@ -41,14 +43,23 @@ main(void) {
     PRINT_OFFSETOF(struct stat, st_uid,  "$st-uid-offset");
     PRINT_OFFSETOF(struct stat, st_gid,  "$st-gid-offset");
     PRINT_OFFSETOF(struct stat, st_size, "$st-size-offset");
-    PRINT_OFFSETOF(struct stat, st_atime, "$st-atime-offset");
-    PRINT_OFFSETOF(struct stat, st_mtime, "$st-mtime-offset");
-    PRINT_OFFSETOF(struct stat, st_ctime, "$st-ctime-offset");
+#if defined(_DARWIN_C_SOURCE)
+    PRINT_OFFSETOF(struct stat, st_atimespec, "$st-atim-offset");
+    PRINT_OFFSETOF(struct stat, st_mtimespec, "$st-mtim-offset");
+    PRINT_OFFSETOF(struct stat, st_ctimespec, "$st-ctim-offset");
+#else
+    PRINT_OFFSETOF(struct stat, st_atim, "$st-atim-offset");
+    PRINT_OFFSETOF(struct stat, st_mtim, "$st-mtim-offset");
+    PRINT_OFFSETOF(struct stat, st_ctim, "$st-ctim-offset");
+#endif
 
     printf("\n");
-    PRINT_OFFSETOF(struct group, gr_name, "$gr-name-offset");
+    PRINT_SIZEOF(struct timespec, "$timespec-size");
+    PRINT_OFFSETOF(struct timespec, tv_sec, "$tv-sec-offset");
+    PRINT_OFFSETOF(struct timespec, tv_nsec, "$tv-nsec-offset");
 
     printf("\n");
+    PRINT_SIZEOF(struct tm, "$tm-size");
     PRINT_OFFSETOF(struct tm, tm_sec,    "$tm-sec-offset");
     PRINT_OFFSETOF(struct tm, tm_min,    "$tm-min-offset");
     PRINT_OFFSETOF(struct tm, tm_hour,   "$tm-hour-offset");

--- a/sources/system/file-system/unix-ffi.dylan
+++ b/sources/system/file-system/unix-ffi.dylan
@@ -92,13 +92,6 @@ define inline-only function st-ctime (st :: <machine-word>) => (ctime :: <abstra
 end function st-ctime;
 
 
-define inline-only function group-name (group :: <machine-word>) => (name :: <byte-string>)
-  primitive-raw-as-string
-    (primitive-c-pointer-at(primitive-unwrap-machine-word(group),
-                            integer-as-raw($gr-name-offset),
-                            integer-as-raw(0)))
-end function group-name;
-
 
 define inline-only function dirent-name (dirent :: <machine-word>) => (name :: <byte-string>)
   primitive-raw-as-string

--- a/sources/system/file-system/unix-ffi.dylan
+++ b/sources/system/file-system/unix-ffi.dylan
@@ -116,21 +116,29 @@ define function unix-errno () => (errno :: <integer>)
     (%call-c-function("io_errno") ()=>(result :: <raw-c-signed-int>)() end)
 end function;
 
-define function unix-last-error-message () => (message :: <string>)
-  let message :: <byte-string>
-    = primitive-raw-as-string
-       (%call-c-function ("strerror")
-            (errno :: <raw-c-signed-int>) => (message :: <raw-byte-string>)
-          (integer-as-raw(unix-errno()))
-        end);
-  // Make a copy to avoid it being overwritten ...
-  copy-sequence(message)
-end function unix-last-error-message;
+define function unix-error-message
+    (errno :: <integer>)
+ => (message :: <string>)
+  let message-size = 256;
+  with-stack-byte-storage (message-storage, message-size)
+    primitive-raw-as-string
+      (%call-c-function ("io_strerror")
+           (errno :: <raw-c-signed-int>,
+            buffer :: <raw-byte-string>,
+            size :: <raw-c-unsigned-int>)
+        => (message :: <raw-byte-string>)
+         (integer-as-raw(errno),
+          primitive-cast-raw-as-pointer
+            (primitive-unwrap-machine-word(message-storage)),
+          integer-as-raw(message-size))
+       end)
+  end with-stack-byte-storage
+end function unix-error-message;
 
 define function unix-file-error
     (operation :: <string>, additional-information, #rest additional-information-args)
  => (will-never-return :: <bottom>)
-  let status-message = unix-last-error-message();
+  let status-message = unix-error-message(unix-errno());
   if (additional-information)
     error(make(<file-system-error>,
                format-string: concatenate("%s: Can't %s ", additional-information),

--- a/sources/system/file-system/unix-ffi.dylan
+++ b/sources/system/file-system/unix-ffi.dylan
@@ -70,27 +70,17 @@ define inline-only function st-size (st :: <machine-word>) => (size :: <abstract
                               integer-as-raw($st-size-offset)))
 end function st-size;
 
-define inline-only function st-atime (st :: <machine-word>) => (atime :: <abstract-integer>)
-  raw-as-abstract-integer
-  (primitive-c-signed-long-at(primitive-unwrap-machine-word(st),
-                              integer-as-raw(0),
-                              integer-as-raw($st-atime-offset)))
-end function st-atime;
+define inline-only function st-atim-addr (st :: <machine-word>) => (atim-addr :: <machine-word>)
+  u%+(st, $st-atim-offset)
+end function st-atim-addr;
 
-define inline-only function st-mtime (st :: <machine-word>) => (mtime :: <abstract-integer>)
-  raw-as-abstract-integer
-  (primitive-c-signed-long-at(primitive-unwrap-machine-word(st),
-                              integer-as-raw(0),
-                              integer-as-raw($st-mtime-offset)))
-end function st-mtime;
+define inline-only function st-mtim-addr (st :: <machine-word>) => (mtim-addr :: <machine-word>)
+  u%+(st, $st-mtim-offset)
+end function st-mtim-addr;
 
-define inline-only function st-ctime (st :: <machine-word>) => (ctime :: <abstract-integer>)
-  raw-as-abstract-integer
-  (primitive-c-signed-long-at(primitive-unwrap-machine-word(st),
-                              integer-as-raw(0),
-                              integer-as-raw($st-ctime-offset)))
-end function st-ctime;
-
+define inline-only function st-ctim-addr (st :: <machine-word>) => (ctim-addr :: <machine-word>)
+  u%+(st, $st-ctim-offset)
+end function st-ctim-addr;
 
 
 define inline-only function dirent-name (dirent :: <machine-word>) => (name :: <byte-string>)

--- a/sources/system/file-system/unix-file-system.dylan
+++ b/sources/system/file-system/unix-file-system.dylan
@@ -349,9 +349,12 @@ define function %file-properties
       unix-file-error("get attributes of", "%s", file)
     else
       properties[#"size"] := st-size(st);
-      properties[#"creation-date"] := make(<date>, native-clock: st-ctime(st));
-      properties[#"access-date"] := make(<date>, native-clock: st-atime(st));
-      properties[#"modification-date"] := make(<date>, native-clock: st-mtime(st))
+      properties[#"creation-date"]
+        := make(<date>, native-clock: st-ctim-addr(st));
+      properties[#"access-date"]
+        := make(<date>, native-clock: st-atim-addr(st));
+      properties[#"modification-date"]
+        := make(<date>, native-clock: st-mtim-addr(st))
     end
   end;
   properties[#"author"] := %file-property(file, #"author");
@@ -443,7 +446,7 @@ define method %file-property
            end))
       unix-file-error("get the creation date of", "%s", file)
     else
-      make(<date>, native-clock: st-ctime(st))
+      make(<date>, native-clock: st-ctim-addr(st))
     end
   end
 end method %file-property;
@@ -460,7 +463,7 @@ define method %file-property
            end))
       unix-file-error("get the access date of", "%s", file)
     else
-      make(<date>, native-clock: st-atime(st))
+      make(<date>, native-clock: st-atim-addr(st))
     end
   end
 end method %file-property;
@@ -477,7 +480,7 @@ define method %file-property
            end))
       unix-file-error("get the modification date of", "%s", file)
     else
-      make(<date>, native-clock: st-mtime(st))
+      make(<date>, native-clock: st-mtim-addr(st))
     end
   end
 end method %file-property;

--- a/sources/system/library.dylan
+++ b/sources/system/library.dylan
@@ -339,6 +339,7 @@ define module system-internals
   use common-dylan;
   use dylan-extensions;
   use byte-storage;
+  use machine-words;
   use dylan-direct-c-ffi;
   use threads;
   use format;

--- a/sources/system/unix-date-interface.dylan
+++ b/sources/system/unix-date-interface.dylan
@@ -9,160 +9,142 @@ Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
 
 /// Used instead of define C-struct to avoid relying on the C-FFI library ...
 
-define inline-only function tm-seconds (tm :: <machine-word>) => (seconds :: <integer>)
-  raw-as-integer
-    (primitive-c-signed-int-at(primitive-unwrap-machine-word(tm),
-                               integer-as-raw(0),
-                               integer-as-raw($tm-sec-offset)))
-end function tm-seconds;
+define macro tm-getter-definer
+  { define tm-getter ?:name (?c-type:name) }
+    => { define inline-only function ?name (tm :: <machine-word>) => (value :: <integer>)
+           raw-as-integer
+             ("primitive-c-" ## ?c-type ## "-at"
+                (primitive-unwrap-machine-word(tm),
+                 integer-as-raw(0), integer-as-raw("$" ## ?name ## "-offset")))
+         end function }
+end macro;
 
-define inline-only function tm-minutes (tm :: <machine-word>) => (minutes :: <integer>)
-  raw-as-integer
-    (primitive-c-signed-int-at(primitive-unwrap-machine-word(tm),
-                               integer-as-raw(0),
-                               integer-as-raw($tm-min-offset)))
-end function tm-minutes;
+define tm-getter tm-sec (signed-int);   // seconds (0 - 60)
+define tm-getter tm-min (signed-int);   // minutes (0 - 59)
+define tm-getter tm-hour (signed-int);  // hours (0 - 23)
+define tm-getter tm-mday (signed-int);  // day of month (1 - 31)
+define tm-getter tm-mon (signed-int);   // month of year (0 - 11)
+define tm-getter tm-year (signed-int);  // year - 1900
+//define tm-getter tm-wday (signed-int);  // day of week (Sunday = 0)
+//define tm-getter tm-yday (signed-int);  // day of year (0 - 365)
+define tm-getter tm-isdst (signed-int); // is summer time in effect?
+define tm-getter tm-gmtoff (signed-long); // offset from UTC in seconds
 
-define inline-only function tm-hours (tm :: <machine-word>) => (hours :: <integer>)
-  raw-as-integer
-    (primitive-c-signed-int-at(primitive-unwrap-machine-word(tm),
-                               integer-as-raw(0),
-                               integer-as-raw($tm-hour-offset)))
-end function tm-hours;
-
-define inline-only function tm-day (tm :: <machine-word>) => (day :: <integer>)
-  raw-as-integer
-    (primitive-c-signed-int-at(primitive-unwrap-machine-word(tm),
-                               integer-as-raw(0),
-                               integer-as-raw($tm-mday-offset)))
-end function tm-day;
-
-define inline-only function tm-month (tm :: <machine-word>) => (month :: <integer>)
-  1                                // UNIX returns a zero-based month (ugh)
-  + raw-as-integer
-      (primitive-c-signed-int-at(primitive-unwrap-machine-word(tm),
-                                 integer-as-raw(0),
-                                 integer-as-raw($tm-mon-offset)))
-end function tm-month;
-
-define inline-only function tm-year (tm :: <machine-word>) => (year :: <integer>)
-  1900                                // UNIX returns years since 1900
-  + raw-as-integer
-      (primitive-c-signed-int-at(primitive-unwrap-machine-word(tm),
-                                 integer-as-raw(0),
-                                 integer-as-raw($tm-year-offset)))
-end function tm-year;
-
-define inline-only function tm-dst? (tm :: <machine-word>) => (dst? :: <boolean>)
-  primitive-raw-as-boolean
-    (primitive-c-signed-int-at(primitive-unwrap-machine-word(tm),
-                               integer-as-raw(0),
-                               integer-as-raw($tm-isdst-offset)))
-end function tm-dst?;
-
-define inline-only function tm-tz-offset (tm :: <machine-word>) => (tz-offset :: <integer>)
-  truncate/(raw-as-integer
-              (primitive-c-signed-long-at(primitive-unwrap-machine-word(tm),
-                                          integer-as-raw(0),
-                                          integer-as-raw($tm-gmtoff-offset))),
-            60)                        // UNIX returns time zone offset in seconds
-end function tm-tz-offset;
-
-define inline-only function tm-tz-name (tm :: <machine-word>) => (tz-name :: <byte-string>)
+define inline-only function tm-tz-name (tm :: <machine-word>) => (tz-name :: <string>)
   primitive-raw-as-string
-  (primitive-c-pointer-at(primitive-unwrap-machine-word(tm),
-                          integer-as-raw(0),
-                          integer-as-raw($tm-zone-offset)))
+    (primitive-c-pointer-at(primitive-unwrap-machine-word(tm),
+                            integer-as-raw(0),
+                            integer-as-raw($tm-zone-offset)))
 end function tm-tz-name;
-
 
 ///
 
-define function read-clock () => (time :: <machine-word>)
-  let time = primitive-wrap-machine-word
-               (%call-c-function ("time")
-                    (timeloc :: <raw-c-pointer>) => (time :: <raw-c-signed-int>)
-                  (primitive-cast-raw-as-pointer(integer-as-raw(0)))
-                end);
-  if (primitive-machine-word-equal?(primitive-unwrap-machine-word(time),
-                                    integer-as-raw(-1)))
-    error("Can't get time of day")
+define function native-clock-to-tm
+    (native-clock :: <machine-word>, tm :: <machine-word>)
+  let tv-sec-addr = u%+(native-clock, $tv-sec-offset);
+  let tm-result
+    = primitive-wrap-machine-word
+        (primitive-cast-pointer-as-raw
+           (%call-c-function ("localtime_r")
+                (clock :: <raw-c-pointer>, tm :: <raw-c-pointer>)
+             => (tm :: <raw-c-pointer>)
+              (primitive-cast-raw-as-pointer
+                 (primitive-unwrap-machine-word(tv-sec-addr)),
+               primitive-cast-raw-as-pointer
+                 (primitive-unwrap-machine-word(tm)))
+           end));
+  if (primitive-machine-word-equal?
+        (primitive-unwrap-machine-word(tm-result), integer-as-raw(0)))
+    error("Can't decode native clock value")
   end;
-  time
-end function read-clock;
-
-define generic native-clock-to-tm (time) => (tm :: <machine-word>);
-
-define method native-clock-to-tm (time :: <abstract-integer>) => (tm :: <machine-word>)
-  native-clock-to-tm(primitive-wrap-machine-word(abstract-integer-as-raw(time)))
-end method native-clock-to-tm;
-
-/// UNIX strikes again!  The localtime function takes a pointer to the clock reading
-/// rather than the clock reading directly.  Unfortunately, there's no simple way to
-/// do that with our Dylan primitives.  So, we're forced to actually allocate a small
-/// block of storage, store the time therein, and then pass the block's address.  (Sigh)
-define method native-clock-to-tm (time :: <machine-word>) => (tm :: <machine-word>)
-  with-stack-byte-storage (timeloc, raw-as-integer(primitive-word-size()))
-    primitive-c-signed-long-at(primitive-unwrap-machine-word(timeloc),
-                               integer-as-raw(0),
-                               integer-as-raw(0))
-      := primitive-unwrap-machine-word(time);
-    let tm = primitive-wrap-machine-word
-               (primitive-cast-pointer-as-raw
-                  (%call-c-function ("localtime")
-                       (time :: <raw-c-pointer>) => (tm :: <raw-c-pointer>)
-                     (primitive-cast-raw-as-pointer(primitive-unwrap-machine-word(timeloc)))
-                   end));
-    if (primitive-machine-word-equal?(primitive-unwrap-machine-word(tm),
-                                      integer-as-raw(0)))
-      error("Can't decode native clock value")
-    end;
-    tm
-  end with-stack-byte-storage
-end method native-clock-to-tm;
+end function;
 
 define function encode-native-clock-as-date (native-clock) => (date :: <date>)
-  let tm = native-clock-to-tm(native-clock);
-  make(<date>, year: tm-year(tm),
-               month: tm-month(tm),
-               day: tm-day(tm),
-               hours: tm-hours(tm),
-               minutes: tm-minutes(tm),
-               seconds: tm-seconds(tm),
-               time-zone-offset: tm-tz-offset(tm))
+  let nsec
+    = raw-as-integer
+        (primitive-c-signed-long-at(primitive-unwrap-machine-word(native-clock),
+                                    integer-as-raw(0),
+                                    integer-as-raw($tv-nsec-offset)));
+  with-stack-byte-storage (tm, $tm-size)
+    native-clock-to-tm(native-clock, tm);
+    make(<date>,
+         year: 1900 + tm-year(tm),
+         month: 1 + tm-mon(tm),
+         day: tm-mday(tm),
+         hours: tm-hour(tm),
+         minutes: tm-min(tm),
+         seconds: tm-sec(tm),
+         microseconds: truncate/(nsec, 1000),
+         time-zone-offset: truncate/(tm-gmtoff(tm), 60))
+  end
 end function encode-native-clock-as-date;
 
+define function read-clock (timespec :: <machine-word>)
+  let rc
+    = raw-as-integer(%call-c-function ("system_clock_realtime")
+                         (clock-ptr :: <raw-c-pointer>)
+                      => (result :: <raw-c-signed-int>)
+                       (primitive-cast-raw-as-pointer
+                          (primitive-unwrap-machine-word(timespec)))
+                     end);
+  if (~zero?(rc))
+    error("clock read failed");
+  end if;
+end function;
+
 define function current-date () => (now :: <date>)
-  encode-native-clock-as-date(read-clock())
+  with-stack-byte-storage (timespec, $timespec-size)
+    read-clock(timespec);
+    encode-native-clock-as-date(timespec)
+  end
 end function current-date;
 
-/// UNIX strikes again!  The time-of-day clock is only accurate to seconds.  So, to
-/// avoid getting duplicate timestamps on successive calls, we'll add a counter to
-/// the timestamp that's incremented on each call (modulo 1000).  (Sigh!)
-define variable *ts-counter* :: <integer> = 0;
-
 define function current-timestamp () => (milliseconds :: <integer>, days :: <integer>)
-  let tm = native-clock-to-tm(read-clock());
-  let (ud, ut) = compute-universal-time(tm-year(tm), tm-month(tm), tm-day(tm),
-                                        tm-hours(tm), tm-minutes(tm), tm-seconds(tm),
-                                        tm-tz-offset(tm));
-  values(1000 * ut
-           + begin
-               let tsc = *ts-counter*;
-               *ts-counter* := modulo(*ts-counter* + 1, 1000);
-               tsc
-             end,
-         ud)
+  with-stack-byte-storage (timespec, $timespec-size)
+    read-clock(timespec);
+    let nsec
+      = raw-as-integer
+          (primitive-c-signed-long-at(primitive-unwrap-machine-word(timespec),
+                                      integer-as-raw(0),
+                                      integer-as-raw($tv-nsec-offset)));
+    with-stack-byte-storage (tm, $tm-size)
+      native-clock-to-tm(timespec, tm);
+      let (ud, ut)
+        = compute-universal-time(1900 + tm-year(tm),
+                                 1 + tm-mon(tm), tm-mday(tm),
+                                 tm-hour(tm), tm-min(tm), tm-sec(tm),
+                                 truncate/(tm-gmtoff(tm), 60));
+      values(1000 * ut + truncate/(nsec, 1_000_000), ud)
+    end
+  end
 end function current-timestamp;
 
 define function local-time-zone-offset () => (zone-offset :: <integer>)
-  tm-tz-offset(native-clock-to-tm(read-clock()))
+  with-stack-byte-storage (timespec, $timespec-size)
+    read-clock(timespec);
+    with-stack-byte-storage (tm, $tm-size)
+      native-clock-to-tm(timespec, tm);
+      truncate/(tm-gmtoff(tm), 60)
+    end
+  end
 end function local-time-zone-offset;
 
 define function local-time-zone-name () => (zone-name :: <string>)
-  tm-tz-name(native-clock-to-tm(read-clock()))
+  with-stack-byte-storage (timespec, $timespec-size)
+    read-clock(timespec);
+    with-stack-byte-storage (tm, $tm-size)
+      native-clock-to-tm(timespec, tm);
+      tm-tz-name(tm)
+    end
+  end
 end function local-time-zone-name;
 
 define function local-daylight-savings-time? () => (is-dst? :: <boolean>)
-  tm-dst?(native-clock-to-tm(read-clock()))
+  with-stack-byte-storage (timespec, $timespec-size)
+    read-clock(timespec);
+    with-stack-byte-storage (tm, $tm-size)
+      native-clock-to-tm(timespec, tm);
+      ~zero?(tm-isdst(tm))
+    end
+  end
 end function local-daylight-savings-time?;

--- a/sources/system/unix-operating-system.dylan
+++ b/sources/system/unix-operating-system.dylan
@@ -19,16 +19,24 @@ define function command-line-option-prefix
 end function command-line-option-prefix;
 
 define function login-name () => (name :: false-or(<string>))
-  let value = primitive-wrap-machine-word
-                (primitive-cast-pointer-as-raw
-                   (%call-c-function ("getlogin") () => (name :: <raw-byte-string>) () end));
-  if (primitive-machine-word-not-equal?(primitive-unwrap-machine-word(value),
-                                        integer-as-raw(0)))
-    primitive-raw-as-string
-      (primitive-cast-raw-as-pointer(primitive-unwrap-machine-word(value)))
-  else
-    #f
-  end
+  let maxlogname = 255 + 1;
+  with-stack-byte-storage (name-storage, maxlogname)
+    let raw-name-storage
+      = primitive-cast-raw-as-pointer
+          (primitive-unwrap-machine-word(name-storage));
+    let result
+      = primitive-wrap-machine-word
+          (%call-c-function ("getlogin_r")
+               (name :: <raw-byte-string>, size :: <raw-c-unsigned-int>)
+            => (result :: <raw-c-signed-int>)
+             (raw-name-storage, integer-as-raw(maxlogname))
+           end);
+    if (zero?(result))
+      primitive-raw-as-string(raw-name-storage)
+    else
+      #f
+    end
+  end with-stack-byte-storage
 end function login-name;
 
 define function login-group () => (group :: false-or(<string>))

--- a/sources/system/unix-operating-system.dylan
+++ b/sources/system/unix-operating-system.dylan
@@ -40,19 +40,28 @@ define function login-name () => (name :: false-or(<string>))
 end function login-name;
 
 define function login-group () => (group :: false-or(<string>))
-  let group = primitive-wrap-machine-word
-                (%call-c-function ("getgid") () => (gid :: <raw-c-unsigned-int>) () end);
-  let value = primitive-wrap-machine-word
-                (primitive-cast-pointer-as-raw
-                   (%call-c-function ("getgrgid")
-                        (gid :: <raw-c-unsigned-int>) => (group :: <raw-c-pointer>)
-                      (primitive-unwrap-machine-word(group))
-                    end));
-  if (primitive-machine-word-not-equal?(primitive-unwrap-machine-word(value),
-                                        integer-as-raw(0)))
-    group-name(value)
-  else
-    #f
+  let raw-gid
+    = %call-c-function ("getgid") () => (gid :: <raw-c-unsigned-int>) () end;
+  let max-groupname-size = 256;
+  with-stack-byte-storage (groupname-storage, max-groupname-size)
+    let raw-name-storage
+      = primitive-cast-raw-as-pointer
+          (primitive-unwrap-machine-word(groupname-storage));
+    let result
+      = raw-as-integer
+          (%call-c-function ("system_group_name_from_gid")
+               (gid :: <raw-c-unsigned-int>,
+                name-buffer :: <raw-byte-string>,
+                name-buffer-size :: <raw-c-unsigned-int>)
+            => (status :: <raw-c-signed-int>)
+             (raw-gid, raw-name-storage,
+              integer-as-raw(max-groupname-size))
+           end);
+    if (zero?(result))
+      primitive-raw-as-string(raw-name-storage)
+    else
+      #f
+    end
   end
 end function login-group;
 

--- a/sources/system/unix-portability.c
+++ b/sources/system/unix-portability.c
@@ -201,9 +201,10 @@ int system_copy_file_range(int in_fd, int out_fd, off_t in_size)
 // Store the homedir associated with `username` into `homedir`. `homedir_size` is the
 // size of the `homedir` buffer. Returns 0 on success, -1 on failure.
 int system_user_homedir (const char* username, char* homedir, int homedir_size) {
-  int passwd_bufsize = 0;
+  long passwd_bufsize = 0;
   if ((passwd_bufsize = sysconf(_SC_GETPW_R_SIZE_MAX)) == -1) {
-    return -1;
+    // No hard limit, so pick a size
+    passwd_bufsize = 2048;
   }
   char buffer[passwd_bufsize];
   struct passwd pwd;
@@ -222,9 +223,10 @@ int system_user_homedir (const char* username, char* homedir, int homedir_size) 
 // Store the username associated with `uid` into `username`. `username_size` is the size
 // of the `username` buffer.  Returns 0 on success, -1 on failure.
 int system_passwd_username_from_uid (uid_t uid, char* username, int username_size) {
-  int passwd_bufsize = 0;
+  long passwd_bufsize = 0;
   if ((passwd_bufsize = sysconf(_SC_GETPW_R_SIZE_MAX)) == -1) {
-    return -1;
+    // No hard limit, so pick a size
+    passwd_bufsize = 2048;
   }
   char buffer[passwd_bufsize];
   struct passwd pwd;

--- a/sources/system/unix-portability.c
+++ b/sources/system/unix-portability.c
@@ -6,6 +6,7 @@
 #define _GNU_SOURCE
 #endif
 
+#include <time.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <signal.h>
@@ -45,6 +46,11 @@ int system_setenv(char *name, char *value, int overwrite)
 int system_unsetenv(const char *name)
 {
   return unsetenv(name);
+}
+
+int system_clock_realtime(struct timespec *tp)
+{
+  return clock_gettime(CLOCK_REALTIME, tp);
 }
 
 /* Adapted from the SBCL run-time system, which in turn is derived

--- a/sources/system/unix-portability.c
+++ b/sources/system/unix-portability.c
@@ -16,6 +16,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <pwd.h>
+#include <grp.h>
 #include <string.h>
 
 
@@ -239,5 +240,25 @@ int system_passwd_username_from_uid (uid_t uid, char* username, int username_siz
     return -1;
   }
   strncpy(username, pwd.pw_name, len);
+  return 0;
+}
+
+int system_group_name_from_gid (gid_t gid, char *name, int name_size) {
+  long group_bufsize = 0;
+  if ((group_bufsize = sysconf(_SC_GETGR_R_SIZE_MAX)) == -1) {
+    // No hard limit, so pick a size
+    group_bufsize = 2048;
+  }
+  char buffer[group_bufsize];
+  struct group group;
+  struct group *result = NULL;
+  if (getgrgid_r(gid, &group, buffer, group_bufsize, &result) < 0 || result == NULL) {
+    return -1;
+  }
+  size_t len = strlen(group.gr_name);
+  if (len >= name_size) {
+    return -1;
+  }
+  strcpy(name, group.gr_name);
   return 0;
 }

--- a/sources/system/x86_64-darwin-magic-numbers.dylan
+++ b/sources/system/x86_64-darwin-magic-numbers.dylan
@@ -16,12 +16,15 @@ define constant $st-mode-offset :: <integer> = 4;
 define constant $st-uid-offset :: <integer> = 16;
 define constant $st-gid-offset :: <integer> = 20;
 define constant $st-size-offset :: <integer> = 96;
-define constant $st-atime-offset :: <integer> = 32;
-define constant $st-mtime-offset :: <integer> = 48;
-define constant $st-ctime-offset :: <integer> = 64;
+define constant $st-atim-offset :: <integer> = 32;
+define constant $st-mtim-offset :: <integer> = 48;
+define constant $st-ctim-offset :: <integer> = 64;
 
-define constant $gr-name-offset :: <integer> = 0;
+define constant $timespec-size :: <integer> = 16;
+define constant $tv-sec-offset :: <integer> = 0;
+define constant $tv-nsec-offset :: <integer> = 8;
 
+define constant $tm-size :: <integer> = 56;
 define constant $tm-sec-offset :: <integer> = 0;
 define constant $tm-min-offset :: <integer> = 4;
 define constant $tm-hour-offset :: <integer> = 8;

--- a/sources/system/x86_64-freebsd-magic-numbers.dylan
+++ b/sources/system/x86_64-freebsd-magic-numbers.dylan
@@ -16,12 +16,15 @@ define constant $st-mode-offset :: <integer> = 24;
 define constant $st-uid-offset :: <integer> = 28;
 define constant $st-gid-offset :: <integer> = 32;
 define constant $st-size-offset :: <integer> = 112;
-define constant $st-atime-offset :: <integer> = 48;
-define constant $st-mtime-offset :: <integer> = 64;
-define constant $st-ctime-offset :: <integer> = 80;
+define constant $st-atim-offset :: <integer> = 48;
+define constant $st-mtim-offset :: <integer> = 64;
+define constant $st-ctim-offset :: <integer> = 80;
 
-define constant $gr-name-offset :: <integer> = 0;
+define constant $timespec-size :: <integer> = 16;
+define constant $tv-sec-offset :: <integer> = 0;
+define constant $tv-nsec-offset :: <integer> = 8;
 
+define constant $tm-size :: <integer> = 56;
 define constant $tm-sec-offset :: <integer> = 0;
 define constant $tm-min-offset :: <integer> = 4;
 define constant $tm-hour-offset :: <integer> = 8;

--- a/sources/system/x86_64-linux-magic-numbers.dylan
+++ b/sources/system/x86_64-linux-magic-numbers.dylan
@@ -16,12 +16,15 @@ define constant $st-mode-offset :: <integer> = 24;
 define constant $st-uid-offset :: <integer> = 28;
 define constant $st-gid-offset :: <integer> = 32;
 define constant $st-size-offset :: <integer> = 48;
-define constant $st-atime-offset :: <integer> = 72;
-define constant $st-mtime-offset :: <integer> = 88;
-define constant $st-ctime-offset :: <integer> = 104;
+define constant $st-atim-offset :: <integer> = 72;
+define constant $st-mtim-offset :: <integer> = 88;
+define constant $st-ctim-offset :: <integer> = 104;
 
-define constant $gr-name-offset :: <integer> = 0;
+define constant $timespec-size :: <integer> = 16;
+define constant $tv-sec-offset :: <integer> = 0;
+define constant $tv-nsec-offset :: <integer> = 8;
 
+define constant $tm-size :: <integer> = 56;
 define constant $tm-sec-offset :: <integer> = 0;
 define constant $tm-min-offset :: <integer> = 4;
 define constant $tm-hour-offset :: <integer> = 8;


### PR DESCRIPTION
These commits fix various thread safety issues in the system library and improve the precision of date retrieval.

Closes #381 

