### PR TITLE
Make the base-address project option obsolete

### DIFF
--- a/documentation/source/getting-started-ide/projects.rst
+++ b/documentation/source/getting-started-ide/projects.rst
@@ -685,10 +685,10 @@ of two modes: Interactive Development mode, and Production mode. See
 Link page
 ---------
 
-The **Project > Settings...** dialog's Link page controls whether a project
+The :menuselection:`Project --> Settings...` dialog's Link page controls whether a project
 is linked as an executable or as a DLL, and what its name will be. It
-also allows you to specify version information for the target, a base
-address for it, and the Windows subsystem it runs in.
+also allows you to specify version information for the target
+and the Windows subsystem it runs in.
 
 .. note:: The default linker used in Open Dylan is a GNU linker. If
    you own Microsoft Developer Studio, you can use the Microsoft linker
@@ -699,30 +699,16 @@ address for it, and the Windows subsystem it runs in.
 Target File section of the Link page
 ------------------------------------
 
-The **Project > Settings...** dialog's Link page has a Target File section
+The :menuselection:`Project --> Settings...` dialog's Link page has a Target File section
 that contains the name of the project target and the type of the target.
 The default target name is derived from the name of the project. Note
 that the name will always end in .EXE or .DLL according to the target
 type, regardless of any extension you give to the target's name.
 
-Base Address section of the Link page
--------------------------------------
-
-The **Project > Settings...** dialog's Link page has a Base Address section
-that allows you to specify a base address for your target file. This is
-the address at which the target will be loaded into memory.
-
-Windows 95, Windows 98, and Windows NT all provide a default base
-address, one for EXEs and one for DLLs, and will also relocate the
-target automatically if there is no room for it at that address. You can
-provide a value in the Base Address if you would like the target to be
-loaded at a particular location. The value should be specified in
-hexadecimal, using Dylan's *#x* prefix: for example, *#x1000000*.
-
 Version Information section of the Link page
 --------------------------------------------
 
-The **Project > Settings...** dialog's Link page has a Version Information
+The :menuselection:`Project --> Settings...` dialog's Link page has a Version Information
 section that allows you to add major and minor version numbers to a DLL
 or EXE. The values in this section are recorded in the DLL or EXE that
 the project builds. Open Dylan uses them at compile time and run

--- a/documentation/source/library-reference/lid.rst
+++ b/documentation/source/library-reference/lid.rst
@@ -415,25 +415,21 @@ LID keyword
 
     Base-Address: *address*
 
+.. deprecated:: 2026.2
+   Because Windows versions starting with Windows Vista and
+   Windows Server 2008 implement Address Space Layout Randomization for
+   improved security, providing an initial base address is no longer
+   useful.
+
 .. note:: This keyword is only used on Windows and is ignored on other
    platforms.
 
-Specifies the base address of the DLL built from this Dylan library. The
-*address* must be a hexadecimal value. For convenience, you can use
-either Dylan (``#xNNNNNNNN``) or C (``0xNNNNNNNN``) notations when
-specifying the address.
+This keyword specifies the base address of the Windows DLL built from
+this Dylan library. If provided, *address* must be a hexadecimal value. For
+convenience, you can use either Dylan (``#xNNNNNNNN``) or C
+(``0xNNNNNNNN``) notations when specifying the address.
 
 This base address is ignored when building a ``.EXE`` file.
-
-If this keyword is not specified, the compiler will compute a default
-base address for the library. However, it is possible for more than one
-library to end up with the same default base address. If an application
-uses any of these libraries, all but one of them will have to be
-relocated when the application starts. This process is automatic, but
-cuts down on the amount of sharing, increases your application's memory
-footprint, and slows down load time. In such circumstances, you may want
-to give one or more libraries an explicit base address using this
-keyword.
 
 Linker-Options:
 ^^^^^^^^^^^^^^^

--- a/documentation/source/release-notes/2026.2.rst
+++ b/documentation/source/release-notes/2026.2.rst
@@ -30,6 +30,12 @@ Compiler
   ABIs, and which improves performance in certain situations (such as
   dispatching methods with keyword arguments).
 
+* The ``base-address`` keyword in LID and HDP project files,
+  specifying a default load address for DLLs on Windows, has been
+  obsoleted. The :guilabel:`Base address` project link option in the
+  IDE has been removed, and the compiler will no longer attempt to
+  assign a base address automatically when projects are saved.
+
 Tools
 =====
 

--- a/sources/app/dylan-playground/dylan-playground.lid
+++ b/sources/app/dylan-playground/dylan-playground.lid
@@ -1,7 +1,6 @@
 Library:   dylan-playground
 Author:    Andy Armstrong
 Synopsis:  A Dylan application to play around in
-Base-Address:	  0x64FE0000
 Major-Version:    2
 Minor-Version:	  1
 Compilation-Mode: loose

--- a/sources/app/dylan-playground/gui-dylan-playground.lid
+++ b/sources/app/dylan-playground/gui-dylan-playground.lid
@@ -1,7 +1,6 @@
 Library:   gui-dylan-playground
 Author:    Andy Armstrong
 Synopsis:  A Dylan application to play around in
-Base-Address:	  0x64FE0000
 Linker-Options:	  $(guilflags)
 Major-Version:    2
 Minor-Version:	  1

--- a/sources/app/plonker/plonker.lid
+++ b/sources/app/plonker/plonker.lid
@@ -6,7 +6,6 @@ files:	library
 	keyboard-pane
 	frame
 	plonker
-base-address:	0x64FA0000
 start-function:	main
 linker-options:	$(guilflags)
 major-version:	2

--- a/sources/collections/collections-win32.lid
+++ b/sources/collections/collections-win32.lid
@@ -2,7 +2,6 @@ Library:      collections
 Synopsis:     Collection extensions library
 Author:       Andy Armstrong
 Executable:   DxCOLLNS
-Base-Address: 0x66CA0000
 Library-Pack: Core
 RC-Files:     version.rc
 LID:          collections.lid

--- a/sources/common-dylan/win32-common-dylan.lid
+++ b/sources/common-dylan/win32-common-dylan.lid
@@ -3,7 +3,6 @@ Module:       dylan-user
 Synopsis:     Common Dylan library definition
 Author:       Andy Armstrong
 Executable:   DxCMNDYL
-Base-Address: 0x66DC0000
 RC-Files:     version.rc
 Target-Type:  dll
 Files: library

--- a/sources/corba/demos/bank/bank-client/bank-client.hdp
+++ b/sources/corba/demos/bank/bank-client/bank-client.hdp
@@ -5,7 +5,6 @@ files:	library
 	module
 	bank-client
 	init-client
-base-address:	0x64FE0000
 debug-arguments:	-ORBname-service-file c:\temp\ns.ior -location-service:shared-file
 start-function:	
 linker-options:	$(guilflags)

--- a/sources/corba/demos/bank/bank-server/bank-server.hdp
+++ b/sources/corba/demos/bank/bank-server/bank-server.hdp
@@ -6,7 +6,6 @@ files:	library
 	bank-server
 	server-frame
 	init-server
-base-address:	0x64DE0000
 debug-arguments:	-ORBname-service-file c:\temp\ns.ior -location-service:shared-file
 linker-options:	$(guilflags)
 major-version:	2

--- a/sources/corba/demos/chat/client/chat-client.hdp
+++ b/sources/corba/demos/chat/client/chat-client.hdp
@@ -1,7 +1,6 @@
 comment:	This file is generated, please don't edit
 format-version:	2
 target-type:	executable
-base-address:	0x63F80000
 linker-options:	$(guilflags)
 start-function:	main
 major-version:	2

--- a/sources/corba/demos/chat/server/chat-server.hdp
+++ b/sources/corba/demos/chat/server/chat-server.hdp
@@ -1,7 +1,6 @@
 comment:	This file is generated, please don't edit
 format-version:	2
 target-type:	executable
-base-address:	0x63F80000
 linker-options:	$(guilflags)
 start-function:	main
 major-version:	2

--- a/sources/corba/demos/corba-hello-world/client/corba-hello-world-client.hdp
+++ b/sources/corba/demos/corba-hello-world/client/corba-hello-world-client.hdp
@@ -4,7 +4,6 @@ library:	corba-hello-world-client
 files:	library
 	module
 	corba-hello-world-client
-base-address:	0x63AC0000
 start-function:	main
 major-version:	2
 minor-version:	1

--- a/sources/corba/demos/corba-hello-world/server/corba-hello-world-server.hdp
+++ b/sources/corba/demos/corba-hello-world/server/corba-hello-world-server.hdp
@@ -4,7 +4,6 @@ library:	corba-hello-world-server
 files:	library
 	module
 	corba-hello-world-server
-base-address:	0x63AA0000
 start-function:	main
 major-version:	2
 minor-version:	1

--- a/sources/corba/demos/pente/corba-pente.hdp
+++ b/sources/corba/demos/pente/corba-pente.hdp
@@ -5,7 +5,6 @@ files:	library
 	module
 	board
 	start
-base-address:	0x63FE0000
 start-function:	play-pente
 linker-options:	$(guilflags)
 major-version:	2

--- a/sources/corba/orb/connections/orb-connections.hdp
+++ b/sources/corba/orb/connections/orb-connections.hdp
@@ -1,7 +1,6 @@
 comment:	This file is generated, please don't edit
 format-version:	2
 Library-Pack:   CORBA
-base-address:	0x63EE0000
 minor-version:	1
 files:	orb-connections-library
 	manager

--- a/sources/corba/orb/core/orb-core.hdp
+++ b/sources/corba/orb/core/orb-core.hdp
@@ -2,7 +2,6 @@ comment:	This file is generated, please don't edit
 format-version:	2
 target-type:	dll
 Library-Pack:   CORBA
-base-address:	0x63F40000
 files:	orb-core-library
 	args
 	orb

--- a/sources/corba/orb/dylan/corba-dylan.hdp
+++ b/sources/corba/orb/dylan/corba-dylan.hdp
@@ -3,7 +3,6 @@ format-version:	2
 library:	corba-dylan
 files:	corba-dylan-library
 	corba-dylan
-base-address:	0x64FE0000
 Library-Pack:   CORBA
 major-version:	2
 minor-version:	1

--- a/sources/corba/orb/iiop/orb-iiop.hdp
+++ b/sources/corba/orb/iiop/orb-iiop.hdp
@@ -2,7 +2,6 @@ comment:	This file is generated, please don't edit
 format-version:	2
 target-type:	dll
 Library-Pack:   CORBA
-base-address:	0x63F40000
 files:	orb-iiop-library
 	cdr-basic
 	cdr-constructed

--- a/sources/corba/orb/orb/win32-orb.hdp
+++ b/sources/corba/orb/orb/win32-orb.hdp
@@ -3,7 +3,6 @@ format-version:	2
 target-type:	dll
 Library-Pack:   CORBA
 RC-Files:       version.rc
-base-address:	0x64EC0000
 files:	orb-library
 major-version:	2
 minor-version:	1

--- a/sources/corba/orb/poa/orb-poa.hdp
+++ b/sources/corba/orb/poa/orb-poa.hdp
@@ -2,7 +2,6 @@ comment:	This file is generated, please don't edit
 format-version:	2
 target-type:	dll
 Library-Pack:   CORBA
-base-address:	0x63EC0000
 files:	orb-poa-library
 	poa
 	receiver

--- a/sources/corba/orb/protocols/corba/corba-protocol.hdp
+++ b/sources/corba/orb/protocols/corba/corba-protocol.hdp
@@ -13,7 +13,6 @@ files:	corba-protocol-library
 	exceptions
 	conditions
 subprojects:	../../dylan/corba-dylan.hdp
-base-address:	0x63D80000
 Library-Pack:   CORBA
 debug-arguments:	-debug
 major-version: 2

--- a/sources/corba/orb/protocols/portableserver/portableserver-protocol.hdp
+++ b/sources/corba/orb/protocols/portableserver/portableserver-protocol.hdp
@@ -6,7 +6,6 @@ files:	portableserver-protocol-library
 subprojects:	../../dylan/corba-dylan.hdp
 	../corba/corba-protocol.hdp
 Library-Pack:   CORBA
-base-address:	0x63FC0000
 major-version: 2
 minor-version: 1
 compilation-mode:	tight

--- a/sources/corba/orb/streams/orb-streams.hdp
+++ b/sources/corba/orb/streams/orb-streams.hdp
@@ -9,7 +9,6 @@ files:	orb-streams-library
 subprojects:	../utilities/orb-utilities.hdp
 	../dylan/corba-dylan.hdp
 Library-Pack:   CORBA
-base-address:	0x63FC0000
 major-version: 2
 minor-version: 1
 compilation-mode:	tight

--- a/sources/corba/orb/utilities/orb-utilities.hdp
+++ b/sources/corba/orb/utilities/orb-utilities.hdp
@@ -8,7 +8,6 @@ files:	orb-utilities-library
 	tickets
 subprojects:	../dylan/corba-dylan.hdp
 Library-Pack:   CORBA
-base-address:	0x63FE0000
 major-version: 2
 minor-version: 1
 compilation-mode:	tight

--- a/sources/corba/scepter/abstract-syntax-tree/scepter-ast.hdp
+++ b/sources/corba/scepter/abstract-syntax-tree/scepter-ast.hdp
@@ -33,7 +33,6 @@ files:	scepter-ast-library
 	root
 	error
 subprojects:	../core/scepter-core.hdp
-base-address:	0x63F40000
 major-version:	2
 minor-version:	1
 compilation-mode:	tight

--- a/sources/corba/scepter/back-end/dump/scepter-dump-back-end.hdp
+++ b/sources/corba/scepter/back-end/dump/scepter-dump-back-end.hdp
@@ -6,7 +6,6 @@ files:	library
 	dump
 subprojects:	../../core/scepter-core.hdp
 	../../abstract-syntax-tree/scepter-ast.hdp
-base-address:	0x63FE0000
 major-version:	2
 minor-version:	1
 compilation-mode:	tight

--- a/sources/corba/scepter/back-end/dylan/scepter-dylan-back-end.hdp
+++ b/sources/corba/scepter/back-end/dylan/scepter-dylan-back-end.hdp
@@ -23,7 +23,6 @@ files:	scepter-dylan-back-end-library
 	typedef
 subprojects:	../../core/scepter-core.hdp
 	../../abstract-syntax-tree/scepter-ast.hdp
-base-address:	0x63FE0000
 major-version:	2
 minor-version:	1
 compilation-mode:	tight

--- a/sources/corba/scepter/back-end/ir/scepter-ir-back-end.hdp
+++ b/sources/corba/scepter/back-end/ir/scepter-ir-back-end.hdp
@@ -17,7 +17,6 @@ files:	scepter-ir-back-end-library
 	operation
 subprojects:	../../core/scepter-core.hdp
 	../../abstract-syntax-tree/scepter-ast.hdp
-base-address:	0x63FE0000
 major-version:	2
 minor-version:	1
 compilation-mode:	tight

--- a/sources/corba/scepter/back-end/ir/tests/scepter-ir-back-end-test-suite.hdp
+++ b/sources/corba/scepter/back-end/ir/tests/scepter-ir-back-end-test-suite.hdp
@@ -6,7 +6,6 @@ files:	library
 	scepter-ir-back-end-test-suite
 subprojects:	../scepter-ir-back-end.hdp
 	../../../core/scepter-core.hdp
-base-address:	0x63FE0000
 debug-arguments:	-debug -progress
 start-function:	
 major-version:	2

--- a/sources/corba/scepter/console/console-scepter.hdp
+++ b/sources/corba/scepter/console/console-scepter.hdp
@@ -7,7 +7,6 @@ files:	console-scepter-library
 	main
 subprojects:	../scepter.hdp
 	../core/scepter-core.hdp
-base-address:	0x64F20000
 debug-arguments:	/debugger /language:dump /stdout c:/users/keithd/foo.idl
 start-function:	main
 major-version:	2

--- a/sources/corba/scepter/console/minimal-console-scepter.hdp
+++ b/sources/corba/scepter/console/minimal-console-scepter.hdp
@@ -7,7 +7,6 @@ files:	minimal-console-scepter-library
 	main
 subprojects:	../scepter.hdp
 	../core/scepter-core.hdp
-base-address:	0x64F20000
 start-function:	main
 major-version:	2
 minor-version:	1

--- a/sources/corba/scepter/core/scepter-core.hdp
+++ b/sources/corba/scepter/core/scepter-core.hdp
@@ -9,7 +9,6 @@ files:	scepter-core-library
 	back-end
 	error
 subprojects:	../utilities/scepter-utilities.hdp
-base-address:	0x63FE0000
 major-version:	2
 minor-version:	1
 compilation-mode:	tight

--- a/sources/corba/scepter/minimal-scepter.hdp
+++ b/sources/corba/scepter/minimal-scepter.hdp
@@ -7,7 +7,6 @@ subprojects:	front-end\file\scepter-file-front-end.hdp
 	back-end\dylan\scepter-dylan-back-end.hdp
 	back-end\dump\scepter-dump-back-end.hdp
 	core\scepter-core.hdp
-base-address:	0x63DE0000
 major-version:	2
 minor-version:	1
 compilation-mode:	tight

--- a/sources/corba/scepter/scepter.hdp
+++ b/sources/corba/scepter/scepter.hdp
@@ -7,7 +7,6 @@ subprojects:	front-end\file\scepter-file-front-end.hdp
 	back-end\dylan\scepter-dylan-back-end.hdp
 	back-end\dump\scepter-dump-back-end.hdp
 	core\scepter-core.hdp
-base-address:	0x63DE0000
 major-version:	2
 minor-version:	1
 compilation-mode:	tight

--- a/sources/corba/scepter/tests/console/console-scepter-tests.hdp
+++ b/sources/corba/scepter/tests/console/console-scepter-tests.hdp
@@ -4,7 +4,6 @@ library:	console-scepter-tests
 files:	console-scepter-tests-library
 	start
 subprojects:	../scepter-tests.hdp
-base-address:	0x64E80000
 major-version: 2
 minor-version: 1
 compilation-mode:	tight

--- a/sources/corba/scepter/tests/scepter-tests.hdp
+++ b/sources/corba/scepter/tests/scepter-tests.hdp
@@ -69,7 +69,6 @@ files:	library
 	errors/damaged-suite
 	suites
 subprojects:	../scepter.hdp
-base-address:	0x64EA0000
 major-version: 2
 minor-version: 1
 compilation-mode:	tight

--- a/sources/corba/scepter/tool/tool-scepter.hdp
+++ b/sources/corba/scepter/tool/tool-scepter.hdp
@@ -7,7 +7,6 @@ files:	tool-scepter-library
 subprojects:	../scepter.hdp
 	../abstract-syntax-tree/scepter-ast.hdp
 	../front-end/file/scepter-file-front-end.hdp
-base-address:	0x63CA0000
 major-version:	2
 minor-version:	1
 compilation-mode:	tight

--- a/sources/corba/scepter/utilities/scepter-utilities.hdp
+++ b/sources/corba/scepter/utilities/scepter-utilities.hdp
@@ -5,7 +5,6 @@ files:	scepter-utilities-library
 	scepter-utilities-module
 	indenting
 	misc
-base-address:	0x63E00000
 major-version:	2
 minor-version:	1
 compilation-mode:	tight

--- a/sources/corba/services/naming/client/win32-naming-client.lid
+++ b/sources/corba/services/naming/client/win32-naming-client.lid
@@ -1,7 +1,6 @@
 Library:      naming-client
 Author:       Gary Palter
 Executable:   DxCNSC
-Base-Address: 0x64E80000
 Library-Pack: CORBA
 RC-Files:     version.rc
 LID:          naming-client.lid

--- a/sources/corba/services/naming/naming-service.hdp
+++ b/sources/corba/services/naming/naming-service.hdp
@@ -7,7 +7,6 @@ files:	library
 	naming-service
 	binding-iterator
 	main
-base-address:	0x63FE0000
 start-function:	start-naming-service
 major-version:	2
 minor-version:	1

--- a/sources/corba/services/naming/tests/naming-service-test-suite.hdp
+++ b/sources/corba/services/naming/tests/naming-service-test-suite.hdp
@@ -1,6 +1,5 @@
 comment:	This file is generated, please don't edit
 format-version:	2
-base-address:	0x63FC0000
 compilation-mode:	tight
 target-type:	executable
 files:	library

--- a/sources/corba/tests/dylan/client-app/corba-tests-client-app.hdp
+++ b/sources/corba/tests/dylan/client-app/corba-tests-client-app.hdp
@@ -6,7 +6,6 @@ files:	corba-tests-client-app-library
 subprojects:	../client/corba-tests-client.hdp
 	../server/corba-tests-server.hdp
 executable:	corba-tests-client-app
-base-address:	0x64E60000
 major-version:	2
 minor-version:	1
 compilation-mode:	tight

--- a/sources/corba/tests/dylan/client/corba-tests-client.hdp
+++ b/sources/corba/tests/dylan/client/corba-tests-client.hdp
@@ -1,7 +1,6 @@
 comment:	This file is generated, please don't edit
 format-version:	2
 target-type:	dll
-base-address:	0x63FE0000
 files:	corba-tests-client-library
 	corba-tests-client-module
 	any-client

--- a/sources/corba/tests/dylan/server-app/corba-tests-server-app.hdp
+++ b/sources/corba/tests/dylan/server-app/corba-tests-server-app.hdp
@@ -5,7 +5,6 @@ files:	corba-tests-server-app-library
 	corba-tests-server-app
 subprojects:	../server/corba-tests-server.hdp
 	../utilities/corba-tests-utilities.hdp
-base-address:	0x64DC0000
 major-version:	2
 minor-version:	1
 compilation-mode:	tight

--- a/sources/corba/tests/dylan/server/corba-tests-server.hdp
+++ b/sources/corba/tests/dylan/server/corba-tests-server.hdp
@@ -25,4 +25,3 @@ files:	corba-tests-server-library
 	union-server
 library:	corba-tests-server
 other-files:	idl.spec
-base-address:	0x63FE0000

--- a/sources/corba/tests/dylan/utilities/corba-tests-utilities.hdp
+++ b/sources/corba/tests/dylan/utilities/corba-tests-utilities.hdp
@@ -3,7 +3,6 @@ format-version:	2
 library:	corba-tests-utilities
 files:	corba-tests-utilities-library
 	servers
-base-address:	0x63FE0000
 major-version:	2
 minor-version:	1
 compilation-mode:	tight

--- a/sources/corba/tools/ir-browser/ir-browser.hdp
+++ b/sources/corba/tools/ir-browser/ir-browser.hdp
@@ -7,7 +7,6 @@ files:	library
 	info
 	frame
 	ir-browser
-base-address:	0x63FE0000
 debug-arguments:	-ORBinterface-repository-file u:\keithd\ir.ior
 start-function:	main
 linker-options:	$(guilflags)

--- a/sources/databases/sql-odbc/sql-odbc.lid
+++ b/sources/databases/sql-odbc/sql-odbc.lid
@@ -1,6 +1,5 @@
 Library:      sql-odbc
 Executable:   DxDB
-Base-Address: 0x651E0000
 Library-Pack: ODBC
 RC-Files:     version.rc
 Major-Version: 2

--- a/sources/deuce/duim/win32-duim-deuce.lid
+++ b/sources/deuce/duim/win32-duim-deuce.lid
@@ -2,7 +2,6 @@ Library:      duim-deuce
 Synopsis:     DUIM back-end for Deuce
 Author:       Scott McKay
 Executable:   DxDMDCE
-Base-Address: 0x65A60000
 Library-Pack: Deuce
 RC-Files:     version.rc
 LID:          duim-deuce.lid

--- a/sources/deuce/win32-deuce.lid
+++ b/sources/deuce/win32-deuce.lid
@@ -2,7 +2,6 @@ Library:      deuce
 Synopsis:     The Deuce ("Dylan Environment Universal Code Editor") editor
 Author:       Scott McKay
 Executable:   DxDEUCE
-Base-Address: 0x65AE0000
 Library-Pack: Deuce
 RC-Files:     version.rc
 LID:          deuce.lid

--- a/sources/duim/core/win32-duim-core.lid
+++ b/sources/duim/core/win32-duim-core.lid
@@ -2,7 +2,6 @@ Library:      duim-core
 Synopsis:     DUIM core, for Win32
 Author:       Scott McKay, Andy Armstrong, Gary Palter
 Executable:   DxDUIM
-Base-address: 0x65e00000
 Library-Pack: GUI
 LID:          duim-core.lid
 RC-Files:     version.rc

--- a/sources/duim/gtk/duim.lid
+++ b/sources/duim/gtk/duim.lid
@@ -5,7 +5,6 @@ Target-Type:  dll
 Files:        duim-library
 Major-version: 2
 Minor-version: 1
-Base-address:  0x65c00000
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.
 License:      See License.txt in this distribution for details.

--- a/sources/duim/win32/duim.lid
+++ b/sources/duim/win32/duim.lid
@@ -6,7 +6,6 @@ Files:     duim-library
 Major-version: 2
 Minor-version: 1
 Executable:    DxWDUIM
-Base-address:  0x65c00000
 Library-Pack:  GUI
 Comment:       'C-Header-Files' is a kludge to get the manifest included
 RC-Files:       version.rc

--- a/sources/duim/win32/win32-duim-unix.lid
+++ b/sources/duim/win32/win32-duim-unix.lid
@@ -1,0 +1,55 @@
+Library:   win32-duim
+Synopsis:  DUIM back-end for Microsoft Windows
+Author:    Scott McKay, Andy Armstrong
+Files:  library
+        module
+        win32-definitions
+        win32-c-definitions
+        ffi-bindings
+        whandler
+        wresources
+        wutils
+        wport
+        wmirror
+        wmedium
+        wcolors
+        wfonts
+        wdraw
+        wkeyboard
+        wevents
+        wframem
+        wdisplay
+        wpixmaps
+        wtop
+        wgadgets
+        wcontrols
+        wmenus
+        wdialogs
+        whelp
+        wclipboard
+Major-version: 2
+Minor-version: 1
+C-Source-Files: c-com.c
+C-libraries: ole32.lib
+        uuid.lib
+        shell32.lib
+        comdlg32.lib
+        comctl32.lib
+        user32.lib
+        gdi32.lib
+        advapi32.lib
+        htmlhelp.lib
+Library-Pack: GUI
+Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
+              All rights reserved.
+License:      See License.txt in this distribution for details.
+Warranty:     Distributed WITHOUT WARRANTY OF ANY KIND
+Platforms: aarch64-darwin
+           arm-linux
+           x86-freebsd
+           x86-linux
+           x86-netbsd
+           x86_64-darwin
+           x86_64-freebsd
+           x86_64-linux
+           x86_64-netbsd

--- a/sources/dylan/dylan-win32.lid
+++ b/sources/dylan/dylan-win32.lid
@@ -2,7 +2,6 @@ Library:      dylan
 Author:       Gary Palter
 Synopsis:     Win32 specific options for the Functional Objects Dylan library
 Executable:   DxDYLAN
-Base-Address: 0x66E00000
 RC-Files:     version.rc
 LID:          dylan.lid
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.

--- a/sources/environment/tools/project-settings.dylan
+++ b/sources/environment/tools/project-settings.dylan
@@ -85,8 +85,6 @@ define pane <link-settings-page> ()
     required-init-keyword: target-type:;
   sealed slot %interface-type :: <project-interface-type>,
     required-init-keyword: interface-type:;
-  sealed slot %base-address :: false-or(<machine-word>),
-    required-init-keyword: base-address:;
   sealed slot %major-version :: false-or(<integer>),
     required-init-keyword: major-version:;
   sealed slot %minor-version :: false-or(<integer>),
@@ -140,14 +138,6 @@ define pane <link-settings-page> ()
          value-changed-callback: method (gadget)
                                    pane.%interface-type := gadget.gadget-value
                                  end);
-  pane %base-address-pane (pane)
-    make(<text-field>,
-         enabled?: pane.%enabled?,
-         value-type: <machine-word>,
-         value: pane.%base-address,
-         value-changing-callback: method (gadget)
-                                    pane.%base-address := gadget.gadget-value
-                                  end);
   pane %major-version-pane (pane)
     make(<text-field>,
          enabled?: pane.%enabled?,
@@ -174,13 +164,6 @@ define pane <link-settings-page> ()
                              pane.%target-name-pane),
                       vector(make(<label>, label: "Type:"),
                              pane.%target-type-pane)))
-      end grouping;
-      grouping ("Base address", max-width: $fill)
-        make(<table-layout>,
-             y-spacing: 2,
-             contents:
-               vector(vector(make(<label>, label: "Address:"),
-                             pane.%base-address-pane)));
       end grouping;
       grouping ("Version information", max-width: $fill)
         make(<table-layout>,
@@ -335,7 +318,6 @@ define frame <project-settings-dialog> (<property-frame>)
            target-name:    project.project-build-filename,
            target-type:    project.project-target-type,
            interface-type: project.project-interface-type,
-           base-address:   can-be-built? & project.project-base-address,
            major-version:  can-be-built? & project.project-major-version,
            minor-version:  can-be-built? & project.project-minor-version)
     end;
@@ -411,7 +393,6 @@ define method update-project-settings
     project.project-build-filename   := link-page.%target-name;
     project.project-target-type      := link-page.%target-type;
     project.project-interface-type   := link-page.%interface-type;
-    project.project-base-address     := link-page.%base-address;
     project.project-major-version    := link-page.%major-version;
     project.project-minor-version    := link-page.%minor-version;
   end;
@@ -437,14 +418,6 @@ define method valid-project-settings?
     let target-name = link-page.%target-name;
     validate(target-name ~== #f,
              "The target file name must not be empty.");
-    // Validate DLL base address. Check the text size first so we can
-    // distinguish between no setting and bogus text.
-    let base-address = link-page.%base-address;
-    if (size(link-page.%base-address-pane.gadget-text) > 0)
-      validate(base-address ~= #f,
-               "The base address must be an unsigned hexadecimal integer,"
-                 " or you may leave it blank to have one automatically assigned.");
-    end;
     // Validate version information.
     let major-version = link-page.%major-version;
     let minor-version = link-page.%minor-version;

--- a/sources/examples/c-ffi/taskbar-icons/status-buttons/status-buttons.hdp
+++ b/sources/examples/c-ffi/taskbar-icons/status-buttons/status-buttons.hdp
@@ -5,7 +5,6 @@ files:	library
 	module
 	status-buttons
 subprojects:	..\status-icons\status-icons.hdp
-base-address:	0x64FA0000
 start-function:	main
 linker-options:	$(guilflags)
 c-header-files:	taskbar-error.ico

--- a/sources/examples/c-ffi/taskbar-icons/status-icons/status-icons.hdp
+++ b/sources/examples/c-ffi/taskbar-icons/status-icons/status-icons.hdp
@@ -7,7 +7,6 @@ files:	library
 	c-interface
 	start
 subprojects:	..\win32-taskbar\win32-taskbar.hdp
-base-address:	0x64FC0000
 start-function:	main
 linker-options:	$(guilflags)
 c-header-files:	taskbar-error.ico

--- a/sources/examples/c-ffi/taskbar-icons/win32-taskbar/win32-taskbar.hdp
+++ b/sources/examples/c-ffi/taskbar-icons/win32-taskbar/win32-taskbar.hdp
@@ -4,7 +4,6 @@ library:	win32-taskbar
 files:	library
 	module
 	win32-taskbar
-base-address:	0x64FE0000
 start-function:	main
 c-libraries:	C:\MSDEV\lib\Shell32.lib
 major-version:	2

--- a/sources/examples/console/towers-of-hanoi/hanoi.hdp
+++ b/sources/examples/console/towers-of-hanoi/hanoi.hdp
@@ -4,7 +4,6 @@ library:	hanoi
 files:	library
 	hanoi
 	start
-base-address:	0x63F40000
 start-function:	play-hanoi
 major-version:	2
 minor-version:	1

--- a/sources/examples/documentation/task-list-1/task-list.hdp
+++ b/sources/examples/documentation/task-list-1/task-list.hdp
@@ -4,7 +4,6 @@ files:	library
 	module
 	task-list
 	frame
-base-address:	0x64FE0000
 linker-options:	$(guilflags)
 major-version:	2
 minor-version:	1

--- a/sources/examples/documentation/task-list-2/task-list.hdp
+++ b/sources/examples/documentation/task-list-2/task-list.hdp
@@ -4,7 +4,6 @@ files:	library
 	module
 	task-list
 	frame
-base-address:	0x64FE0000
 linker-options:	$(guilflags)
 major-version:	2
 minor-version:	1

--- a/sources/examples/gui/duim-gl-demo/duim-gl-demo.lid
+++ b/sources/examples/gui/duim-gl-demo/duim-gl-demo.lid
@@ -4,7 +4,6 @@ files:	library
 	module
         duim-gl
 	duim-gl-demo
-base-address:	0x64F80000
 start-function:	main
 linker-options:	$(guilflags)
 major-version:	2

--- a/sources/examples/odbc/employee-explorer/employee-explorer.hdp
+++ b/sources/examples/odbc/employee-explorer/employee-explorer.hdp
@@ -6,7 +6,6 @@ files:	library
 	back-end
 	frame
 	employee-explorer
-base-address:	0x64FE0000
 start-function:	main
 linker-options:	$(guilflags)
 c-header-files:	serf-eyes.ico

--- a/sources/examples/odbc/select-viewer/select-viewer.hdp
+++ b/sources/examples/odbc/select-viewer/select-viewer.hdp
@@ -6,7 +6,6 @@ files:	library
 	select-viewer
 	odbc-back-end
 	start
-base-address:	0x64FE0000
 start-function:	main
 linker-options:	$(guilflags)
 major-version:	2

--- a/sources/io/win32-io.lid
+++ b/sources/io/win32-io.lid
@@ -32,7 +32,6 @@ Major-Version: 2
 Minor-Version: 1
 Target-Type:   dll
 Executable:    DxIO
-Base-Address:  0x66C00000
 RC-Files:      version.rc
 Library-Pack:  Core
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.

--- a/sources/lib/big-integers/big-integers-win32.lid
+++ b/sources/lib/big-integers/big-integers-win32.lid
@@ -2,7 +2,6 @@ Library:      big-integers
 Author:       Gary Palter
 Synopsis:     Win32 specific options for the Functional Objects Big-Integers library
 Executable:   DxBIGINT
-Base-Address: 0x66B60000
 Library-Pack: Core
 RC-Files:     version.rc
 LID:          big-integers.lid

--- a/sources/lib/c-ffi/win32-c-ffi.lid
+++ b/sources/lib/c-ffi/win32-c-ffi.lid
@@ -1,6 +1,5 @@
 Library:       c-ffi
 Executable:    DxCFFI
-Base-Address:  0x66CE0000
 Major-Version: 2
 Minor-Version: 1
 Library-Pack:  Core

--- a/sources/lib/commands/commands-win32.lid
+++ b/sources/lib/commands/commands-win32.lid
@@ -1,7 +1,6 @@
 Library:      Commands
 Synopsis:     Win32 specific options for the Functional Objects Commands library
 Author:       Scott McKay, Hugh Greene
-Base-address: 0x66B20000
 Executable:   DxCOMMND
 Library-Pack: Core
 RC-Files:     version.rc

--- a/sources/lib/dood/win32-dood.lid
+++ b/sources/lib/dood/win32-dood.lid
@@ -2,7 +2,6 @@ Library:      dood
 Synopsis:     The Dylan object-oriented database
 Author:       Jonathan Bachrach
 Executable:   DxDOOD
-Base-Address: 0x66AA0000
 Library-Pack: DOOD
 RC-Files:     version.rc
 LID:          dood.lid

--- a/sources/lib/generic-arithmetic/generic-arithmetic-win32.lid
+++ b/sources/lib/generic-arithmetic/generic-arithmetic-win32.lid
@@ -2,7 +2,6 @@ Library:      generic-arithmetic
 Author:       Gary Palter
 Synopsis:     Win32 specific options for the Functional Objects Generic-Arithmetic library
 Executable:   DxGARITH
-Base-Address: 0x66BC0000
 Library-Pack: Core
 RC-Files:     version.rc
 LID:          generic-arithmetic.lid

--- a/sources/lib/midi/win32-midi.lid
+++ b/sources/lib/midi/win32-midi.lid
@@ -6,7 +6,6 @@ Files:	library
 	midi
 	win32-midi
 Executable: DxMIDI
-Base-Address: 0x64a80000
 Major-Version: 2
 Minor-Version: 1
 Compilation-Mode: tight

--- a/sources/network/examples/daytime-client/daytime-client.hdp
+++ b/sources/network/examples/daytime-client/daytime-client.hdp
@@ -3,7 +3,6 @@ format-version:	2
 library:	daytime-client
 files:	library
 	daytime-client
-base-address:	0x63FE0000
 major-version:	2
 minor-version:	1
 compilation-mode:	loose

--- a/sources/network/examples/daytime-server/daytime-server.hdp
+++ b/sources/network/examples/daytime-server/daytime-server.hdp
@@ -3,7 +3,6 @@ format-version:	2
 library:	daytime-server
 files:	library
 	daytime-server
-base-address:	0x63FE0000
 major-version:	2
 minor-version:	1
 compilation-mode:	loose

--- a/sources/network/examples/echo-client/echo-client.hdp
+++ b/sources/network/examples/echo-client/echo-client.hdp
@@ -3,7 +3,6 @@ format-version:	2
 library:	echo-client
 files:	library
 	echo-client
-base-address:	0x63FE0000
 major-version:	2
 minor-version:	1
 compilation-mode:	loose

--- a/sources/network/examples/echo-server/echo-server.hdp
+++ b/sources/network/examples/echo-server/echo-server.hdp
@@ -3,7 +3,6 @@ format-version:	2
 library:	echo-server
 files:	library
 	echo-server
-base-address:	0x63FE0000
 major-version:	2
 minor-version:	1
 compilation-mode:	loose

--- a/sources/network/win32-network.lid
+++ b/sources/network/win32-network.lid
@@ -2,7 +2,6 @@ Library:      network
 Author:       Andy Armstrong
 Synopsis:     Win32 version of the Functional Objects Network library
 Executable:   DxNETWRK
-Base-Address: 0x65140000
 Library-Pack: Network
 RC-Files:     version.rc
 Target-Type:  dll

--- a/sources/ole/com/com.lid
+++ b/sources/ole/com/com.lid
@@ -2,7 +2,6 @@ Library:      COM
 Synopsis:     Interface to the Microsoft "Component Object Model".
 Executable:   DxCOM
 Target-Type:  DLL
-Base-Address: 0x65700000
 Library-Pack: OLE
 Major-Version: 2
 Minor-Version: 1

--- a/sources/ole/com/tests/com-test.hdp
+++ b/sources/ole/com/tests/com-test.hdp
@@ -4,7 +4,6 @@ library:	com-test
 files:	library
 	istream
 	suite
-base-address:	0x63FE0000
 start-function:	run-suite
 major-version:	2
 minor-version:	1

--- a/sources/ole/duim-ole-container/duim-ole-container.lid
+++ b/sources/ole/duim-ole-container/duim-ole-container.lid
@@ -1,7 +1,6 @@
 Library:      DUIM-OLE-container
 Synopsis:     Extends DUIM with the ability to create OLE container applications.
 Executable:   DxDOCON
-Base-Address: 0x65000000
 Library-Pack: OLE
 RC-Files:     version.rc
 Major-Version: 2

--- a/sources/ole/duim-ole-control/duim-ole-control.lid
+++ b/sources/ole/duim-ole-control/duim-ole-control.lid
@@ -2,7 +2,6 @@ Library:      DUIM-OLE-Control
 Synopsis:     Support for creating an OLE Control using DUIM.
 Executable:   DxDOLEC
 Target-type:  DLL
-Base-Address: 0x65080000
 Library-Pack: OLE
 RC-Files:     version.rc
 Major-Version: 2

--- a/sources/ole/duim-ole-server/duim-ole-server.lid
+++ b/sources/ole/duim-ole-server/duim-ole-server.lid
@@ -1,6 +1,5 @@
 Library:      DUIM-OLE-server
 Executable:   DxDOLES
-Base-Address: 0x652C0000
 Library-Pack: OLE
 RC-Files:     version.rc
 Major-Version: 2

--- a/sources/ole/examples/bank/Client/bank-client.hdp
+++ b/sources/ole/examples/bank/Client/bank-client.hdp
@@ -6,7 +6,6 @@ files:	client-library
 	client-frame
 	client-main
 subprojects:	..\interface\bank-interface.hdp
-base-address:	0x63D00000
 linker-options:	$(guilflags)
 major-version:	2
 minor-version:	1

--- a/sources/ole/examples/bank/Interface/bank-interface.hdp
+++ b/sources/ole/examples/bank/Interface/bank-interface.hdp
@@ -3,7 +3,6 @@ format-version:	2
 library:	bank-interface
 files:	interface-library
 	interface
-base-address:	0x63F40000
 major-version:	2
 minor-version:	1
 compilation-mode:	tight

--- a/sources/ole/examples/bank/Server/bank-server.hdp
+++ b/sources/ole/examples/bank/Server/bank-server.hdp
@@ -7,7 +7,6 @@ files:	server-library
 	server-frame
 	server-main
 subprojects:	..\interface\bank-interface.hdp
-base-address:	0x63BE0000
 linker-options:	$(guilflags)
 major-version:	2
 minor-version:	1

--- a/sources/ole/ole-automation/ole-automation.lid
+++ b/sources/ole/ole-automation/ole-automation.lid
@@ -1,7 +1,6 @@
 Library:      OLE-Automation
 Executable:   DxOLEAUT
 Target-type:  DLL
-Base-Address: 0x65580000
 Library-Pack: OLE
 RC-Files:     version.rc
 major-version: 2

--- a/sources/ole/ole-automation/tests/parameter-type-tests/parameter-type-tests-server.lid
+++ b/sources/ole/ole-automation/tests/parameter-type-tests/parameter-type-tests-server.lid
@@ -7,7 +7,6 @@ files:	library-server
 	inproc
 subprojects:	..\..\..\com\com.hdp
 	..\..\ole-automation.hdp
-base-address:	0x63EC0000
 debug-command:	regsvr32
 debug-arguments:	parameter-type-tests-server.dll
 start-function:	

--- a/sources/ole/ole-automation/tests/parameter-type-tests/parameter-type-tests.lid
+++ b/sources/ole/ole-automation/tests/parameter-type-tests/parameter-type-tests.lid
@@ -7,7 +7,6 @@ files:	library
 	run
 subprojects:	..\..\..\com\com.hdp
 	..\..\ole-automation.hdp
-base-address:	0x63EC0000
 start-function:	run-suite
 major-version:	2
 minor-version:	1

--- a/sources/ole/ole-container/ole-container.lid
+++ b/sources/ole/ole-container/ole-container.lid
@@ -2,7 +2,6 @@ Library:      OLE-Container
 Synopsis:     Utility library for creating OLE container applications 
 	      using the Win32 API for the user interface.
 Executable:   DxOLECON
-Base-Address: 0x65020000
 Library-Pack: OLE
 RC-Files:     version.rc
 Major-Version: 2

--- a/sources/ole/ole-control-framework/ole-control-framework.lid
+++ b/sources/ole/ole-control-framework/ole-control-framework.lid
@@ -2,7 +2,6 @@ Library:      OLE-Control-Framework
 Synopsis:     High-level support for OLE Controls.
 Author:       David N. Gray
 Executable:   DxOLECFR
-Base-Address: 0x650e0000
 Library-Pack: OLE
 RC-Files:     version.rc
 Major-Version: 2

--- a/sources/ole/ole-controls/ole-controls.lid
+++ b/sources/ole/ole-controls/ole-controls.lid
@@ -3,7 +3,6 @@ Synopsis:     Windows OLE Controls low-level API (OLECTL.H and OLEPRO32.DLL)
 Author:       David N. Gray
 Executable:   DxOLECTL
 Target-type:  DLL
-Base-Address: 0x65460000
 Library-Pack: OLE
 RC-Files:     version.rc
 Major-version: 2

--- a/sources/ole/ole-dialogs/ole-dialogs.lid
+++ b/sources/ole/ole-dialogs/ole-dialogs.lid
@@ -1,7 +1,6 @@
 Library:      OLE-Dialogs
 Executable:   DxOLEDLG
 Target-type:  DLL
-Base-Address: 0x65520000
 Library-Pack: OLE
 RC-Files:     version.rc
 Major-version: 2

--- a/sources/ole/ole-server/ole-server.lid
+++ b/sources/ole/ole-server/ole-server.lid
@@ -1,6 +1,5 @@
 Library:      OLE-Server
 Executable:   DxOLESVR
-Base-Address: 0x653E0000
 Library-Pack: OLE
 RC-Files:     version.rc
 Major-Version: 2

--- a/sources/ole/ole/ole.lid
+++ b/sources/ole/ole/ole.lid
@@ -2,7 +2,6 @@ Library:      OLE
 Synopsis:     FFI interfaces to Microsoft Windows OLE features from "OLE2.H".
 Executable:   DxOLE
 Target-type:  DLL
-Base-Address: 0x65680000
 Library-Pack: OLE
 RC-Files:     version.rc
 Major-version: 2

--- a/sources/ole/win32-automation/win32-automation.lid
+++ b/sources/ole/win32-automation/win32-automation.lid
@@ -1,6 +1,5 @@
 Library:      win32-Automation
 Target-type:  DLL
-Base-Address: 0x65590000
 Library-Pack: OLE
 major-version: 2
 minor-version: 1

--- a/sources/project-manager/tools-interface/library.dylan
+++ b/sources/project-manager/tools-interface/library.dylan
@@ -45,7 +45,7 @@ define module tools-interface
          project-information-target-type, project-information-executable,
          project-information-compilation-mode,
          project-information-major-version, project-information-minor-version,
-         project-information-base-address, project-information-remaining-keys,
+         project-information-remaining-keys,
          project-information-files-setter,
          project-information-subprojects-setter,
          project-information-library-setter,
@@ -54,7 +54,6 @@ define module tools-interface
          project-information-compilation-mode-setter,
          project-information-major-version-setter,
          project-information-minor-version-setter,
-         project-information-base-address-setter,
          project-information-remaining-keys-setter;
 
   export read-keyword-pair-file, read-keyword-pair-stream;

--- a/sources/project-manager/tools-interface/project-files.dylan
+++ b/sources/project-manager/tools-interface/project-files.dylan
@@ -34,8 +34,6 @@ define class <project-information> (<object>)
     init-keyword: major-version:;
   slot project-information-minor-version :: <integer> = 0,
     init-keyword: minor-version:;
-  slot project-information-base-address :: false-or(<machine-word>) = #f,
-    init-keyword: base-address:;
   slot project-information-remaining-keys :: false-or(<table>) = #f,
     init-keyword: remaining-keys:;
 end class <project-information>;
@@ -100,12 +98,7 @@ define function write-project-to-stream
   t[compilation-mode:] := as(<string>, p.project-information-compilation-mode);
   t[major-version:] := integer-to-string(p.project-information-major-version);
   t[minor-version:] := integer-to-string(p.project-information-minor-version);
-  if (p.project-information-base-address)
-    t[base-address:]
-      := machine-word-to-string(p.project-information-base-address, prefix: "0x");
-  else
-    remove-key!(t, base-address:);
-  end if;
+  remove-key!(t, base-address:);
 
   if (version ~= 1 & version ~= 2)
     error("attempt to write unknown project version: %d", version);
@@ -230,16 +223,6 @@ define function read-project-from-stream
       p.project-information-minor-version := i;
     else
       err("minor-version \"%s\" is not a number", list(minor-version), line: line);
-    end if;
-  end if;
-
-  let (base-address, line) = single-key((base-address:).key, base-address:);
-  if (base-address)
-    let i = string-to-machine-word(base-address, default: #f);
-    if (i)
-      p.project-information-base-address := i;
-    else
-      err("base-address \"%s\" is not a hex number", list(base-address), line: line);
     end if;
   end if;
 

--- a/sources/project-manager/user-projects/save-project.dylan
+++ b/sources/project-manager/user-projects/save-project.dylan
@@ -152,8 +152,7 @@ define function save-lid-info
                                      p.project-lid-location.locator-directory))
                  end;
   save-single-value(stream, #"executable", executable);
-  save-single-value(stream, #"base-address",
-                    base-address-string | compute-base-address(p, #f));
+  save-single-value(stream, #"base-address", base-address-string);
   save-single-value(stream, #"debug-command", debug-command);
   save-single-value(stream, #"debug-arguments", debug-arguments-string);
   save-single-value(stream, #"debug-machine", debug-machine);
@@ -385,41 +384,3 @@ define method destructure-flat-assoc-list (list-seq :: <sequence>, rank == 3,
 
   table
 end;
-
-
-/// All Functional Developer DLLs that may be used by user libraries reside above
-/// this address.  Consequently, it's an upper bound for the base for user
-/// libraries including our private libraries (e.g., the compiler and environment)
-define constant $top-for-user-libraries = #x64000;
-
-/// Presume that user libraries fit into 32 pages (128K)
-define constant $allowance-for-user-libraries = #x20;
-define method library-base (#key base-address = #f, #all-keys)
- => (base :: false-or(<machine-word>))
-  base-address
-end method;
-
-define method compute-base-address (project :: <lid-project>, explicit-base :: false-or(<machine-word>))
- => (computed-base :: <string>)
-  let base-address =
-    explicit-base
-    | begin
-        let baseless-libraries = 1;
-        let top = $top-for-user-libraries;
-        let projects = all-used-projects(project);
-        for (p in projects)
-          let base = apply(library-base, project-build-settings(p));
-          if (base)
-            let base :: <machine-word> = base;
-            top := min(top,
-                       as(<integer>, machine-word-unsigned-shift-right(base, 12)))
-          else
-            baseless-libraries := baseless-libraries + 1
-          end
-        end;
-        let machine-word :: <machine-word> =
-          as(<machine-word>, top - baseless-libraries * $allowance-for-user-libraries);
-        machine-word-unsigned-shift-left(machine-word, 12)
-      end begin;
-  machine-word-to-string(base-address, prefix: "0x")
-end method compute-base-address;

--- a/sources/system/x86-win32-system.lid
+++ b/sources/system/x86-win32-system.lid
@@ -32,7 +32,6 @@ C-Libraries: advapi32.lib
              shell32.lib
 Library-Pack: Core
 Executable:   DxSYSTEM
-Base-Address: 0x66D20000
 RC-Files:     version.rc
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.
               All rights reserved.

--- a/sources/win32/win32-common/win32-common.lid
+++ b/sources/win32/win32-common/win32-common.lid
@@ -2,7 +2,6 @@ Library:      Win32-common
 Synopsis:     Declarations used by the other Win32 API libraries.
 Executable:   DxW32CMN
 Target-type:  DLL
-Base-Address: 0x66980000
 Library-Pack: Win32
 RC-Files:     version.rc
 Major-version: 2

--- a/sources/win32/win32-controls/win32-controls.lid
+++ b/sources/win32/win32-controls/win32-controls.lid
@@ -2,7 +2,6 @@ Library:      Win32-controls
 Synopsis:     Win32 API for Windows Common Controls.
 Executable:   DxW32CTL
 Target-type:  DLL
-Base-Address: 0x66660000
 Library-Pack: Win32
 RC-Files:     version.rc
 Major-version: 2

--- a/sources/win32/win32-dde/win32-dde.lid
+++ b/sources/win32/win32-dde/win32-dde.lid
@@ -2,7 +2,6 @@ Library:      Win32-DDE
 Synopsis:     Win32 API for "DDE"
 Executable:   DxW32DDE
 Target-type:  DLL
-Base-Address: 0x66500000
 Library-Pack: Win32
 RC-Files:     version.rc
 Major-version: 2

--- a/sources/win32/win32-dialog/win32-dialog.lid
+++ b/sources/win32/win32-dialog/win32-dialog.lid
@@ -2,7 +2,6 @@ Library:      Win32-dialog
 Synopsis:     Win32 API for common dialog boxes
 Executable:   DxW32DLG
 Target-type:  DLL
-Base-Address: 0x66700000
 Library-Pack: Win32
 RC-Files:     version.rc
 Major-version: 2

--- a/sources/win32/win32-gdi/win32-gdi.lid
+++ b/sources/win32/win32-gdi/win32-gdi.lid
@@ -2,7 +2,6 @@ Library:      Win32-GDI
 Synopsis:     Win32 API for "Graphics Device Interface" in "GDI32.DLL".
 Executable:   DxW32GDI
 Target-type:  DLL
-Base-Address: 0x66760000
 Library-Pack: Win32
 RC-Files:     version.rc
 Major-version: 2

--- a/sources/win32/win32-gl/win32-gl.lid
+++ b/sources/win32/win32-gl/win32-gl.lid
@@ -2,7 +2,6 @@ Library:      win32-gl
 Synopsis:     FFI bindings for the Win32 OpenGL implementation.
 Executable:   DxW32GL
 Target-Type:  DLL
-Base-Address: 0x66300000
 Library-Pack: Win32
 RC-Files:     version.rc
 Major-Version: 2

--- a/sources/win32/win32-glu/win32-glu.lid
+++ b/sources/win32/win32-glu/win32-glu.lid
@@ -2,7 +2,6 @@ Library:       win32-glu
 Synopsis:      Win32 bindings for the OpenGL utilities
 Executable:    DxW32GLU
 Target-Type:   DLL
-Base-Address:  0x662A0000
 Library-Pack:  Win32
 RC-Files:      version.rc
 Major-Version: 2

--- a/sources/win32/win32-html-help/win32-html-help.lid
+++ b/sources/win32/win32-html-help/win32-html-help.lid
@@ -1,6 +1,5 @@
 Library:      Win32-HTML-Help
 Executable:   DxHTMHLP
-Base-Address: 0x66420000
 Library-Pack: Win32
 RC-Files:     version.rc
 Major-Version: 2

--- a/sources/win32/win32-kernel/win32-kernel.lid
+++ b/sources/win32/win32-kernel/win32-kernel.lid
@@ -2,7 +2,6 @@ Library:      Win32-kernel
 Synopsis:     Win32 API for non-GUI system services in "KERNEL32.DLL"
 Executable:   DxW32KNL
 Target-type:  DLL
-Base-Address: 0x66900000
 Library-Pack: Win32
 RC-Files:     version.rc
 Major-version: 2

--- a/sources/win32/win32-multimedia/win32-multimedia.lid
+++ b/sources/win32/win32-multimedia/win32-multimedia.lid
@@ -1,7 +1,6 @@
 Library:       Win32-multimedia
 Executable:    DxW32MM
 Target-Type:   DLL
-Base-Address:  0x66360000
 Library-Pack:  Win32
 RC-Files:      version.rc
 Major-Version: 2

--- a/sources/win32/win32-registry/win32-registry.lid
+++ b/sources/win32/win32-registry/win32-registry.lid
@@ -2,7 +2,6 @@ Library:      Win32-Registry
 Synopsis:     Win32 API for the System Registry.
 Executable:   DxW32REG
 Target-type:  DLL
-Base-Address: 0x665C0000
 Library-Pack: Win32
 RC-Files:     version.rc
 Major-version: 2

--- a/sources/win32/win32-resources/win32-resources.lid
+++ b/sources/win32/win32-resources/win32-resources.lid
@@ -16,7 +16,6 @@ Major-Version: 2
 Minor-Version: 1
 Executable:   DxW32RES
 Target-Type:  DLL
-Base-Address: 0x66560000
 Library-Pack: Win32
 RC-Files:     version.rc
 Copyright:    Original Code is Copyright (c) 1995-2004 Functional Objects, Inc.

--- a/sources/win32/win32-rich-edit/win32-rich-edit.lid
+++ b/sources/win32/win32-rich-edit/win32-rich-edit.lid
@@ -1,7 +1,6 @@
 Library:      Win32-Rich-Edit
 Executable:   DxW32RED
 Target-type:  DLL
-Base-Address: 0x66600000
 Library-Pack: Win32
 RC-Files:     version.rc
 Major-version: 2

--- a/sources/win32/win32-shell/win32-shell.lid
+++ b/sources/win32/win32-shell/win32-shell.lid
@@ -1,7 +1,6 @@
 Library:      Win32-shell
 Synopsis:     Translation of Microsoft "shellapi.h".
 Executable:   DxW32SHL
-Base-Address: 0x664A0000
 target-type:  DLL
 Library-Pack: Win32
 RC-Files:     version.rc

--- a/sources/win32/win32-user/win32-user.lid
+++ b/sources/win32/win32-user/win32-user.lid
@@ -2,7 +2,6 @@ Library:      Win32-user
 Synopsis:     Win32 API for window functions implemented in "USER32.DLL".
 Executable:   DxW32USR
 Target-type:  DLL
-Base-Address: 0x66860000
 Library-Pack: Win32
 RC-Files:     version.rc
 Major-version: 2

--- a/sources/win32/win32-version/win32-version.lid
+++ b/sources/win32/win32-version/win32-version.lid
@@ -1,7 +1,6 @@
 Library:      Win32-version
 Executable:   DxW32VER
 Target-type:  DLL
-Base-Address: 0x66460000
 Library-Pack: Win32
 RC-Files:     version.rc
 Major-version: 2


### PR DESCRIPTION
Since Windows Vista and Windows Server 2008, DLLs are loaded at random addresses as part of Address Space Layout Randomization. Windows XP, the last version that respected DLL base addresses specified in the DLL executable, ended support in April 2014. It is no longer desirable to specify base addresses for Dylan library projects.
