### PR TITLE
Fix DOOD on aarch64-linux and riscv64-linux

### DIFF
--- a/sources/lib/dood/dood.dylan
+++ b/sources/lib/dood/dood.dylan
@@ -558,6 +558,8 @@ define method initialize
     (dood :: <dood>, #rest all-keys,
      #key name, locator, if-exists, stream, backups?, segments, #all-keys)
   next-method();
+  assert($word-size = $machine-word-size,
+         "DOOD word-size must match the machine word size");
   dood-init-keys(dood) := copy-sequence(all-keys);
   unless (segments)
     dood-segments(dood)

--- a/sources/registry/aarch64-linux/dood
+++ b/sources/registry/aarch64-linux/dood
@@ -1,1 +1,1 @@
-abstract://dylan/lib/dood/dood.lid
+abstract://dylan/lib/dood/dood-64.lid

--- a/sources/registry/riscv64-linux/dood
+++ b/sources/registry/riscv64-linux/dood
@@ -1,1 +1,1 @@
-abstract://dylan/lib/dood/dood.lid
+abstract://dylan/lib/dood/dood-64.lid


### PR DESCRIPTION
This change fixes DOOD on two platforms that were using the wrong DOOD build variant, causing machine word values within compiler databases to be truncated.