### PR TITLE
doc: Attempt to fix Fosstodon link in page header

### DIFF
--- a/documentation/source/_templates/base.html
+++ b/documentation/source/_templates/base.html
@@ -2,5 +2,5 @@
 
 {% block extrahead %}
   {# Make Fosstodon display opendylan.org as a validated website in the @DylanLang profile. #}
-  <link rel="me" href="https://fosstodon.org/@DylanLang" />
+  <link rel="me" href="https://fosstodon.org/@DylanLang">
 {% endblock %}


### PR DESCRIPTION
The website is still not marked as verified on Fosstodon.  Maybe the unnecessary / in the link was causing a problem?