### PR TITLE
Runtime manager transaction logging

### DIFF
--- a/sources/environment/dfmc/application/address-objects.dylan
+++ b/sources/environment/dfmc/application/address-objects.dylan
@@ -92,7 +92,7 @@ define method address-to-string
   let value = address.application-object-proxy;
 
   // The access-path can perform this transformation for us.
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "address-to-string")
     remote-value-as-string(path, value, numerical-base-description(format))
   end
 end method address-to-string;
@@ -109,7 +109,7 @@ define method string-to-address
   let address = $invalid-address-object;
 
   // The access-path can perform this transformation for us.
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "string-to-address")
     let value
       = string-as-remote-value(path, representation,
                                numerical-base-description(format));
@@ -127,7 +127,7 @@ define method address-application-object
   => (obj :: <application-object>)
   let target = application.application-target-app;
   let obj = address;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "address-application-object")
     let value = address.application-object-proxy;
     make-environment-object-for-runtime-value
       (application, value, address?: #t)
@@ -141,7 +141,7 @@ define method application-object-address
     (application :: <dfmc-application>, obj :: <application-object>)
  => (address :: false-or(<address-object>))
   let target = application.application-target-app;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "application-object-address")
     let proxy = obj.application-object-proxy;
     if (proxy)
       let value = runtime-proxy-to-remote-value(application, proxy);
@@ -159,7 +159,7 @@ define method indirect-address
     (application :: <dfmc-application>, address :: <address-object>)
  => (i-address :: <address-object>)
   let target = application.application-target-app;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "indirect-address")
     block ()
       let raw-addr = address.application-object-proxy;
       let path = target.debug-target-access-path;
@@ -197,7 +197,7 @@ define method address-read-application-object
     (application :: <dfmc-application>, address :: <address-object>)
  => (obj :: false-or(<application-object>))
   let target = application.application-target-app;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "address-read-application-object")
     block ()
       let raw-addr = address.application-object-proxy;
       let val = read-dylan-value(target, raw-addr);
@@ -224,7 +224,7 @@ define method address-read-memory-contents
   let target = application.application-target-app;
   let sz = to-index - from-index + 1;
   let printable-strings = make(<vector>, size: sz, fill: "");
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "address-read-memory-contents")
     let path = target.debug-target-access-path;
     let base-addr = address.application-object-proxy;
     let next-addr

--- a/sources/environment/dfmc/application/app-server.dylan
+++ b/sources/environment/dfmc/application/app-server.dylan
@@ -315,7 +315,8 @@ define method perform-application-transaction
  => (#rest values)
   let target = application.application-target-app;
   if (target)
-    perform-debugger-transaction(target, function)
+    perform-debugger-transaction(target, function,
+                                 name: "perform-application-transaction")
   else
     function()
   end

--- a/sources/environment/dfmc/application/application-objects.dylan
+++ b/sources/environment/dfmc/application/application-objects.dylan
@@ -256,7 +256,7 @@ define method application-object-class
     (application :: <dfmc-application>, obj :: <application-object>)
  => (class-obj :: false-or(<class-object>))
   let target = application.application-target-app;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "application-object-class")
     let proxy = obj.application-object-proxy;
     if (proxy)
       let proxy-value = runtime-proxy-to-remote-value(application, proxy);

--- a/sources/environment/dfmc/application/breakpoint-objects.dylan
+++ b/sources/environment/dfmc/application/breakpoint-objects.dylan
@@ -175,12 +175,13 @@ define method function-entry-callback
                 = runtime-proxy-to-remote-value(application, proxy);
               remote-generic-function-inspect(target, function-value)
             else
-              debug-out(#"dfmc-environment-application",
-                        "Failed to find proxy for method or generic!")
+              debug-target-message
+                (target, $warn-level,
+                 "Failed to find proxy for method or generic!");
             end;
           otherwise =>
-            debug-out(#"dfmc-environment-application",
-                      "Failed to find generic proxy!");
+            debug-target-message
+              (target, $warn-level, "Failed to find generic proxy!");
         end
       end;
   let (required-values, rest-value, keyword-values)
@@ -194,8 +195,8 @@ define method function-entry-callback
                rest & constructor(rest),
                keywords & map(constructor, keywords))
       else
-        debug-out(#"dfmc-environment-application",
-                  "No signature for breakpoint function!");
+        debug-target-message
+          (target, $warn-level, "No signature for breakpoint function!");
         values(#[], #f, #[])
       end;
   breakpoint-info(application, breakpoint)

--- a/sources/environment/dfmc/application/breakpoint-objects.dylan
+++ b/sources/environment/dfmc/application/breakpoint-objects.dylan
@@ -579,7 +579,7 @@ define method server-note-breakpoint-state-changed
      bp, state-change);
   unless (breakpoint-has-failed-already?(application, bp))
     let cc = use-project-proxy & use-project-proxy.project-browsing-context;
-    with-debugger-transaction (target)
+    with-debugger-transaction (target, name: "server-note-breakpoint-state-changed")
       block ()
         debug-target-message
           (target, $debug-level,

--- a/sources/environment/dfmc/application/breakpoint-objects.dylan
+++ b/sources/environment/dfmc/application/breakpoint-objects.dylan
@@ -288,6 +288,10 @@ define method function-object-breakpoint-address
   let project = application.server-project;
   let source-location
     = environment-object-source-location(project, function-object);
+  debug-target-message
+    (target, $debug-level,
+     "function-object-breakpoint-address %=, source-location=%=",
+     function-object, source-location);
   case
     source-location =>
       let source-record = source-location.source-location-source-record;
@@ -300,12 +304,18 @@ define method function-object-breakpoint-address
              interactive-only?:   #f,
              entry-point-only?:   entry-point?,
              compilation-context: context);
+      debug-target-message
+        (target, $debug-level, "source-location is at %= (exact?=%=)",
+         address, exact);
       address;
     instance?(function-object, <generic-function-object>) =>
       #f;
     otherwise =>
       //---*** We need to handle entry-point? in here too!
       let proxy = ensure-application-proxy(application, function-object);
+      debug-target-message
+        (target, $debug-level, "function-object-breakpoint-address (no source) proxy=%=",
+         proxy);
       if (proxy)
         let function-value = runtime-proxy-to-remote-value(application, proxy);
         let (sig, breakpoint-address, keyword-specifiers)
@@ -320,11 +330,17 @@ define method calculate-breakpoint-address
      bp-object :: <function-breakpoint-object>,
      #key compilation-context = #f)
   => (address-we-hope :: false-or(<remote-value>))
+  let target = application.application-target-app;
   let function = bp-object.breakpoint-object;
+  debug-target-message
+    (target, $debug-level, "calculate-breakpoint-address %=, function: %=",
+     bp-object, function);
   ensure-application-proxy(application, function);
   if (instance?(function, <method-object>))
     let project = application.server-project;
     let gf = method-generic-function(project, function);
+    debug-target-message
+      (target, $debug-level, "calculate-breakpoint-address gf=%=", gf);
     gf & ensure-application-proxy(application, gf)
   end;
   ensure-application-proxy(application, function);
@@ -557,15 +573,24 @@ define method server-note-breakpoint-state-changed
      state-change :: <breakpoint-state>,
      #key use-project-proxy = application.server-project.project-proxy)
  => ()
+  let target = application.application-target-app;
+  debug-target-message
+    (target, $debug-level, "server-note-breakpoint-state-changed %= %s",
+     bp, state-change);
   unless (breakpoint-has-failed-already?(application, bp))
-    let target = application.application-target-app;
     let cc = use-project-proxy & use-project-proxy.project-browsing-context;
     with-debugger-transaction (target)
       block ()
+        debug-target-message
+          (target, $debug-level,
+           "Handling breakpoint state change to %s", state-change);
         select (state-change)
           #"created" =>
             let proxy = find-or-instantiate-proxy(application, bp,
                                                   compilation-context: cc);
+            debug-target-message
+              (target, $debug-level, "%= enabled?=%=",
+               bp, bp.breakpoint-enabled?);
             if (bp.breakpoint-enabled?)
               register-proxy-if-necessary(application, proxy)
             end;
@@ -578,6 +603,9 @@ define method server-note-breakpoint-state-changed
           #"enabled?" =>
             let proxy = find-or-instantiate-proxy(application, bp,
                                                   compilation-context: cc);
+            debug-target-message
+              (target, $debug-level, "%= enabled?=%=",
+               bp, bp.breakpoint-enabled?);
             if (bp.breakpoint-enabled?)
               register-proxy-if-necessary(application, proxy);
             else
@@ -587,7 +615,9 @@ define method server-note-breakpoint-state-changed
           otherwise => #f;
 
         end
-      exception (<breakpoint-error>)
+      exception (e :: <breakpoint-error>)
+        debug-target-message
+          (target, $debug-level, "Breakpoint state handling exception %=", e);
         if (application.application-state == #"running")
           note-breakpoint-state-changes-failed
             (application.server-project, vector(bp), state-change);

--- a/sources/environment/dfmc/application/class-objects.dylan
+++ b/sources/environment/dfmc/application/class-objects.dylan
@@ -14,7 +14,7 @@ define method singleton-value
     (application :: <dfmc-application>, singleton-obj :: <singleton-object>)
  => (val :: <environment-object>)
   let target = application.application-target-app;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "singleton-value")
     let proxy = singleton-obj.application-object-proxy;
     let remote-singleton = runtime-proxy-to-remote-value(application, proxy);
 
@@ -45,7 +45,7 @@ define method do-direct-subclasses
   // Within a debugger transaction, get an exploded view of the class.
   // For each direct subclass, intern a new proxy and build an environment
   // object. Apply the supplied function to it.
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "do-direct-subclasses")
     let proxy = ensure-application-value-proxy(application, class);
     let proxy-value = runtime-proxy-to-remote-value(application, proxy);
     let (direct-subs, direct-supers, all-supers,
@@ -71,7 +71,7 @@ define method do-direct-superclasses
   // Within a debugger transaction, get an exploded view of the class.
   // For each direct superclass, intern a new proxy and build an environment
   // object. Apply the supplied function to it.
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "do-direct-superclasses")
     let proxy = ensure-application-value-proxy(application, class);
     let proxy-value = runtime-proxy-to-remote-value(application, proxy);
     let (direct-subs, direct-supers, all-supers,
@@ -97,7 +97,7 @@ define method do-direct-methods
   // Within a debugger transaction, get an exploded view of the class.
   // For each direct method, intern a new proxy and build an environment
   // object. Apply the supplied function to it.
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "do-direct-methods")
     let proxy = ensure-application-value-proxy(application, class);
     let proxy-value = runtime-proxy-to-remote-value(application, proxy);
     let (direct-subs, direct-supers, all-supers,
@@ -123,7 +123,7 @@ define method do-direct-slots
   // Within a debugger transaction, get an exploded view of the class.
   // For each direct slot, intern a new proxy and build an environment
   // object. Apply the supplied function to it.
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "do-direct-slots")
     let proxy = ensure-application-value-proxy(application, class);
     let proxy-value = runtime-proxy-to-remote-value(application, proxy);
     let (direct-subs, direct-supers, all-supers,
@@ -149,7 +149,7 @@ define method do-all-superclasses
   // Within a debugger transaction, get an exploded view of the class.
   // For each superclass, intern a new proxy and build an environment
   // object. Apply the supplied function to it.
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "do-all-superclasses")
     let proxy = ensure-application-value-proxy(application, class);
     let proxy-value = runtime-proxy-to-remote-value(application, proxy);
     let (direct-subs, direct-supers, all-supers,
@@ -175,7 +175,7 @@ define method do-all-slots
   // Within a debugger transaction, get an exploded view of the class.
   // For each slot, intern a new proxy and build an environment
   // object. Apply the supplied function to it.
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "do-all-slots")
     let proxy = ensure-application-value-proxy(application, class);
     let proxy-value = runtime-proxy-to-remote-value(application, proxy);
     let (direct-subs, direct-supers, all-supers,

--- a/sources/environment/dfmc/application/collection-objects.dylan
+++ b/sources/environment/dfmc/application/collection-objects.dylan
@@ -13,7 +13,7 @@ define method collection-size
     (application :: <dfmc-application>, collection :: <collection-object>)
  => (size :: <integer>)
   let target = application.application-target-app;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "collection-size")
     let proxy = collection.application-object-proxy;
     let cl = runtime-proxy-to-remote-value(application, proxy);
     remote-collection-size(target, cl)
@@ -115,7 +115,7 @@ define method do-collection-contents
   // subset of the collection. That done, construct application environment
   // objects for each key.
 
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "do-collection-contents")
     let proxy-value = runtime-proxy-to-remote-value(application, proxy);
     let (key-vals, el-vals)
       = remote-collection-inspect(target, proxy-value,

--- a/sources/environment/dfmc/application/component-objects.dylan
+++ b/sources/environment/dfmc/application/component-objects.dylan
@@ -38,22 +38,18 @@ define method lookup-component-by-name
                                   application-object-proxy: l)
         end method;
 
-  perform-debugger-transaction
-    (target,
-     method ()
-       let path = target.debug-target-access-path;
-       component :=
-         block(return)
-           do-libraries(method (l :: <remote-library>) => ()
-                          if (l.library-core-name = name)
-                            return(wrap-for-env(l))
-                          end if
-                        end method,
-                        path);
-           return(#f)
-         end block
-     end method);
-  component
+  with-debugger-transaction (target, name: "lookup-component-by-name")
+    let path = target.debug-target-access-path;
+    block(return)
+      do-libraries(method (l :: <remote-library>) => ()
+                     if (l.library-core-name = name)
+                       return(wrap-for-env(l))
+                     end if
+                   end method,
+                   path);
+      return(#f)
+    end block
+  end with-debugger-transaction
 end method;
 
 
@@ -70,13 +66,11 @@ define method do-application-components
                                   application-object-proxy: l)
         end method;
 
-  perform-debugger-transaction
-    (target,
-     method ()
-       let path = target.debug-target-access-path;
-       do-libraries(method (l :: <remote-library>) => ()
-                      f(wrap-for-env(l))
-                    end method,
-                    path);
-     end method);
+  with-debugger-transaction (target, name: "do-applicationn-components")
+    let path = target.debug-target-access-path;
+    do-libraries(method (l :: <remote-library>) => ()
+                   f(wrap-for-env(l))
+                 end method,
+                 path);
+  end with-debugger-transaction;
 end method;

--- a/sources/environment/dfmc/application/composite-objects.dylan
+++ b/sources/environment/dfmc/application/composite-objects.dylan
@@ -15,35 +15,29 @@ define method composite-object-size
      #key inherited? = #f)
         => (sz :: <integer>)
   let target = application.application-target-app;
-  let sz = 0;
 
   // Within a debugger transaction, get the proxy for this composite
   // object, and call the DM to calculate the total number of slots
   // in the object.
-  perform-debugger-transaction
-    (target,
-     method ()
-       let proxy = ro.application-object-proxy;
-       let proxy-value = runtime-proxy-to-remote-value(application, proxy);
-       let (byte-size, fixed-count, element-count)
-         = dylan-object-size(target, proxy-value);
-       let (class, incarnation, current-incarnation, immediate?)
-         = dylan-object-class(target, proxy-value);
-       let class-proxy =
-         exchange-value-proxy-for-browsable-class-proxy
-           (application, proxy);
-       if (class-proxy)
-         let (slots, navigation, repeat, count-offset, element-size,
-              element-offset, class-slot-count)
-            = class-proxy-browser-information
-                (application, class-proxy, incarnation: incarnation);
-         sz := fixed-count + class-slot-count;
-       else
-         sz := fixed-count;
-       end if;
-     end method);
-
-  sz;
+  with-debugger-transaction (target, name: "composite-object-size")
+    let proxy = ro.application-object-proxy;
+    let proxy-value = runtime-proxy-to-remote-value(application, proxy);
+    let (byte-size, fixed-count, element-count)
+      = dylan-object-size(target, proxy-value);
+    let (class, incarnation, current-incarnation, immediate?)
+      = dylan-object-class(target, proxy-value);
+    let class-proxy
+      = exchange-value-proxy-for-browsable-class-proxy(application, proxy);
+    if (class-proxy)
+      let (slots, navigation, repeat, count-offset, element-size,
+           element-offset, class-slot-count)
+        = class-proxy-browser-information
+        (application, class-proxy, incarnation: incarnation);
+      fixed-count + class-slot-count
+    else
+      fixed-count
+    end if
+  end with-debugger-transaction
 end method;
 
 
@@ -64,58 +58,55 @@ define method composite-object-contents
   // Within a debugger transaction, get the proxy for this composite
   // object, and exchange it for its class proxy. Get the browser
   // navigation info from the class, and use that to unpick the object.
-  perform-debugger-transaction
-    (target,
-     method ()
-       let proxy = ro.application-object-proxy;
-       let class-proxy =
-         exchange-value-proxy-for-browsable-class-proxy
-           (application, proxy);
-       if (class-proxy)
-         let proxy-value = runtime-proxy-to-remote-value(application, proxy);
-         let (class, incarnation, current-incarnation, immediate?)
-           = dylan-object-class(target, proxy-value);
-         let (slots, navigation, repeat, count-offset, element-size,
-              element-offset, class-slot-count)
-            = class-proxy-browser-information
-                (application, class-proxy, incarnation: incarnation);
-         let class-object =
-           runtime-proxy-to-remote-value(application, class-proxy);
-         let (byte-size, fixed-count, element-count)
-            = dylan-object-size(target, proxy-value);
-         let (class-slot-names, class-slots, class-slot-values)
-           = dylan-class-slot-storage
-                (target, class-object, use-incarnation: incarnation);
-         if (repeat)
-           names := make(<vector>, size: fixed-count + 1 + class-slot-count);
-           vals := make(<vector>, size: fixed-count + 1 + class-slot-count);
-         else
-           names := make(<vector>, size: fixed-count + class-slot-count);
-           vals := make(<vector>, size: fixed-count + class-slot-count);
-         end if;
-         let i = 0;
-         for (j from 0 below class-slot-count)
-           names[i] := class-slot-names[j];
-           vals[i] :=
-             make-environment-object-for-runtime-value
+  with-debugger-transaction (target, name: "composite-object-contents")
+    let proxy = ro.application-object-proxy;
+    let class-proxy
+      = exchange-value-proxy-for-browsable-class-proxy(application, proxy);
+    if (class-proxy)
+      let proxy-value = runtime-proxy-to-remote-value(application, proxy);
+      let (class, incarnation, current-incarnation, immediate?)
+        = dylan-object-class(target, proxy-value);
+      let (slots, navigation, repeat, count-offset, element-size,
+           element-offset, class-slot-count)
+        = class-proxy-browser-information
+        (application, class-proxy, incarnation: incarnation);
+      let class-object
+        = runtime-proxy-to-remote-value(application, class-proxy);
+      let (byte-size, fixed-count, element-count)
+        = dylan-object-size(target, proxy-value);
+      let (class-slot-names, class-slots, class-slot-values)
+        = dylan-class-slot-storage(target, class-object,
+                                   use-incarnation: incarnation);
+      if (repeat)
+        names := make(<vector>, size: fixed-count + 1 + class-slot-count);
+        vals := make(<vector>, size: fixed-count + 1 + class-slot-count);
+      else
+        names := make(<vector>, size: fixed-count + class-slot-count);
+        vals := make(<vector>, size: fixed-count + class-slot-count);
+      end if;
+      let i = 0;
+      for (j from 0 below class-slot-count)
+        names[i] := class-slot-names[j];
+        vals[i]
+          := make-environment-object-for-runtime-value
                (application, class-slot-values[i]);
-           i := i + 1;
-         end for;
-         for (name-offset-pair in slots)
-           let slot-name = head(name-offset-pair);
-           let slot-value =
-             read-dylan-value(target,
-                              indexed-remote-value(proxy-value,
-                                                   tail(name-offset-pair)));
-           names[i] := slot-name;
-           vals[i] :=
-             make-environment-object-for-runtime-value
+        i := i + 1;
+      end for;
+      for (name-offset-pair in slots)
+        let slot-name = head(name-offset-pair);
+        let slot-value
+          = read-dylan-value(target,
+                             indexed-remote-value(proxy-value,
+                                                  tail(name-offset-pair)));
+        names[i] := slot-name;
+        vals[i]
+          := make-environment-object-for-runtime-value
                (application, slot-value);
-           i := i + 1;
-         end for;
-       end if
-     end method);
+        i := i + 1;
+      end for;
+    end if
+  end with-debugger-transaction;
 
-  values(names, vals);
+  values(names, vals)
 end method;
 

--- a/sources/environment/dfmc/application/control-protocols.dylan
+++ b/sources/environment/dfmc/application/control-protocols.dylan
@@ -347,11 +347,11 @@ end method;
 // a continue callback
 
 define method perform-continuing-debugger-transaction
-    (application :: <dfmc-application>, remote-thread,
+    (application :: <dfmc-application>, remote-thread, name :: <string>,
      transaction :: <function>)
  => (#rest results)
   perform-debugger-transaction
-    (application.application-target-app, transaction,
+    (application.application-target-app, transaction, name: name,
      continue:
        method()
            continue-application-runtime(application, remote-thread)
@@ -371,7 +371,7 @@ define method close-application
     invalidate-interactive-compiler-proxies(application);
 
     perform-continuing-debugger-transaction
-      (application, #f,
+      (application, #f, "close-application",
        method ()
          kill-target-application(target);
        end);
@@ -456,7 +456,7 @@ define method step-application-out
   // Ensuring that a debugger transaction is in effect, tell the DM
   // to instruct the thread to perform the step-out operation.
   perform-continuing-debugger-transaction
-     (application, remote-thread,
+     (application, remote-thread, "step-application-out",
       method ()
         if (call-frame)
           instruct-thread-to-step-out(target, remote-thread,
@@ -489,7 +489,7 @@ define method step-application-over
   // Ensuring that a debugger transaction is in effect, tell the DM
   // to instruct the thread to perform the step-over operation.
   perform-continuing-debugger-transaction
-     (application, remote-thread,
+     (application, remote-thread, "step-application-over",
       method ()
         if (call-frame)
           instruct-thread-to-step-over(target, remote-thread,
@@ -514,7 +514,7 @@ define method step-application-into
   let callees =
     top-function & function-called-functions(application, top-function);
   perform-continuing-debugger-transaction
-    (application, remote-thread,
+    (application, remote-thread, "step-application-into",
      method ()
        let addresses =
          if (callees)

--- a/sources/environment/dfmc/application/control-protocols.dylan
+++ b/sources/environment/dfmc/application/control-protocols.dylan
@@ -395,9 +395,11 @@ end method close-application;
 
 define method invalidate-interactive-compiler-proxies
     (application :: <dfmc-application>) => ()
+  let target = application.application-target-app;
+  debug-target-message
+    (target, $warn-level,
+     "Failing to invalidate interactive proxies!");
   //---*** Need to do this!
-  debug-out(#"dfmc-environment-application",
-            "Failing to invalidate interactive proxies!");
   /*
   let project = database.server-project;
   let object-table = compiler-object-table(database);

--- a/sources/environment/dfmc/application/definition-tracking.dylan
+++ b/sources/environment/dfmc/application/definition-tracking.dylan
@@ -16,17 +16,10 @@ define method find-application-proxy
   let target = application.application-target-app;
   let (binding-name, module-name, library-name)
     = definition-id-to-string-triple(id);
-  let proxy = #f;
-  perform-debugger-transaction
-    (target,
-     method ()
-       proxy :=
-         application-name-to-runtime-proxy(application,
-                                           binding-name,
-                                           module-name,
-                                           library-name)
-     end method);
-  proxy;
+  with-debugger-transaction (target, name: "find-application-proxy")
+    application-name-to-runtime-proxy
+      (application, binding-name, module-name, library-name)
+  end with-debugger-transaction;
 end method;
 
 

--- a/sources/environment/dfmc/application/dylan-objects.dylan
+++ b/sources/environment/dfmc/application/dylan-objects.dylan
@@ -13,7 +13,7 @@ define method pair-head
     (application :: <dfmc-application>, pair-object :: <pair-object>)
  => (head-object :: false-or(<application-object>))
   let target = application.application-target-app;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "pair-head")
     let pair-value
       = runtime-proxy-to-remote-value
           (application, pair-object.application-object-proxy);
@@ -31,7 +31,7 @@ define method pair-tail
     (application :: <dfmc-application>, pair-object :: <pair-object>)
  => (tail-object :: false-or(<application-object>))
   let target = application.application-target-app;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "pair-tail")
     let pair-value
       = runtime-proxy-to-remote-value
           (application, pair-object.application-object-proxy);
@@ -55,7 +55,7 @@ define method collection-size
   // end value, so we'll return #f.
   let target = application.application-target-app;
   let has-end?
-    = with-debugger-transaction (target)
+    = with-debugger-transaction (target, name: "collection-size <range>")
         let range-value
           = runtime-proxy-to-remote-value
               (application, range-object.application-object-proxy);
@@ -78,7 +78,7 @@ define method range-start
     (application :: <dfmc-application>, range-object :: <range-object>)
  => (s :: <number-object>)
   let target = application.application-target-app;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "range-start")
     let range-value
       = runtime-proxy-to-remote-value
           (application, range-object.application-object-proxy);
@@ -96,7 +96,7 @@ define method range-end
     (application :: <dfmc-application>, range-object :: <range-object>)
  => (e :: false-or(<number-object>))
   let target = application.application-target-app;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "range-end")
     let range-value
       = runtime-proxy-to-remote-value
           (application, range-object.application-object-proxy);
@@ -116,7 +116,7 @@ define method range-by
     (application :: <dfmc-application>, range-object :: <range-object>)
  => (b :: false-or(<number-object>))
   let target = application.application-target-app;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "range-by")
     let range-value
       = runtime-proxy-to-remote-value
           (application, range-object.application-object-proxy);

--- a/sources/environment/dfmc/application/environment-objects.dylan
+++ b/sources/environment/dfmc/application/environment-objects.dylan
@@ -14,7 +14,7 @@ define method get-environment-object-primitive-name
     (application :: <dfmc-application>, obj :: <application-object>)
  => (name :: <string>)
   let target = application.application-target-app;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "get-environment-object-primitive-name")
     let proxy = obj.application-object-proxy;
     application-proxy-primitive-name(application, proxy, decorate?: #t)
   end
@@ -24,7 +24,7 @@ define method get-environment-object-primitive-name
     (application :: <dfmc-application>, obj :: <symbol-object>)
  => (name :: <string>)
   let target = application.application-target-app;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "get-environment-object-primitive-name")
     let proxy = obj.application-object-proxy;
     application-proxy-primitive-name(application, proxy, decorate?: #f)
   end
@@ -34,7 +34,7 @@ define method get-environment-object-primitive-name
     (application :: <dfmc-application>, obj :: <number-object>)
  => (name :: <string>)
   let target = application.application-target-app;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "get-environment-object-primitive-name")
     let proxy = obj.application-object-proxy;
     application-proxy-primitive-name(application, proxy, decorate?: #f)
   end
@@ -46,7 +46,7 @@ define method number-object-to-string
           prefix? :: <boolean> = #t)
  => (name :: <string>)
   let target = application.application-target-app;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "number-object-to-string")
     let proxy = obj.application-object-proxy;
     let value = runtime-proxy-to-remote-value(application, proxy);
     let text = print-dylan-object(target, value, format: format);
@@ -68,7 +68,7 @@ define method get-environment-object-primitive-name
     (application :: <dfmc-application>, obj :: <character-object>)
  => (name :: <string>)
   let target = application.application-target-app;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "get-environment-object-primitive-name")
     let proxy = obj.application-object-proxy;
     application-proxy-primitive-name(application, proxy, decorate?: #f)
   end
@@ -78,7 +78,7 @@ define method get-environment-object-primitive-name
     (application :: <dfmc-application>, obj :: <string-object>)
  => (name :: <string>)
   let target = application.application-target-app;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "get-environment-object-primitive-name")
     let proxy = obj.application-object-proxy;
     application-proxy-primitive-name(application, proxy, decorate?: #f)
   end
@@ -88,7 +88,7 @@ define method get-environment-object-primitive-name
     (application :: <dfmc-application>, obj :: <boolean-object>)
  => (name :: <string>)
   let target = application.application-target-app;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "get-environment-object-primitive-name")
     let proxy = obj.application-object-proxy;
     application-proxy-primitive-name(application, proxy, decorate?: #f)
   end

--- a/sources/environment/dfmc/application/evaluations.dylan
+++ b/sources/environment/dfmc/application/evaluations.dylan
@@ -150,16 +150,11 @@ define method project-runtime-context
      #key stack-frame = #f)
         => (runtime-context)
   let target = application.application-target-app;
-  let context = #f;
   let remote-thread = thread.application-object-proxy;
   let frame = stack-frame & stack-frame.application-object-proxy;
-  perform-debugger-transaction
-     (target,
-      method ()
-        context :=
-          current-runtime-context(target, remote-thread, stack-frame: frame);
-      end method);
-  context;
+  with-debugger-transaction (target, name: "project-runtime-context")
+    current-runtime-context(target, remote-thread, stack-frame: frame)
+  end with-debugger-transaction
 end method;
 
 
@@ -224,7 +219,7 @@ define method project-execute-code
     // Otherwise, call the project manager's API to actually download the
     // expression.
     perform-continuing-debugger-transaction
-      (app, remote-thread,
+      (app, remote-thread, "project-execute-code",
        method ()
 
          let evaluation-on-suspended-thread? =
@@ -310,35 +305,31 @@ define method execute-function
   let remote-thread = thread.application-object-proxy;
   let id = #f;
 
-  perform-debugger-transaction
-      (target,
-       method ()
-         let evaluation-on-suspended-thread? =
-           thread-permanently-suspended?(path, remote-thread);
+  with-debugger-transaction (target, name: "execute-function")
+    let evaluation-on-suspended-thread?
+      = thread-permanently-suspended?(path, remote-thread);
+    if (evaluation-on-suspended-thread?)
+      resume-evaluator-thread(app, thread.application-object-proxy);
+    end;
 
-         if (evaluation-on-suspended-thread?)
-           resume-evaluator-thread(app, thread.application-object-proxy);
-         end;
+    if (evaluation-on-suspended-thread?
+          | thread-available-for-interaction?(target, remote-thread))
+      let transaction :: <interactor-return-breakpoint> = function();
+      id := transaction;
 
-         if (evaluation-on-suspended-thread?
-             | thread-available-for-interaction?(target, remote-thread))
-           let transaction :: <interactor-return-breakpoint> = function();
-           id := transaction;
+      transaction.interaction-request-application-state := state;
 
-           transaction.interaction-request-application-state := state;
+      if (evaluation-on-suspended-thread?)
+        thread-state-transaction(app, remote-thread) := transaction;
+      end;
 
-           if (evaluation-on-suspended-thread?)
-             thread-state-transaction(app, remote-thread) := transaction;
-           end;
-
-           invoke-application-callback
-             (app, application-started-interaction-callback, thread, id);
-         else
-           error("Cannot perform the requested interaction");
-         end if;
-       end method);
-
-    id
+      invoke-application-callback
+      (app, application-started-interaction-callback, thread, id);
+    else
+      error("Cannot perform the requested interaction");
+    end if;
+  end with-debugger-transaction;
+  id
 end method;
 
 
@@ -363,18 +354,16 @@ define method fetch-interactor-return-values
     element(application.interactor-results-table, id, default: #f);
   if (remote-value-seq)
     env-obj-seq := make(<vector>, size: size(remote-value-seq));
-    perform-debugger-transaction
-       (target,
-        method ()
-          for (i from 0 below size(remote-value-seq))
-            env-obj-seq[i] :=
-              pair(head(remote-value-seq[i]),
-                   make-environment-object-for-runtime-value
-                      (application, tail(remote-value-seq[i])));
-          end for;
-        end method);
+    with-debugger-transaction (target, name: "fetch-interactor-return-values")
+      for (i from 0 below size(remote-value-seq))
+        env-obj-seq[i]
+          := pair(head(remote-value-seq[i]),
+                  make-environment-object-for-runtime-value
+                    (application, tail(remote-value-seq[i])));
+      end for;
+    end with-debugger-transaction;
   end if;
-  env-obj-seq;
+  env-obj-seq
 end method;
 
 

--- a/sources/environment/dfmc/application/function-objects.dylan
+++ b/sources/environment/dfmc/application/function-objects.dylan
@@ -324,9 +324,10 @@ define method do-generic-function-methods
     let (sig, method-values)
       = remote-generic-function-inspect(target, generic-value);
 
-    debug-out(#"dfmc-environment-application",
-              "Generic function: signature %=, methods %=",
-              sig, method-values);
+    debug-target-message
+      (target, $debug-level,
+       "Generic function: signature %=, methods %=",
+       sig, method-values);
 
     //---*** andrewa: this won't match up with the same methods
     //---*** from the compiler database. :-(
@@ -397,8 +398,10 @@ end method;
 define method method-generic-function
     (application :: <dfmc-application>, meth :: <method-object>)
  => (parent-gf :: false-or(<generic-function-object>))
-  debug-out(#"dfmc-environment-application",
-            "Ignoring method-generic-function in application server");
+  let target = application.application-target-app;
+  debug-target-message
+    (target, $warn-level,
+     "Ignoring method-generic-function in application server");
   #f
 end method;
 

--- a/sources/environment/dfmc/application/function-objects.dylan
+++ b/sources/environment/dfmc/application/function-objects.dylan
@@ -89,87 +89,83 @@ define method function-parameters
   // values while still within the debugger transaction (because it might
   // involve the interning of proxies and construction of environment
   // objects).
-  perform-debugger-transaction
-    (target,
-     method ()
-       let function-proxy =
-         ensure-application-value-proxy(application, func);
+  with-debugger-transaction (target, name: "function-parameters")
+    let function-proxy
+      = ensure-application-value-proxy(application, func);
 
-       // Get the actual value of the function object from its interned
-       // proxy.
-       let function-value =
-         runtime-proxy-to-remote-value(application, function-proxy);
+    // Get the actual value of the function object from its interned
+    // proxy.
+    let function-value
+      = runtime-proxy-to-remote-value(application, function-proxy);
 
-       // Call the DM's inspector for generic functions,
-       let (sig, methods) =
-         remote-generic-function-inspect(target, function-value);
+    // Call the DM's inspector for generic functions,
+    let (sig, methods)
+      = remote-generic-function-inspect(target, function-value);
 
-       // Call the DM's inspector for the signature. We are not interested
-       // in the method list for the time being, although there may come
-       // a time when we have to look at the signatures for all the methods,
-       // in order to get a union of all accepted keywords. Nasty.
-       let (reqtypes, valtypes, rtype, kwds, ktypes) =
-         remote-signature-inspect(target, sig);
+    // Call the DM's inspector for the signature. We are not interested
+    // in the method list for the time being, although there may come
+    // a time when we have to look at the signatures for all the methods,
+    // in order to get a union of all accepted keywords. Nasty.
+    let (reqtypes, valtypes, rtype, kwds, ktypes)
+      = remote-signature-inspect(target, sig);
 
-       // We now know the size of the returned sequences.
-       required := make(<vector>, size: size(reqtypes));
-       vals := make(<vector>, size: size(valtypes));
+    // We now know the size of the returned sequences.
+    required := make(<vector>, size: size(reqtypes));
+    vals := make(<vector>, size: size(valtypes));
 
-       // Iterate over the required arguments, generating <parameter> objects
-       // with invented names (based on the counter, since we don't know
-       // their real names from the runtime), and environment objects for the
-       // types.
-       for (i from 0 below size(reqtypes))
-         let name-i = format-to-string("r%d", i);
-         let type-i =
-           make-environment-object-for-runtime-value
-             (application, reqtypes[i]);
-         required[i] := make(<parameter>, name: name-i, type: type-i);
-       end for;
+    // Iterate over the required arguments, generating <parameter> objects
+    // with invented names (based on the counter, since we don't know
+    // their real names from the runtime), and environment objects for the
+    // types.
+    for (i from 0 below size(reqtypes))
+      let name-i = format-to-string("r%d", i);
+      let type-i
+        = make-environment-object-for-runtime-value
+            (application, reqtypes[i]);
+      required[i] := make(<parameter>, name: name-i, type: type-i);
+    end for;
 
-       // Iterate over the return value types in the same way.
-       for (i from 0 below size(valtypes))
-         let name-i = format-to-string("v%d", i);
-         let type-i =
-           make-environment-object-for-runtime-value
-             (application, valtypes[i]);
-         vals[i] := make(<parameter>, name: name-i, type: type-i);
-       end for;
+    // Iterate over the return value types in the same way.
+    for (i from 0 below size(valtypes))
+      let name-i = format-to-string("v%d", i);
+      let type-i
+        = make-environment-object-for-runtime-value
+            (application, valtypes[i]);
+      vals[i] := make(<parameter>, name: name-i, type: type-i);
+    end for;
 
-       // If there's a typed #rest argument, build the parameter for it.
-       if (rtype)
-         let name-r = "args";
-         let type-r =
-           make-environment-object-for-runtime-value
-             (application, rtype);
-         rest := make(<parameter>, name: name-r, type: type-r);
-       end if;
+    // If there's a typed #rest argument, build the parameter for it.
+    if (rtype)
+      let name-r = "args";
+      let type-r
+        = make-environment-object-for-runtime-value(application, rtype);
+      rest := make(<parameter>, name: name-r, type: type-r);
+    end if;
 
-       // If there are keyword arguments present, construct the optional
-       // parameters for them.
-       if (kwds)
-         keys := make(<vector>, size: size(kwds));
-         for (k from 0 below size(kwds))
-           let name-k = dylan-keyword-name(target, kwds[k]);
-           let type-k =
-             make-environment-object-for-runtime-value
-                (application, ktypes[k]);
-           let default-k = #f;  // GF's can't have defaulted keyword args!!
-                                // Only methods can.
-           //---*** need to get the real keyword
-           let key-k = name-k;
-           keys[k] := make(<optional-parameter>,
-                           name: name-k,
-                           keyword: key-k,
-                           type: type-k,
-                           default-value: default-k);
-         end for
-       end if;
-
-     end method);
+    // If there are keyword arguments present, construct the optional
+    // parameters for them.
+    if (kwds)
+      keys := make(<vector>, size: size(kwds));
+      for (k from 0 below size(kwds))
+        let name-k = dylan-keyword-name(target, kwds[k]);
+        let type-k
+          = make-environment-object-for-runtime-value
+              (application, ktypes[k]);
+        let default-k = #f;  // GF's can't have defaulted keyword args!!
+                             // Only methods can.
+        //---*** need to get the real keyword
+        let key-k = name-k;
+        keys[k] := make(<optional-parameter>,
+                        name: name-k,
+                        keyword: key-k,
+                        type: type-k,
+                        default-value: default-k);
+      end for
+    end if;
+  end with-debugger-transaction;
 
   // Assume that we've "legalized" the return values as far as possible.
-  values(required, rest, keys, all-keys?, next, vals, rest-value);
+  values(required, rest, keys, all-keys?, next, vals, rest-value)
 end method;
 
 
@@ -222,87 +218,83 @@ define method function-parameters
   // involve the interning of proxies and construction of environment
   // objects).
 
-  perform-debugger-transaction
-    (target,
-     method ()
-       let function-proxy =
-         ensure-application-value-proxy(application, func);
+  with-debugger-transaction (target, name: "function-parameters")
+    let function-proxy
+      = ensure-application-value-proxy(application, func);
 
-       // Get the actual value of the function object from its interned
-       // proxy.
-       let function-value =
-         runtime-proxy-to-remote-value(application, function-proxy);
+    // Get the actual value of the function object from its interned
+    // proxy.
+    let function-value
+      = runtime-proxy-to-remote-value(application, function-proxy);
 
-       // Call the DM's inspector for methods.
-       let (sig, iep, keyword-specifiers) =
-         remote-method-inspect(target, function-value);
+    // Call the DM's inspector for methods.
+    let (sig, iep, keyword-specifiers)
+      = remote-method-inspect(target, function-value);
 
-       // Call the DM to inspect the signature. From there, we follow most
-       // of the same procedure as for generic functions.
+    // Call the DM to inspect the signature. From there, we follow most
+    // of the same procedure as for generic functions.
+    let (reqtypes, valtypes, rtype, kwds, ktypes)
+      = remote-signature-inspect(target, sig);
 
-       let (reqtypes, valtypes, rtype, kwds, ktypes) =
-         remote-signature-inspect(target, sig);
+    // We now know the size of the returned sequences.
+    required := make(<vector>, size: size(reqtypes));
+    vals := make(<vector>, size: size(valtypes));
 
-       // We now know the size of the returned sequences.
-       required := make(<vector>, size: size(reqtypes));
-       vals := make(<vector>, size: size(valtypes));
+    // Iterate over the required arguments, generating <parameter> objects
+    // with invented names (based on the counter, since we don't know
+    // their real names from the runtime), and environment objects for the
+    // types.
+    for (i from 0 below size(reqtypes))
+      let name-i = format-to-string("r%d", i);
+      let type-i
+        = make-environment-object-for-runtime-value
+            (application, reqtypes[i]);
+      required[i] := make(<parameter>, name: name-i, type: type-i);
+    end for;
 
-       // Iterate over the required arguments, generating <parameter> objects
-       // with invented names (based on the counter, since we don't know
-       // their real names from the runtime), and environment objects for the
-       // types.
-       for (i from 0 below size(reqtypes))
-         let name-i = format-to-string("r%d", i);
-         let type-i =
-           make-environment-object-for-runtime-value
-             (application, reqtypes[i]);
-         required[i] := make(<parameter>, name: name-i, type: type-i);
-       end for;
+    // Iterate over the return value types in the same way.
+    for (i from 0 below size(valtypes))
+      let name-i = format-to-string("v%d", i);
+      let type-i
+        = make-environment-object-for-runtime-value
+            (application, valtypes[i]);
+      vals[i] := make(<parameter>, name: name-i, type: type-i);
+    end for;
 
-       // Iterate over the return value types in the same way.
-       for (i from 0 below size(valtypes))
-         let name-i = format-to-string("v%d", i);
-         let type-i =
-           make-environment-object-for-runtime-value
-             (application, valtypes[i]);
-         vals[i] := make(<parameter>, name: name-i, type: type-i);
-       end for;
-
-       // If there's a typed #rest argument, build the parameter for it.
-       if (rtype)
-         let name-r = "args";
-         let type-r =
-           make-environment-object-for-runtime-value
-             (application, rtype);
+    // If there's a typed #rest argument, build the parameter for it.
+    if (rtype)
+      let name-r = "args";
+      let type-r
+        = make-environment-object-for-runtime-value(application, rtype);
          rest := make(<parameter>, name: name-r, type: type-r);
-       end if;
+    end if;
 
-       // If there are keyword arguments present, construct the optional
-       // parameters for them. Since this is a method, we may also have a
-       // default value in the list of keyword-specifiers from the method
-       // object.
+    // If there are keyword arguments present, construct the optional
+    // parameters for them. Since this is a method, we may also have a
+    // default value in the list of keyword-specifiers from the method
+    // object.
 
-       if (kwds)
-         keys := make(<vector>, size: size(kwds));
-         for (k from 0 below size(kwds))
-           let name-k = dylan-keyword-name(target, kwds[k]);
-           let type-k =
-             make-environment-object-for-runtime-value
-                (application, ktypes[k]);
-           let default-k = get-keyword-default(kwds[k], keyword-specifiers);
-           //---*** Need to get the real value for this!
-           let key-k = name-k;
-           keys[k] := make(<optional-parameter>,
-                           name: name-k,
-                           keyword: key-k,
-                           type: type-k,
-                           default-value: default-k);
-         end for
-       end if;
-     end method);
+    if (kwds)
+      keys := make(<vector>, size: size(kwds));
+      for (k from 0 below size(kwds))
+        let name-k = dylan-keyword-name(target, kwds[k]);
+        let type-k
+          = make-environment-object-for-runtime-value
+              (application, ktypes[k]);
+        let default-k = get-keyword-default(kwds[k], keyword-specifiers);
+        //---*** Need to get the real value for this!
+        let key-k = name-k;
+        keys[k] := make(<optional-parameter>,
+                        name: name-k,
+                        keyword: key-k,
+                        type: type-k,
+                        default-value: default-k);
+      end for;
+    end if;
+    end with-debugger-transaction;
 
   // Assume that we've "legalized" the return values as far as possible.
-  values(required, rest, keys, all-keys?, next, vals, rest-value);
+  values(required, rest, keys, all-keys?, next, vals, rest-value)
 end method;
 
 
@@ -322,27 +314,25 @@ define method do-generic-function-methods
   // methods. From each of these, intern a proxy and construct the
   // environment object. Apply the supplied function to the environment
   // object.
-  perform-debugger-transaction
-     (target,
-      method ()
-        let generic-proxy =
-          ensure-application-value-proxy(application, gf);
-        let generic-value =
-          runtime-proxy-to-remote-value(application, generic-proxy);
+  with-debugger-transaction (target, name: "do-generic-function-methods")
+    let generic-proxy
+      = ensure-application-value-proxy(application, gf);
+    let generic-value
+      = runtime-proxy-to-remote-value(application, generic-proxy);
 
-        // Inspect the generic function.
-        let (sig, method-values) =
-          remote-generic-function-inspect(target, generic-value);
+    // Inspect the generic function.
+    let (sig, method-values)
+      = remote-generic-function-inspect(target, generic-value);
 
-        debug-out(#"dfmc-environment-application",
-                  "Generic function: signature %=, methods %=",
-                  sig, method-values);
+    debug-out(#"dfmc-environment-application",
+              "Generic function: signature %=, methods %=",
+              sig, method-values);
 
-        //---*** andrewa: this won't match up with the same methods
-        //---*** from the compiler database. :-(
-        do-environment-objects-for-runtime-values
-          (do-this-one, application, method-values)
-      end method);
+    //---*** andrewa: this won't match up with the same methods
+    //---*** from the compiler database. :-(
+    do-environment-objects-for-runtime-values
+      (do-this-one, application, method-values)
+  end with-debugger-transaction;
 end method;
 
 
@@ -360,36 +350,33 @@ define method method-specializers
   // these being the specializers for the method concerned. Go through the
   // usual trauma of interning a runtime proxy for each one, and building
   // the appropriate environment object.
-  perform-debugger-transaction
-     (target,
-      method ()
-        let method-proxy =
-          ensure-application-value-proxy(application, meth);
+  with-debugger-transaction (target, name: "method-specializers")
+    let method-proxy
+      = ensure-application-value-proxy(application, meth);
 
-        let method-value =
-          runtime-proxy-to-remote-value(application, method-proxy);
+    let method-value
+      = runtime-proxy-to-remote-value(application, method-proxy);
 
-        // Call the DM's special inspector for methods. This function
-        // returns three values, but the signature is the first value, and
-        // that's the only one we want.
-        let sig = remote-method-inspect(target, method-value);
+    // Call the DM's special inspector for methods. This function
+    // returns three values, but the signature is the first value, and
+    // that's the only one we want.
+    let sig = remote-method-inspect(target, method-value);
 
-        // Call the DM's special inspector for signatures. This function
-        // returns several values, bu we are only interested in the first,
-        // so that is the only one we bind.
-        let reqtypes = remote-signature-inspect(target, sig);
+    // Call the DM's special inspector for signatures. This function
+    // returns several values, bu we are only interested in the first,
+    // so that is the only one we bind.
+    let reqtypes = remote-signature-inspect(target, sig);
 
-        // Now we know how big the return sequence is.
-        specializers := make(<vector>, size: size(reqtypes));
+    // Now we know how big the return sequence is.
+    specializers := make(<vector>, size: size(reqtypes));
 
-        // The usual story. Iterate over the sequence of specializers, and
-        // turn each one into a kosher environment object.
-        for (i from 0 below size(reqtypes))
-           specializers[i] :=
-             make-environment-object-for-runtime-value
-                (application, reqtypes[i]);
-        end for;
-      end method);
+    // The usual story. Iterate over the sequence of specializers, and
+    // turn each one into a kosher environment object.
+    for (i from 0 below size(reqtypes))
+      specializers[i]
+        := make-environment-object-for-runtime-value(application, reqtypes[i]);
+    end for;
+  end with-debugger-transaction;
 
   // Return the sequence of specializers.
   specializers;

--- a/sources/environment/dfmc/application/local-variable-objects.dylan
+++ b/sources/environment/dfmc/application/local-variable-objects.dylan
@@ -151,21 +151,15 @@ define method variable-value
   ignore(thread);
 
   let target = application.application-target-app;
-  let val = #f;
 
   // Ensuring a debugger transaction, get the <remote-value> for the
   // local variable, and construct the right kind of environment object
   // for it.
-  perform-debugger-transaction
-     (target,
-      method ()
-        ignore(variable.application-object-proxy.is-argument?);
-        val :=
-          make-environment-object-for-runtime-value
-             (application,
-              get-local-variable-value
-                (application, variable.application-object-proxy));
-      end method);
-
-  val;
+  with-debugger-transaction (target, name: "variable-value")
+    ignore(variable.application-object-proxy.is-argument?);
+    make-environment-object-for-runtime-value
+      (application,
+       get-local-variable-value
+         (application, variable.application-object-proxy))
+  end with-debugger-transaction
 end method;

--- a/sources/environment/dfmc/application/profiling.dylan
+++ b/sources/environment/dfmc/application/profiling.dylan
@@ -84,7 +84,7 @@ define method maybe-initialize-cpu-profiling
         & application.application-loaded-dylan-library?)
     let target = application.application-target-app;
     debug-target-message(target, $debug-level, "Initializing CPU profiling");
-    with-debugger-transaction (target)
+    with-debugger-transaction (target, name: "maybe-initialize-cpu-profiling")
       start-profiling(target, class-profiling?: #f);
       profile-state.state-profile-initialized? := #t
     end
@@ -104,7 +104,7 @@ define method maybe-initialize-allocation-profiling
     //---*** Temporary hack, this may not always be what we want but
     //---*** for now switch on breakpoints on all threads
     let interactive-thread = application-open-interactor-thread(application);
-    with-debugger-transaction (target)
+    with-debugger-transaction (target, name: "maybe-initialize-allocation-profiling")
       if (interactive-thread)
         set-application-class-breakpoint(application, interactive-thread, #f)
       end;
@@ -142,7 +142,7 @@ define sealed method stop-profiling-application
         //---*** for now switch on breakpoints on all threads
         application-open-interactor-thread(application);
       end;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "stop-profiling-application")
     if (interactive-thread)
       debug-target-message(target, $debug-level, "Stopping general class breakpoint");
       let remote-thread = interactive-thread.application-object-proxy;

--- a/sources/environment/dfmc/application/register-objects.dylan
+++ b/sources/environment/dfmc/application/register-objects.dylan
@@ -32,17 +32,15 @@ define method do-application-registers
         end method;
 
   let target = application.application-target-app;
-  perform-debugger-transaction
-    (target,
-     method ()
-       let path = target.debug-target-access-path;
-       do-registers
-         (method (r :: <remote-register>) => ()
-            f(wrap-for-env(r))
-          end method,
-          path,
-          type: convert-category(category))
-     end method);
+  with-debugger-transaction (target, name: "do-application-registers")
+    let path = target.debug-target-access-path;
+    do-registers
+      (method (r :: <remote-register>) => ()
+         f(wrap-for-env(r))
+       end method,
+       path,
+       type: convert-category(category));
+  end with-debugger-transaction;
 end method;
 
 
@@ -54,28 +52,22 @@ define method register-contents
      #key stack-frame-context = #f)
  => (obj :: false-or(<application-object>))
   let target = application.application-target-app;
-  let obj = #f;
-  perform-debugger-transaction
-    (target,
-     method ()
-       let path = target.debug-target-access-path;
-       let reg-proxy = reg.application-object-proxy;
-       let remote-thread = thread.application-object-proxy;
-       let frame = stack-frame-context &
-                   stack-frame-context.application-object-proxy;
-       let low-level-frame =
-         if (instance?(frame, <call-frame>))
-           call-frame-description(target, frame)
-         end if;
-       let context-sensitive-register =
-         active-register(path, remote-thread, reg-proxy);
-       let value =
-         read-value(path, context-sensitive-register,
-                    stack-frame: low-level-frame);
-       obj :=
-         make-environment-object-for-runtime-value(application, value);
-     end method);
-  obj
+  with-debugger-transaction (target, name: "register-contents")
+    let path = target.debug-target-access-path;
+    let reg-proxy = reg.application-object-proxy;
+    let remote-thread = thread.application-object-proxy;
+    let frame
+      = stack-frame-context & stack-frame-context.application-object-proxy;
+    let low-level-frame
+      = if (instance?(frame, <call-frame>))
+          call-frame-description(target, frame)
+        end if;
+    let context-sensitive-register
+      = active-register(path, remote-thread, reg-proxy);
+    let value = read-value(path, context-sensitive-register,
+                           stack-frame: low-level-frame);
+    make-environment-object-for-runtime-value(application, value)
+  end with-debugger-transaction
 end method;
 
 
@@ -87,29 +79,25 @@ define method register-contents-address
      #key stack-frame-context = #f)
  => (obj :: false-or(<address-object>))
   let target = application.application-target-app;
-  let obj = #f;
-  perform-debugger-transaction
-    (target,
-     method ()
-       let path = target.debug-target-access-path;
-       let reg-proxy = reg.application-object-proxy;
-       let remote-thread = thread.application-object-proxy;
-       let frame = stack-frame-context &
-                   stack-frame-context.application-object-proxy;
-       let low-level-frame =
-         if (instance?(frame, <call-frame>))
-           call-frame-description(target, frame)
-         end if;
-       let context-sensitive-register =
-         active-register(path, remote-thread, reg-proxy);
-       let value =
-         read-value(path, context-sensitive-register,
-                    stack-frame: low-level-frame);
-       obj := make-environment-object(<address-object>,
-                                      project: application.server-project,
-                                      application-object-proxy: value);
-     end method);
-  obj
+  with-debugger-transaction (target, name: "register-contents-address")
+    let path = target.debug-target-access-path;
+    let reg-proxy = reg.application-object-proxy;
+    let remote-thread = thread.application-object-proxy;
+    let frame
+      = stack-frame-context & stack-frame-context.application-object-proxy;
+    let low-level-frame
+      = if (instance?(frame, <call-frame>))
+          call-frame-description(target, frame)
+        end if;
+    let context-sensitive-register
+      = active-register(path, remote-thread, reg-proxy);
+    let value
+      = read-value(path, context-sensitive-register,
+                   stack-frame: low-level-frame);
+    make-environment-object(<address-object>,
+                            project: application.server-project,
+                            application-object-proxy: value);
+  end with-debugger-transaction
 end method;
 
 
@@ -118,30 +106,25 @@ end method;
 define method lookup-register-by-name
     (application :: <dfmc-application>, name :: <string>)
   => (reg :: false-or(<register-object>))
-  let reg = #f;
   let target = application.application-target-app;
-  perform-debugger-transaction
-    (target,
-     method ()
-       let path = target.debug-target-access-path;
-       block ()
-         let ap-reg =
-           enumeration-code-to-register(path, name);
-         reg :=
-           make-environment-object(<register-object>,
-                                   project: application.server-project,
-                                   application-object-proxy: ap-reg);
-       exception(<error>)
-         // TODO:
-         // Obviously, this blanket error-catching is wrong! Unfortunately,
-         // the underlying access-path API signals an undisciplined error
-         // if the lookup fails. The preferred fix would be to have the
-         // access-path library signal a _documented_ condition class,
-         // which we can just catch instead of <error>.
-         // However, the following is still the correct course of
-         // action.
-         reg := #f;
-       end block;
-     end method);
-  reg
+  with-debugger-transaction (target, name: "lookup-register-by-name")
+    let path = target.debug-target-access-path;
+    block ()
+      let ap-reg
+        = enumeration-code-to-register(path, name);
+      make-environment-object(<register-object>,
+                              project: application.server-project,
+                              application-object-proxy: ap-reg)
+    exception(<error>)
+      // TODO:
+      // Obviously, this blanket error-catching is wrong! Unfortunately,
+      // the underlying access-path API signals an undisciplined error
+      // if the lookup fails. The preferred fix would be to have the
+      // access-path library signal a _documented_ condition class,
+      // which we can just catch instead of <error>.
+      // However, the following is still the correct course of
+      // action.
+      #f
+    end block;
+  end with-debugger-transaction
 end method;

--- a/sources/environment/dfmc/application/restart-objects.dylan
+++ b/sources/environment/dfmc/application/restart-objects.dylan
@@ -20,7 +20,7 @@ define method application-thread-restarts
     (application :: <dfmc-application>, thread :: <thread-object>)
  => (restarts :: <sequence>)
   let target = application.application-target-app;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "application-thread-restarts")
     let project = application.server-project;
     let remote-thread = thread.application-object-proxy;
     let remote-restarts
@@ -42,7 +42,7 @@ define method application-restart-message
     (application :: <dfmc-application>, rst :: <restart-object>)
  => (description :: <string>)
   let target = application.application-target-app;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "application-restart-message")
     let remote-restart = rst.application-object-proxy;
     remote-restart-description(remote-restart)
   end
@@ -64,7 +64,7 @@ define method invoke-application-restart
 
   // We must be in a debugger transaction to do this.
   perform-continuing-debugger-transaction
-     (application, remote-thread,
+     (application, remote-thread, "invoke-application-restart",
       method ()
         // Get the DM to prepare for the restart
         signal-restart-on-thread(target, remote-thread, remote-restart);

--- a/sources/environment/dfmc/application/slot-objects.dylan
+++ b/sources/environment/dfmc/application/slot-objects.dylan
@@ -18,26 +18,19 @@ define method slot-class
 
   // Within a debugger transaction, call the DM to inspect the slot.
   // Build a <class-object> for the slot's owner class.
-  perform-debugger-transaction
-     (target,
-      method ()
-        let slot-descriptor =
-          runtime-proxy-to-remote-value(application, slot-proxy);
+  with-debugger-transaction (target, name: "slot-class")
+    let slot-descriptor
+      = runtime-proxy-to-remote-value(application, slot-proxy);
 
-        // Call the DM's inspector for slots.
-        let (basic-name, basic-type, owner-class, getter, setter,
-             init-key, init-req?, init-val, specializer)
-               = remote-slot-inspect(target, slot-descriptor);
+    // Call the DM's inspector for slots.
+    let (basic-name, basic-type, owner-class, getter, setter,
+         init-key, init-req?, init-val, specializer)
+      = remote-slot-inspect(target, slot-descriptor);
 
-        // We are interested in the owner class, so build the
-        // correct environment object for it.
-        class-object
-          := make-environment-object-for-runtime-value
-               (application, owner-class)
-      end method);
-
-  // Return the environment object.
-  class-object;
+    // We are interested in the owner class, so build the
+    // correct environment object for it.
+    make-environment-object-for-runtime-value(application, owner-class)
+  end with-debugger-transaction
 end method;
 
 
@@ -47,36 +40,31 @@ end method;
 
 define method slot-getter
     (application :: <dfmc-application>, slot :: <slot-object>)
-         => (getter :: false-or(<function-object>))
+ => (getter :: false-or(<function-object>))
   let target = application.application-target-app;
   let slot-proxy = slot.application-object-proxy;
   let function-object = #f;
 
   // Within a debugger transaction, call the DM to inspect the slot.
   // Build a <function-object> for the getter function, if it exists.
-  perform-debugger-transaction
-     (target,
-      method ()
-        let slot-descriptor =
-          runtime-proxy-to-remote-value(application, slot-proxy);
+  with-debugger-transaction (target, name: "slot-getter")
+    let slot-descriptor
+      = runtime-proxy-to-remote-value(application, slot-proxy);
 
-        // Call the DM's inspector for slots.
-        let (basic-name, basic-type, owner-class, getter, setter,
-             init-key, init-req?, init-val, specializer)
-               = remote-slot-inspect(target, slot-descriptor);
+    // Call the DM's inspector for slots.
+    let (basic-name, basic-type, owner-class, getter, setter,
+         init-key, init-req?, init-val, specializer)
+      = remote-slot-inspect(target, slot-descriptor);
 
-        // We are interested in the getter function, but it might be #f.
-        // If it is a <remote-value>, then build the correct environment
-        // object.
-        if (getter)
-          function-object
-            := make-environment-object-for-runtime-value
-                 (application, getter)
-        end if
-      end method);
-
-  // Return the environment object.
-  function-object;
+    // We are interested in the getter function, but it might be #f.
+    // If it is a <remote-value>, then build the correct environment
+    // object.
+    if (getter)
+      make-environment-object-for-runtime-value(application, getter)
+    else
+      #f
+    end if
+  end with-debugger-transaction
 end method;
 
 
@@ -86,36 +74,29 @@ end method;
 
 define method slot-setter
     (application :: <dfmc-application>, slot :: <slot-object>)
-         => (setter :: false-or(<function-object>))
+ => (setter :: false-or(<function-object>))
   let target = application.application-target-app;
   let slot-proxy = slot.application-object-proxy;
-  let function-object = #f;
-
   // Within a debugger transaction, call the DM to inspect the slot.
   // Build a <function-object> for the setter function, if it exists.
-  perform-debugger-transaction
-     (target,
-      method ()
-        let slot-descriptor =
-          runtime-proxy-to-remote-value(application, slot-proxy);
+  with-debugger-transaction (target, name: "slot-getter")
+    let slot-descriptor
+      = runtime-proxy-to-remote-value(application, slot-proxy);
 
-        // Call the DM's inspector for slots.
-        let (basic-name, basic-type, owner-class, getter, setter,
-             init-key, init-req?, init-val, specializer)
-               = remote-slot-inspect(target, slot-descriptor);
+    // Call the DM's inspector for slots.
+    let (basic-name, basic-type, owner-class, getter, setter,
+         init-key, init-req?, init-val, specializer)
+      = remote-slot-inspect(target, slot-descriptor);
 
-        // We are interested in the setter function, but it might be #f.
-        // If it is a <remote-value>, then build the correct environment
-        // object.
-        if (setter)
-          function-object
-            := make-environment-object-for-runtime-value
-                 (application, setter)
-        end if
-      end method);
-
-  // Return the environment object.
-  function-object;
+    // We are interested in the setter function, but it might be #f.
+    // If it is a <remote-value>, then build the correct environment
+    // object.
+    if (setter)
+      make-environment-object-for-runtime-value(application, setter)
+    else
+      #f
+    end if
+  end with-debugger-transaction
 end method;
 
 
@@ -132,24 +113,17 @@ define method slot-type
 
   // Within a debugger transaction, call the DM to inspect the slot.
   // Build a <symbol-object> for the init-keyword, if it exists.
-  perform-debugger-transaction
-     (target,
-      method ()
-        let slot-descriptor =
-          runtime-proxy-to-remote-value(application, slot-proxy);
+  with-debugger-transaction (target, name: "slot-type")
+    let slot-descriptor
+      = runtime-proxy-to-remote-value(application, slot-proxy);
 
-        // Call the DM's inspector for slots.
+    // Call the DM's inspector for slots.
+    let (basic-name, basic-type, owner-class, getter, setter,
+         init-key, init-req?, init-val, specializer)
+      = remote-slot-inspect(target, slot-descriptor);
 
-        let (basic-name, basic-type, owner-class, getter, setter,
-             init-key, init-req?, init-val, specializer)
-               = remote-slot-inspect(target, slot-descriptor);
-
-        type := make-environment-object-for-runtime-value
-                   (application, specializer);
-
-      end method);
-
-  type
+    make-environment-object-for-runtime-value(application, specializer)
+  end with-debugger-transaction
 end method;
 
 /* -- This is currently commented-out at the protocol level, so I need

--- a/sources/environment/dfmc/application/stack-frame-objects.dylan
+++ b/sources/environment/dfmc/application/stack-frame-objects.dylan
@@ -72,7 +72,7 @@ define method stack-frame-function
     (application :: <dfmc-application>, sf :: <stack-frame-object>)
  => (func :: false-or(<application-code-object>))
   let target = application.application-target-app;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "stack-frame-function")
     let project = application.server-project;
     let dm-frame = sf.application-object-proxy;
     let (location, exact?)
@@ -96,7 +96,7 @@ define method stack-frame-source-location
     (application :: <dfmc-application>, sf :: <stack-frame-object>)
  => (location :: false-or(<source-location>), exact? :: <boolean>)
   let target = application.application-target-app;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "stack-frame-source-location")
     let dm-frame = sf.application-object-proxy;
     source-location-from-frame-proxy(application, dm-frame)
   end
@@ -128,7 +128,7 @@ define method stack-frame-type
     (application :: <dfmc-application>, sf :: <stack-frame-object>)
  => (type :: <symbol>)
   let target = application.application-target-app;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "stack-frame-type")
     let dm-frame = sf.application-object-proxy;
     if (instance?(dm-frame, <call-frame>))
       if (dylan-call-frame?(target, dm-frame))
@@ -153,7 +153,7 @@ define method stack-frame-local-variables
     (application :: <dfmc-application>, sf :: <stack-frame-object>)
  => (locvars :: <sequence>)
   let target = application.application-target-app;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "stack-frame-local-variables")
     let dm-frame = sf.application-object-proxy;
     let var-seq = all-frame-local-variables(application, dm-frame);
     let count = size(var-seq);
@@ -177,7 +177,7 @@ define method stack-frame-local-variable-count
     (application :: <dfmc-application>, sf :: <stack-frame-object>)
  => (count :: <integer>)
   let target = application.application-target-app;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "stack-frame-local-variable-count")
     let dm-frame = sf.application-object-proxy;
     count-frame-local-variables(application, dm-frame)
   end

--- a/sources/environment/dfmc/application/stop-reason-handlers.dylan
+++ b/sources/environment/dfmc/application/stop-reason-handlers.dylan
@@ -892,16 +892,25 @@ define sealed method stop-reason-transaction-admin
     (application :: <dfmc-application>,
      stop-reason :: <breakpoint-stop-reason>)
  => (stay-stopped? :: <boolean>)
+  let target = application.application-target-app;
   let thread :: <thread-object>
     = stop-reason-thread-object(application, stop-reason);
 
+  debug-target-message
+    (target, $debug-level,
+     "stop-reason-transaction-admin for stop %=", stop-reason);
   if (application-just-interacted?(application, thread)
-      & application.application-temporary-stop?)
+        & application.application-temporary-stop?)
+    debug-target-message(target, $debug-level,
+                         "transaction admin: invoking application callback");
     invoke-application-callback
       (application, application-just-interacted-callback, thread)
   end if;
 
   let breakpoints = current-stop-breakpoints(application, thread);
+  debug-target-message
+    (target, $debug-level, "transaction admin: breakpoints=%=",
+     breakpoints);
 
   // If we came across the special "initial" breakpoint, we need
   // to set the APPLICATION-REACHED-INTERACTION-POINT? property.
@@ -910,6 +919,9 @@ define sealed method stop-reason-transaction-admin
                & breakpoint.breakpoint-entry-function?
            end,
            breakpoints))
+    debug-target-message
+      (target, $debug-level,
+       "transaction admin: interaction point reached");
     application.application-reached-interaction-point? := #t
   end if;
 
@@ -927,6 +939,10 @@ define sealed method stop-reason-transaction-admin
       unless (instance?(breakpoint, <function-breakpoint-object>)
                 & instance?(breakpoint-info(application, breakpoint), <breakpoint-entry-info>)
                 & member?(#"out", breakpoint.breakpoint-directions))
+        debug-target-message
+          (target, $debug-level,
+           "transaction admin: destroying transient breakpoint %=",
+           breakpoint);
         destroy-breakpoint(breakpoint)
       end unless;
     end if;
@@ -934,20 +950,34 @@ define sealed method stop-reason-transaction-admin
 
   // Now is the time to re-establish function breakpoints.
   if (application.application-just-initialized?)
+    debug-target-message
+      (target, $debug-level,
+       "transaction admin: application was just initialized");
     let project = application.server-project;
     for (breakpoint :: <breakpoint-object> in project.environment-object-breakpoints)
+      debug-target-message
+        (target, $debug-level,
+         "transaction admin: establishing environment object breakpoint %=",
+         breakpoint);
       server-note-breakpoint-state-changed
          (application, breakpoint, #"destroyed");
       server-note-breakpoint-state-changed
          (application, breakpoint, #"created");
     end for;
     for (breakpoint :: <breakpoint-object> in project.source-location-breakpoints)
+      debug-target-message
+        (target, $debug-level,
+         "transaction admin: establishing source-location breakpoint %=",
+         breakpoint);
       server-note-breakpoint-state-changed
           (application, breakpoint, #"destroyed");
       server-note-breakpoint-state-changed
           (application, breakpoint, #"created");
     end for;
     if (application.application-startup-option ~== #"start")
+      debug-target-message
+        (target, $debug-level,
+         "transaction admin: establishing transient startup breakpoint");
       // If the application was started via the Debug or Interact
       // route, we must set a transient breakpoint upon the initializer
       // function, given that it exists.

--- a/sources/environment/dfmc/application/thread-objects.dylan
+++ b/sources/environment/dfmc/application/thread-objects.dylan
@@ -207,7 +207,7 @@ define method application-threads
   if (application-tethered?(application))
     let target = application.application-target-app;
     let path = target.debug-target-access-path;
-    with-debugger-transaction (target)
+    with-debugger-transaction (target, name: "application-threads")
       let i = 0;
       let thread-sequence
         = make(<vector>, size: number-of-active-threads(path));
@@ -244,7 +244,7 @@ define method thread-complete-stack-trace
   // has been closed), then return whatever the stack trace was the last
   // time we examined it.
 
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "thread-complete-stack-trace")
     let top-dm-frame = first-stack-frame(target, remote-thread);
     let this-frame = top-dm-frame;
     let all-frames = make(<stretchy-vector>);
@@ -301,7 +301,7 @@ define method create-application-thread
     error("Thread Manager does not exist: Cannot create a new application thread");
   end;
   let path = target.debug-target-access-path;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "create-application-thread")
     block ()
       unless (thread-available-for-interaction?
                 (target, application.dylan-thread-manager))
@@ -348,7 +348,7 @@ define method suspend-application-thread
     error("Permission denied: This is a reserved application thread");
   end if;
 
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "suspend-application-thread")
      if (thread-permanently-suspended?(path, remote-thread))
        error("This thread has already been suspended");
      end if;
@@ -382,7 +382,7 @@ define method resume-application-thread
     error("Resume failed: this is a special thread that has been spawned for interaction");
   end if;
 
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "resume-application-thread")
      unless (thread-permanently-suspended?(path, remote-thread))
        error("This thread is not currently suspended");
      end unless;
@@ -403,7 +403,7 @@ define method thread-current-interactor-level
   => (level :: <integer>)
   let target = application.application-target-app;
   let remote-thread = thread.application-object-proxy;
-  with-debugger-transaction(target)
+  with-debugger-transaction(target, name: "thread-current-interactor-level")
     // Ask the DM for the definitive value
     get-thread-interactor-level(target, remote-thread)
   end
@@ -442,7 +442,7 @@ define method add-application-object-to-thread-history
      object :: <application-object>)
   => (history-varname :: false-or(<string>))
   let target = application.application-target-app;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "add-application-object-to-thread-history")
     let proxy = object.application-object-proxy;
     if (proxy)
       let value = runtime-proxy-to-remote-value(application, proxy);
@@ -533,7 +533,7 @@ define method application-available-interactor-thread
   => (thread-or-bust :: false-or(<thread-object>))
   let target = application.application-target-app;
   let path = target.debug-target-access-path;
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "application-available-interactor-thread")
     block (return)
       do-threads(method (t :: <remote-thread>) => ()
                    if (thread-available-for-interaction?(target, t))
@@ -574,7 +574,7 @@ define method application-open-interactor-thread
   let path = target.debug-target-access-path;
   let interactive-threads? = application.dylan-thread-manager & #t;
   let thread :: <thread-object>
-    = with-debugger-transaction (target)
+    = with-debugger-transaction (target, name: "application-open-interactor-thread")
         block (return)
           do-threads(method (t :: <remote-thread>) => ()
                        unless (reserved-interactive-thread?

--- a/sources/environment/dfmc/application/thread-objects.dylan
+++ b/sources/environment/dfmc/application/thread-objects.dylan
@@ -107,8 +107,11 @@ define method process-next-interaction-request
   let path = target.debug-target-access-path;
   let state-model = thread-state-model(application, thread);
   let requests-pending? =
-     (state-model.thread-state-interactor-queue.size > 0);
-  if (requests-pending? & thread-available-for-interaction?(target, thread))
+    (state-model.thread-state-interactor-queue.size > 0);
+  let tafi? = thread-available-for-interaction?(target, thread);
+  debug-target-message(target, $debug-level, "requests-pending?=%= tafi?(%=)=%=",
+                   requests-pending?, thread, tafi?);
+  if (requests-pending? & tafi?)
     if (thread-permanently-suspended?(path, thread))
       error("Suspended thread cannot have pending interaction requests");
     end if;
@@ -291,10 +294,12 @@ end method;
 define method create-application-thread
     (application :: <dfmc-application>, title :: <string>)
  => (thread :: <thread-object>)
+  let target = application.application-target-app;
+  debug-target-message
+    (target, $debug-level, "create-application-thread: %s", title);
   unless (application.dylan-thread-manager)
     error("Thread Manager does not exist: Cannot create a new application thread");
   end;
-  let target = application.application-target-app;
   let path = target.debug-target-access-path;
   with-debugger-transaction (target)
     block ()
@@ -670,6 +675,9 @@ define method initialize-interactive-threads
   => ()
   // Spawn these three interactive threads after
   // library initialization is complete
+  let target = application.application-target-app;
+  debug-target-message
+    (target, $debug-level, "initialize-interactive-threads %=", thread);
 
   // The Thread Manager is explicitly reserved for spawning
   // new application threads by running a particular deemed
@@ -687,10 +695,7 @@ define method initialize-interactive-threads
                              thread: thread);
 
   // Register this thread as a reserved Spy Thread in the debug-target
-  use-thread-for-spy-functions
-    (application.application-target-app,
-     spy-thread,
-     reserve?: #t);
+  use-thread-for-spy-functions(target, spy-thread, reserve?: #t);
 
   // In addition, a regular interactive thread is spawned at
   // the same time

--- a/sources/environment/dfmc/application/user-objects.dylan
+++ b/sources/environment/dfmc/application/user-objects.dylan
@@ -23,7 +23,7 @@ define method user-object-slot-value
   // find a match between the desired slot name, and the name of a slot
   // in the instance. If we find a match, we return and environment object
   // for the corresponding slot value.
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "user-object-slot-value")
     let proxy = obj.application-object-proxy;
     let class-proxy
       = exchange-value-proxy-for-browsable-class-proxy(application, proxy);
@@ -67,7 +67,7 @@ define method user-object-slot-value
   // find a match between the desired slot name, and the name of a slot
   // in the instance. If we find a match, we return and environment object
   // for the corresponding slot value.
-  with-debugger-transaction (target)
+  with-debugger-transaction (target, name: "user-object-slot-value")
     let proxy = obj.application-object-proxy;
     let class-proxy
       = exchange-value-proxy-for-browsable-class-proxy(application, proxy);

--- a/sources/environment/dfmc/application/variable-objects.dylan
+++ b/sources/environment/dfmc/application/variable-objects.dylan
@@ -106,24 +106,18 @@ define method variable-value (application :: <dfmc-application>,
                               #key thread = #f)
     => (value :: false-or(<application-object>));
   let target = application.application-target-app;
-  let value = #f;
-
-  perform-debugger-transaction
-    (target,
-     method () => ()
-       let proxy =
-          ensure-application-global-variable-proxy(application, variable);
-       let remote-value =
-         if (proxy)
-           get-application-variable-value(application, proxy);
-         else
-           dylan-runtime-unbound-marker(target)
-         end if;
-       value := make-environment-object-for-runtime-value
-                   (application, remote-value);
-     end);
-
-  value;
+  with-debugger-transaction (target, name: "variable-value")
+    let proxy
+      = ensure-application-global-variable-proxy(application, variable);
+    let remote-value
+      = if (proxy)
+          get-application-variable-value(application, proxy);
+        else
+          dylan-runtime-unbound-marker(target)
+        end if;
+    make-environment-object-for-runtime-value
+      (application, remote-value)
+  end with-debugger-transaction
 end method;
 
 
@@ -137,22 +131,17 @@ define method variable-value (application :: <dfmc-application>,
   // At the moment, constants are proxied in the same way as
   // thread-global variables, so this method is identical. This
   // may need to change one day.
-  perform-debugger-transaction
-    (target,
-     method () => ()
-       let proxy =
-          ensure-application-global-variable-proxy(application, variable);
-       let remote-value =
-         if (proxy)
-           get-application-variable-value(application, proxy);
-         else
-           dylan-runtime-unbound-marker(target)
-         end if;
-       value := make-environment-object-for-runtime-value
-                   (application, remote-value);
-     end);
-
-  value;
+  with-debugger-transaction (target, name: "variable-value")
+    let proxy
+      = ensure-application-global-variable-proxy(application, variable);
+    let remote-value
+      = if (proxy)
+          get-application-variable-value(application, proxy);
+        else
+          dylan-runtime-unbound-marker(target)
+        end if;
+    make-environment-object-for-runtime-value(application, remote-value)
+  end with-debugger-transaction
 end method;
 
 
@@ -161,25 +150,18 @@ define method variable-value (application :: <dfmc-application>,
                               #key thread = #f)
     => (value :: false-or(<application-object>));
   let target = application.application-target-app;
-  let value = #f;
-
-  perform-debugger-transaction
-    (target,
-     method () => ()
-       let proxy =
-           ensure-application-thread-variable-proxy(application, variable);
-       let remote-value =
-         if (proxy)
-           get-application-variable-value
-              (application, proxy, thread: thread.application-object-proxy);
+  with-debugger-transaction (target, name: "variable-value")
+    let proxy
+      = ensure-application-thread-variable-proxy(application, variable);
+    let remote-value
+      = if (proxy)
+          get-application-variable-value
+            (application, proxy, thread: thread.application-object-proxy);
          else
-           dylan-runtime-unbound-marker(target)
-         end if;
-       value := make-environment-object-for-runtime-value
-                   (application, remote-value);
-     end);
-
-  value;
+          dylan-runtime-unbound-marker(target)
+        end if;
+    make-environment-object-for-runtime-value(application, remote-value)
+  end with-debugger-transaction
 end method;
 
 

--- a/sources/environment/target-application/synchronized-access.dylan
+++ b/sources/environment/target-application/synchronized-access.dylan
@@ -45,7 +45,7 @@ end macro with-debugger-transaction;
 
 define method perform-debugger-transaction
     (application :: <target-application>, transaction :: <function>,
-     #key continue)
+     #key name = "?", continue)
  => (#rest results)
   if (application.performing-debugger-transaction?)
     assert(~continue,
@@ -56,6 +56,8 @@ define method perform-debugger-transaction
           block()
             transaction();
           exception(<abort>)
+            debug-target-message
+              (application, $error-level, "Aborted transaction %s", name);
             values(); // No action.
           end block;
         end method;
@@ -84,8 +86,9 @@ define method perform-debugger-transaction
           if (application.under-management?)
           temporary-stop? := application-temporary-stop?(application);
 
-            debug-target-message(application, $debug-level,
-                                 "Performing debugger transaction");
+            debug-target-message
+              (application, $debug-level,
+               "[[ debugger transaction %s", name);
           block()
             application.thread-being-served := transaction-thread;
             do-transaction();
@@ -98,14 +101,25 @@ define method perform-debugger-transaction
         // Continue the application only if explicitly requested to do
         // so by clients, or if we explicitly stopped the running application
         if (continue)
-          debug-target-message(application, $debug-level,
-                               "perform-debugger-transaction: continue application");
+          debug-target-message
+            (application, $debug-level,
+             "   debugger transaction %s: invoking continuation", name);
           continue();
+          debug-target-message
+            (application, $debug-level, "]] debugger transaction %s", name);
         elseif (temporary-stop?)
-          debug-target-message(application, $debug-level,
-                               "temporary-stop-reason for interrupting application");
+          debug-target-message
+            (application, $debug-level,
+             "]] debugger transaction %s: temporary-stop-reason "
+               "for interrupting application, continuing",
+             name);
           continue-target-application(application,
                                       application.application-selected-thread);
+        else
+          debug-target-message
+            (application, $debug-level,
+             "]] debugger transaction %s: remaining stopped",
+             name);
         end if
       end
     end with-lock;

--- a/sources/runtime-manager/debugger-manager/initialization-tracking.dylan
+++ b/sources/runtime-manager/debugger-manager/initialization-tracking.dylan
@@ -234,7 +234,9 @@ define method construct-component-name-table
                    end if
                  end method,
                  path);
-              debug-out(#"debugger-manager", "Did not match a <remote-library> to %=", bx);
+              debug-target-message
+                (application, $warn-level,
+                 "Did not match a <remote-library> to %=", bx);
               return(application.application-executable);
             end block;
           end if;
@@ -315,9 +317,10 @@ define method construct-component-name-table
     application.library-component-names["dylan"] :=
       application.application-dylan-library;
   else
-    debug-out(#"debugger-manager",
-              "Resolving %s yielded %=, which is not an object table.",
-              $runtime-module-variable-name, object-table);
+    debug-target-message
+      (application, $warn-level,
+       "Resolving %s yielded %=, which is not an object table.",
+       $runtime-module-variable-name, object-table);
   end if;
 end method;
 

--- a/sources/runtime-manager/debugger-manager/initialization-tracking.dylan
+++ b/sources/runtime-manager/debugger-manager/initialization-tracking.dylan
@@ -153,7 +153,12 @@ define method dynamic-initializer-start-callback
   end if;
   if (start.entry-initialization-tracker.tracker-top-level?)
     construct-component-name-table(application);
+    debug-target-message
+      (application, $debug-level,
+       "This is top-level, doing extra initialization now");
     initialize-static-keywords(application, thread);
+    debug-target-message
+      (application, $debug-level, "Extra top-level initialization done");
   end if;
   handle-library-initialization-phase
     (application, thread,
@@ -174,6 +179,10 @@ define method dynamic-initializer-done-callback
   deregister-debug-point(application, done.corresponding-entry-tracepoint);
   done.exit-initialization-tracker.tracker-initialization-state :=
      #"dynamically-initialized";
+  debug-target-message
+    (application, $debug-level,
+     "Tracker for %s state set to dynamically-initialized (done)",
+     done.exit-initialization-tracker.tracker-remote-library.library-core-name);
   handle-library-initialization-phase
     (application, thread,
      done.exit-initialization-tracker.tracker-remote-library,
@@ -321,7 +330,9 @@ end method;
 
 define method register-dylan-library
     (application :: <debug-target>, dylan-library :: <remote-library>)
-  => ()
+ => ()
+  debug-target-message
+    (application, $debug-level, "Registering Dylan library %=", dylan-library);
   application.application-dylan-library := dylan-library;
   application.dylan-application? := #t;
   application.dylan-spy := make(<dylan-spy-catalogue>);
@@ -348,6 +359,9 @@ define constant $running-under-dylan-debugger? = "_Prunning_under_dylan_debugger
 define method register-dylan-runtime-library
     (application :: <debug-target>, runtime-library :: <remote-library>)
   => ()
+  debug-target-message
+    (application, $debug-level,
+     "Registering Dylan runtime library %=", runtime-library);
   let path = application.debug-target-access-path;
   let one = as-remote-value(1);
   application.application-dylan-runtime-library := runtime-library;

--- a/sources/runtime-manager/debugger-manager/library.dylan
+++ b/sources/runtime-manager/debugger-manager/library.dylan
@@ -341,7 +341,6 @@ end module debugger-manager;
 define module dm-internals
   use common-dylan;
   use simple-format;
-  use simple-debugging, import: { debug-out };
   use threads, rename: {thread-name => thread-name-internal};
   use dylan-extensions, import: {<double-integer>, <set>};
   use table-extensions, import: {<string-table>};

--- a/sources/runtime-manager/debugger-manager/management.dylan
+++ b/sources/runtime-manager/debugger-manager/management.dylan
@@ -60,7 +60,8 @@ end method;
 
 define method dispose-all-state (application :: <debug-target>) => ()
   let access-path = application.debug-target-access-path;
-
+  debug-target-message
+    (application, $debug-level, "dispose-all-state after transaction");
   do-threads
   (method(thr :: <remote-thread>)
     if (thr.thread-suspended?)
@@ -89,6 +90,7 @@ define method open-debugger-transaction (application :: <debug-target>)
 //    ensure-mm-function-info-initialized(application);
 //    step-all-threads-out-of-mm(application);
 //    mm-start-debugger-transaction(application);
+  debug-target-message(application, $debug-level, "open-debugger-transaction");
   application.new-debugger-transaction? := #t;
 end method;
 
@@ -98,6 +100,8 @@ end method;
 
 define method close-debugger-transaction (application :: <debug-target>)
     => ()
+  debug-target-message
+    (application, $debug-level, "close-debugger-transaction");
 //  mm-end-debugger-transaction(application);
 end method;
 

--- a/sources/runtime-manager/debugger-manager/profile.dylan
+++ b/sources/runtime-manager/debugger-manager/profile.dylan
@@ -473,7 +473,8 @@ define method control-profiling
 	cerror("Continue anyway",
 	       "Failed to enable class profiling")
       end;
-      debug-out(#"debugger-manager", "Class profiling enabled");
+      debug-target-message
+        (application, $info-level, "Class profiling enabled");
     interval =>
       profile-state.profile-interval := interval;
       profile-state.profile-breakpoints := #[];
@@ -561,7 +562,8 @@ define method enable-class-profiling
 		     callback: always(#f)));
     #t
   else
-    debug-out(#"debugger-manager", "Failed to start class profiling")
+    debug-target-message
+      (application, $error-level, "Failed to start class profiling")
   end
 end method enable-class-profiling;
 

--- a/sources/runtime-manager/debugger-manager/spy-catalogue.dylan
+++ b/sources/runtime-manager/debugger-manager/spy-catalogue.dylan
@@ -409,6 +409,9 @@ end class;
 
 define method allocate-temporary-download-block-in
     (application :: <debug-target>, spy-thread :: <remote-thread>) => ()
+  debug-target-message
+    (application, $debug-level,
+     "Allocate the temporary download block in %=", spy-thread);
   let path = application.debug-target-access-path;
   let lib = application.application-dylan-runtime-library;
   if (lib)

--- a/sources/runtime-manager/debugger-manager/stepping.dylan
+++ b/sources/runtime-manager/debugger-manager/stepping.dylan
@@ -259,8 +259,9 @@ define method instruct-thread-to-step-into
             success? := #t;
             dm-thread.stepping-mode := $thread-stepping-into;
           else
-            debug-out(#"debugger-manager",
-                      "DM: Function register live but not a function!?");
+            debug-target-message
+              (application, $error-level,
+               "DM: Function register live but not a function!?");
             success? := #f;
           end if;
         else
@@ -274,8 +275,9 @@ define method instruct-thread-to-step-into
           dm-thread.stepping-mode := $thread-stepping-into;
         end if;
       else
-        debug-out(#"debugger-manager",
-                  "DM: Destination for step-into could not be computed");
+        debug-target-message
+          (application, $error-level,
+           "DM: Destination for step-into could not be computed");
         success? := #f;
       end if
     end if;

--- a/sources/runtime-manager/debugger-manager/stop-reason-interpret.dylan
+++ b/sources/runtime-manager/debugger-manager/stop-reason-interpret.dylan
@@ -42,6 +42,8 @@ define method interpret-stop-reason
   let path = application.debug-target-access-path;
   let interesting-debug-points? = #f;
 
+  debug-target-message(application, $debug-level,
+                       "Interpret stop reason %=", stop-reason);
   select (stop-reason by instance?)
     <invoke-debugger-stop-reason> =>
        // If this is a dylan-level invocation of the debugger,
@@ -361,6 +363,9 @@ define method interpret-stop-reason
       maybe-modified-stop-reason := stop-reason;
 
   end select;
+  debug-target-message
+    (application, $debug-level,
+     "Stop reason modified to %=", maybe-modified-stop-reason);
   values(maybe-modified-stop-reason, interesting-debug-points?, stop-reason);
 end method;
 

--- a/sources/runtime-manager/debugger-manager/threads.dylan
+++ b/sources/runtime-manager/debugger-manager/threads.dylan
@@ -596,6 +596,13 @@ define method suspend-interesting-thread
     (application :: <debug-target>, stop-reason :: <internal-stop-reason>)
   let access-path = application.debug-target-access-path;
   let stopped-thread = stop-reason.stop-reason-thread;
+  debug-target-message
+    (application, $trace-level,
+     "Maybe suspend-interesting-thread %= in response to %="
+       " (suspended?=%= just-interacted?=%=)",
+     stopped-thread, stop-reason,
+     stopped-thread.thread-suspended?,
+     application.application-just-interacted-on-running-thread?);
 
   unless (stopped-thread.thread-suspended?)
     unless (application.application-just-interacted-on-running-thread?)


### PR DESCRIPTION
When debugging, the environment runs the debugger-manager in a separate "DM Thread" and makes cross-thread requests to perform various operations. These changes ensure that the flow of these requests is made explicit in debugger logs.
